### PR TITLE
SH-5475 i18n Promo code already redeemed

### DIFF
--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -248,6 +248,7 @@
   "shopping_error_discount_invalid": { "other": "Please enter a valid promo code." },
   "shopping_error_discount_disabled": { "other": "Please enter a valid promo code." },
   "shopping_error_discount_already_applied": { "other": "A promo code has already been used for this session." },
+  "shopping_error_discount_already_redeemed": { "other": "That promo code has already been used." },
   "shopping_error_discount_used_previously": { "other": "That promo code has already been used." },
   "shopping_error_discount_max_limit": { "other": "That promo code can no longer be used." },
   "shopping_error_discount_expired": { "other": "That promo code has expired." },

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -247,6 +247,7 @@
   "shopping_error_discount_invalid": { "other": "Inserisci un codice valido." },
   "shopping_error_discount_disabled": { "other": "Inserisci un codice valido." },
   "shopping_error_discount_already_applied": { "other": "A promo code has already been used for this session." },
+  "shopping_error_discount_already_redeemed": { "other": "That promo code has already been used." },
   "shopping_error_discount_used_previously": { "other": "That promo code has already been used." },
   "shopping_error_discount_max_limit": { "other": "That promo code can no longer be used." },
   "shopping_error_discount_expired": { "other": "That promo code has expired." },


### PR DESCRIPTION
Added a missing translation for `shopping_error_discount_already_redeemed`.

Note, this looks to be a duplicate for `shopping_error_discount_used_previously`, so I'm wondering if it was a rename of that property or something as I can't see `discount_used_previously` getting returned from the API.