### PR TITLE
Update carousel_item.jet

### DIFF
--- a/site/templates/collection/carousel_item.jet
+++ b/site/templates/collection/carousel_item.jet
@@ -9,7 +9,7 @@
     {{ trailer = item.InnerItem.PromoURL }}
   {{ end }}
 
-  <div class="s72-carousel-item">
+  <div class="s72-carousel-item" data-slug="{{item.Slug}}">
     <a href="{{routeToSlug(item.Slug)}}" class="carousel-item-link">
 
       {{if isset(item.Images["Carousel"])}}


### PR DESCRIPTION
Likewise we need this slug in the carousel item in order to easily excise it from the page should it not be available to view