### PR TITLE
Don't load GTM or Google Analytics unless cookies are accepted

### DIFF
--- a/site/google.jet
+++ b/site/google.jet
@@ -1,11 +1,29 @@
 {{block googleTagManagerScript(tagManagerId=config("google_tag_manager_id"))}}
   {{ if len(tagManagerId) > 0 }}
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','{{ tagManagerId }}');</script>
+    <script>
+      function loadGoogleTagManager() {
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','{{ tagManagerId }}')
+      }
+
+      // Only load Google Tag Manager if a/ the frontend cookie consent isn't required or b/ they've agreed to the cookie consent
+      var cookieConsentRequired = {{ isEnabled("frontend_cookie_consent") }};
+      document.addEventListener('s72loaded', function(event) {
+        if(!cookieConsentRequired || event.detail.app.hasCookieConsent()) {
+          loadGoogleTagManager();
+        }
+        else {
+          // Listen for an 'accept' of the cookie consent, in which case load google tag manager
+          event.detail.app.messagebus.subscribe('cookie-consent-set', function(event) {
+            loadGoogleTagManager();
+          });
+        }
+      });
+    </script>
     <!-- End Google Tag Manager -->
   {{end}}
 {{end}}

--- a/site/google.jet
+++ b/site/google.jet
@@ -1,31 +1,47 @@
-{{block googleTagManagerScript(tagManagerId=config("google_tag_manager_id"))}}
-  {{ if len(tagManagerId) > 0 }}
-    <!-- Google Tag Manager -->
-    <script>
-      function loadGoogleTagManager() {
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','{{ tagManagerId }}')
-      }
+{{block googleScripts(tagManagerId=config("google_tag_manager_id"), analyticsId=config("google_analytics_id"))}}
+  <!-- Google integration scripts -->
+  <script>
+    function loadGoogleTagManager() {
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','{{ tagManagerId }}')
+    }
 
-      // Only load Google Tag Manager if a/ the frontend cookie consent isn't required or b/ they've agreed to the cookie consent
-      var cookieConsentRequired = {{ isEnabled("frontend_cookie_consent") }};
-      document.addEventListener('s72loaded', function(event) {
-        if(!cookieConsentRequired || event.detail.app.hasCookieConsent()) {
-          loadGoogleTagManager();
-        }
-        else {
-          // Listen for an 'accept' of the cookie consent, in which case load google tag manager
-          event.detail.app.messagebus.subscribe('cookie-consent-set', function(event) {
-            loadGoogleTagManager();
-          });
-        }
-      });
-    </script>
-    <!-- End Google Tag Manager -->
-  {{end}}
+
+    function loadGoogleAnalytics() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '{{analyticsId}}', 'auto');
+      ga('require', 'ecommerce');
+      ga('send', 'pageview');
+    }
+
+    // Only load Google Tag Manager if a/ the frontend cookie consent isn't required or b/ they've agreed to the cookie consent
+    var googleTagManagerEnabled = {{ (len(tagManagerId) > 0) ? "true" : "false" }};
+    var googleAnalyticsEnabled = {{ (len(analyticsId) > 0) ? "true" : "false" }};
+
+    var cookieConsentRequired = {{ isEnabled("frontend_cookie_consent") }};
+
+    document.addEventListener('s72loaded', function(event) {
+      if(!cookieConsentRequired || event.detail.app.hasCookieConsent()) {
+        if(googleTagManagerEnabled) { loadGoogleTagManager(); }
+        if(googleAnalyticsEnabled) {  loadGoogleAnalytics(); }
+      }
+      else {
+        // Listen for an 'accept' of the cookie consent, in which case load google tag manager
+        event.detail.app.messagebus.subscribe('cookie-consent-set', function(event) {
+          if(googleTagManagerEnabled) { loadGoogleTagManager(); }
+          if(googleAnalyticsEnabled) {  loadGoogleAnalytics(); }
+        });
+      }
+    });
+  </script>
+  <!-- End Google integration scripts -->
 {{end}}
 
 {{block googleTagManagerNoScript(tagManagerId=config("google_tag_manager_id"))}}
@@ -34,20 +50,5 @@
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ tagManagerId }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   {{end}}
-{{end}}
-
-{{block googleAnalytics(analyticsId=config("google_analytics_id"))}}
-  {{ if len(analyticsId) > 0 }}
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', '{{analyticsId}}', 'auto');
-    ga('require', 'ecommerce');
-    ga('send', 'pageview');
-  </script>
-  {{ end }}
 {{end}}
 


### PR DESCRIPTION
- don't load Google Tag Manager and/or Google Analytics unless the site doesn't require a cookie to be agreed-to, or the cookie is set
- merge two blocks into a single `GoogleScripts` block in google.jet; will need application.jet updated to include this consolidated block
- Requires v1.3.19 of Relish so a/ hasCookieConsent is available to run and b/ message bus notice 'cookie-consent-set' can be listened-for