### PR TITLE
5628 a11y sub nav

### DIFF
--- a/site/styles/_nav.scss
+++ b/site/styles/_nav.scss
@@ -256,7 +256,7 @@
     }
     .s72-dropdown-menu {
       background: rgba($navbar-background-color, 1);
-      padding-left: 15px;
+      padding: 0 15px;
       .nav-link {
         font-size: 14px;
         margin: 0;

--- a/site/templates/nav.jet
+++ b/site/templates/nav.jet
@@ -49,16 +49,16 @@
     <ul class="sub-nav">
       {{range site.Navigation.Header}}
         {{if len(.Items) > 0}}
-          <s72-dropdown class="nav-item">
-            <a class="s72-dropdown-toggle nav-link" href="{{ len(.Link.ExternalURL) > 0 ? .Link.ExternalURL : len(.Items) == 0 ? routeToSlug(.Link.Slug) : "#" }}">{{ .Label }}</a>
-
-            <div class="s72-dropdown-menu sub-nav-menu">
-              {{range sub := .Items}}
+          <li class="nav-item">
+            <s72-dropdown>
+              <a class="s72-dropdown-toggle nav-link" href="{{len(.Link.ExternalURL) > 0 ? .Link.ExternalURL : len(.Items) == 0 ? routeToSlug(.Link.Slug) : "#"}}">{{.Label}}</a>
+              <div class="s72-dropdown-menu sub-nav-menu">
+                {{range sub := .Items}}
                   <a class="nav-link" href="{{len(sub.Link.ExternalURL) > 0 ? sub.Link.ExternalURL : routeToSlug(sub.Link.Slug) }}">{{sub.Label}}</a>
-              {{end}}
-            </div>
-          </s72-dropdown>
-
+                {{end}}
+              </div>
+            </s72-dropdown>
+          </li>
         {{else}}
           <li class="nav-item {{len(.Link.ExternalURL) == 0 && routeToSlug(.Link.Slug) == currentUrlPath ? "active" : ""}}">
             <a class="nav-link" href="{{len(.Link.ExternalURL) > 0 ? .Link.ExternalURL : routeToSlug(.Link.Slug)}}">{{.Label}}</a>

--- a/site/templates/nav.jet
+++ b/site/templates/nav.jet
@@ -5,15 +5,18 @@
 <div class="navigation" data-toggle="affix">
   <nav class="navbar navbar-expand-md navbar-dark">
       <a class="navbar-brand" href="/">{{i18n("nav_homepage")}}</a>
-      {{ if config("search_disabled") != "true" }}
+      
+      {{if config("search_disabled") != "true"}}
         <form class="form-search navbar-nav-search" action="/search.html">
             <input class="form-control form-control-search" type="search" placeholder="{{i18n("search_control_placeholder")}}" name="q" aria-label="{{i18n("search_control_placeholder")}}">
             <button class="sr-only" type="submit">{{i18n("search_control_submit")}}</button>
         </form>
-      {{ end }}
+      {{end}}
+      
       <button class="navbar-toggler" type="button" s72-collapse=".navbar-collapse" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="icon-navbar-toggler"></span>
       </button>
+
       <div class="collapse navbar-collapse">
         {{if len(site.Navigation.Header) > 0 && showSubNav}}
           <ul class="mobile-nav d-md-none">
@@ -23,22 +26,24 @@
                 <li class="nav-item title">{{.Label}}</li>
                 {{range sub := .Items}}
                 <li class="nav-item {{len(.Link.ExternalURL) == 0 && routeToSlug(.Link.Slug) == currentUrlPath ? "active" : ""}}">
-                  <a class="nav-link" href="{{ len(sub.Link.ExternalURL) > 0 ? sub.Link.ExternalURL : routeToSlug(sub.Link.Slug) }}">{{ sub.Label }}</a>
+                  <a class="nav-link" href="{{ len(sub.Link.ExternalURL) > 0 ? sub.Link.ExternalURL : routeToSlug(sub.Link.Slug) }}">{{sub.Label}}</a>
                 </li>
                 {{end}}
               {{else}}
                 <li class="nav-item {{len(.Link.ExternalURL) == 0 && routeToSlug(.Link.Slug) == currentUrlPath ? "active" : ""}}">
-                  <a class="nav-link" href="{{ len(.Link.ExternalURL) > 0 ? .Link.ExternalURL : routeToSlug(.Link.Slug) }}">{{ .Label }}</a>
+                  <a class="nav-link" href="{{len(.Link.ExternalURL) > 0 ? .Link.ExternalURL : routeToSlug(.Link.Slug)}}">{{.Label}}</a>
                 </li>
               {{end}}
             {{end}}
           {{end}}
           </ul>
         {{end}}
+
         <div class="navbar-nav s72-hide">
         	{{ yield nav_user_logged_out() }}
         	{{ yield nav_user_logged_in() }}
         </div>
+
       </div>
   </nav>
 
@@ -50,30 +55,20 @@
             <a class="s72-dropdown-toggle nav-link" href="{{ len(.Link.ExternalURL) > 0 ? .Link.ExternalURL : len(.Items) == 0 ? routeToSlug(.Link.Slug) : "#" }}">{{ .Label }}</a>
 
             <div class="s72-dropdown-menu sub-nav-menu">
-
               {{range sub := .Items}}
-
-                <a class="nav-link" href="{{ len(sub.Link.ExternalURL) > 0 ? sub.Link.ExternalURL : routeToSlug(sub.Link.Slug) }}">{{ sub.Label }}</a>
-
+                  <a class="nav-link" href="{{len(sub.Link.ExternalURL) > 0 ? sub.Link.ExternalURL : routeToSlug(sub.Link.Slug) }}">{{sub.Label}}</a>
               {{end}}
-
             </div>
-
           </s72-dropdown>
 
         {{else}}
-
           <li class="nav-item {{len(.Link.ExternalURL) == 0 && routeToSlug(.Link.Slug) == currentUrlPath ? "active" : ""}}">
-
-            <a class="nav-link" href="{{ len(.Link.ExternalURL) > 0 ? .Link.ExternalURL : routeToSlug(.Link.Slug) }}">{{ .Label }}</a>
-
+            <a class="nav-link" href="{{len(.Link.ExternalURL) > 0 ? .Link.ExternalURL : routeToSlug(.Link.Slug)}}">{{.Label}}</a>
           </li>
-
         {{end}}
-
       {{end}}
-
     </ul>
   {{end}}
+
 </div>
 {{end}}

--- a/site/templates/nav.jet
+++ b/site/templates/nav.jet
@@ -20,7 +20,6 @@
       <div class="collapse navbar-collapse">
         {{if len(site.Navigation.Header) > 0 && showSubNav}}
           <ul class="mobile-nav d-md-none">
-          {{if len(site.Navigation.Header) > 0 && showSubNav}}
             {{range site.Navigation.Header}}
               {{if len(.Items) > 0}}
                 <li class="nav-item title">{{.Label}}</li>
@@ -35,7 +34,6 @@
                 </li>
               {{end}}
             {{end}}
-          {{end}}
           </ul>
         {{end}}
 


### PR DESCRIPTION
- Sub-nav dropdowns were missing right padding.
- Standardised the whitespace.
- Removed a check for `{{if len(site.Navigation.Header) > 0 && showSubNav}}` that was already checked in the outer block.
- And the main point of this was to wrap the `<s72-dropdown>` in a `<li>` for a11y.

Individual commits to aid reviewing the above.