### PR TITLE
SH-5628 a11y for Search

### DIFF
--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -59,6 +59,7 @@
   "datetime_next": { "other": "this {{.Date}}" },
 
   "search_control_placeholder": { "other": "Search" },
+  "search_control_submit": { "other": "Submit search" },
 
   "play_button_watch": { "other" : "Play Now"},
   "play_button_resume": { "other" : "Continue"},
@@ -76,7 +77,6 @@
   "signup_form_email": { "other": "Email address" },
   "signup_form_password": { "other": "Password" },
   "signup_form_password_confirmation": { "other": "Confirm your password" },
-  "signup_form_name": { "other": "Name" },
   "signup_form_gender": { "other": "Gender" },
   "signup_form_dob": { "other": "Birth date" },
   "signup_form_submit": { "other": "Submit" },

--- a/site/templates/nav.jet
+++ b/site/templates/nav.jet
@@ -7,8 +7,8 @@
       <a class="navbar-brand" href="/">{{i18n("nav_homepage")}}</a>
       {{ if config("search_disabled") != "true" }}
         <form class="form-search navbar-nav-search" action="/search.html">
-            <input class="form-control form-control-search" type="search" placeholder="{{i18n("search_control_placeholder")}}" name="q">
-            <button class="sr-only" type="submit">Search</button>
+            <input class="form-control form-control-search" type="search" placeholder="{{i18n("search_control_placeholder")}}" name="q" aria-label="{{i18n("search_control_placeholder")}}">
+            <button class="sr-only" type="submit">{{i18n("search_control_submit")}}</button>
         </form>
       {{ end }}
       <button class="navbar-toggler" type="button" s72-collapse=".navbar-collapse" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
- Added an `aria-label` for the nav search and i18n'd the button (recent Relish change will also use this key).
- Removed a dupe `signup_form_name` (appears 4 lines above it).
