### PR TITLE
flex-shrink: 0 for the 'Powered by Foo' badge in the footer

### DIFF
--- a/site/styles/_footer.scss
+++ b/site/styles/_footer.scss
@@ -75,6 +75,7 @@ footer {
 .powered-by {
 	text-align: center;
 	padding: 10px 0 15px 0;
+	flex-shrink: 0;
 	@include media-breakpoint-up(md){
 		margin-left: auto;
 	}


### PR DESCRIPTION
So it never gets split over multiple lines (leave that up to the copyright notice and nav)