### PR TITLE
fix expired translation bug

### DIFF
--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -356,7 +356,7 @@
 
   "availability_coming_soon": {"other": "In Kürze verfügbar"},
   "availability_available": {"other": "Verfügbar ab {{.ReleaseDate}}"},
-  "availability_expired": { "other": "Abgelaufen {{.Expiry}}" },
+  "availability_expired": { "other": "Abgelaufen" },
   "availability_sold_out": { "other": "Ausverkauft" },
   "availability_not_available_in_country": { "other": "Nicht verfügbar" },
 


### PR DESCRIPTION
ADO card: https://dev.azure.com/S72/SHIFT72/_workitems/edit/1332/

The site is https://online.hardline-festival.de/ and not Hamburg. Looks like {{.Expiry}} tag was showing up in the "Expired' translation. If I am not wrong, the date shouldn't be showing up and hence removed the tag. Verified it using the English translation for staging-abc and just the "expired" tag was showing up without any date.