### PR TITLE
Powered by

### DIFF
--- a/site/styles/_footer.scss
+++ b/site/styles/_footer.scss
@@ -80,6 +80,7 @@ footer {
 		margin-left: auto;
 	}
 	a {
+		white-space: nowrap;
 		font-size: 10px;
 		text-transform: uppercase;
 		font-weight: 800;

--- a/site/templates/footer.jet
+++ b/site/templates/footer.jet
@@ -15,10 +15,6 @@
 		      &copy; {{i18n("site_owner")}}. All rights reserved. No part of this site may be reproduced without our written permission.
 		    </p>
 		</div>
-		<div class="powered-by">
-		    <a href="{{i18n("powered_by_url")}}" target="_blank" class="footer-screenplus-powered-by">
-		    	Powered by {{i18n("powered_by_name")}}
-		    </a>
-		</div>
+		{{include "footer/powered-by" }}
 	</footer>
 {{end}}

--- a/site/templates/footer/powered-by.jet
+++ b/site/templates/footer/powered-by.jet
@@ -1,0 +1,5 @@
+<div class="powered-by">
+    <a href="{{i18n("powered_by_url")}}" target="_blank" class="footer-screenplus-powered-by">
+      Powered by {{i18n("powered_by_name")}}
+    </a>
+</div>


### PR DESCRIPTION
Stop text wrap when footer links are larger than expected.
Split into separate template so easier to change.

Note usage of `{{include "footer/powered-by" }}` instead of previous combo of `{{ import... }}` and `{{yield ...() }}`.

Seems a bit easier to manage.
