### PR TITLE
Support for countries on item.jet

### DIFF
--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -291,9 +291,10 @@
 
   "meta_detail_cast_title": { "other": "Cast" },
   "meta_detail_crew_title": { "other": "Crew" },
-  "meta_detail_languages": { "other": "Language(s)" },
-  "meta_detail_studio": { "other": "Studio" },
-  "meta_detail_subtitles": { "other": "Subtitle(s)" },
+  "meta_detail_languages": { "one": "Language", "other": "Languages" },
+  "meta_detail_studios": { "one": "Studio", "other": "Studios" },
+  "meta_detail_countries": { "one": "Country", "other": "Countries" },
+  "meta_detail_subtitles": { "other": "Subtitles" },
   "meta_detail_episodes_title": { "other": "Episodes" },
   "meta_detail_bonus_title": { "other": "Bonus Content" },
   "meta_detail_recommendations_title": { "other": "You may also like" },

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -285,6 +285,7 @@
   .meta-detail-crew,
   .meta-detail-language,
   .meta-detail-studio,
+  .meta-detail-country,
   .meta-detail-subtitle {
     padding-bottom: 20px;
     h3, h4 {


### PR DESCRIPTION
- Support for size-specific labels e.g "country" vs "countries" rather than "country(s)"
- CSS for countries label