### PR TITLE
AB#1620 moved wishlist script into main.js

### DIFF
--- a/site/static/js/main.js
+++ b/site/static/js/main.js
@@ -1,5 +1,37 @@
 var slideObservers = [];
 
+function initializeWishlist() {
+  var wishlist = document.querySelector('s72-userwishlist');
+  var originalFunction = wishlist.classList.remove;
+  wishlist.classList.remove = function(className){
+    if(className == 's72-hide')
+    {
+      // Hide this from view
+      wishlist.style.opacity = '0';
+
+      // Remove class
+      originalFunction.apply(this, [ className ]);
+
+      /* Convert this to a swiper */
+      var containers = wishlist.getElementsByClassName('swiper-container');
+      if(containers.length > 0) {
+        var container = containers[0];
+        var swiper = initializeSwiper(container, true);
+
+        init(swiper);
+        toggleButtons(container);
+      }
+
+      // Now show it
+      wishlist.style.opacity = '1';
+    }
+    else
+    {
+      originalFunction.apply(this, [ className ]);
+    }
+  }
+}
+
 function initializeSwiper(element, force){
   if(element.swiper) {
     if(force) {
@@ -461,6 +493,8 @@ function togglePageTopPadding() {
 }
 
 function documentReady(app) {
+  initializeWishlist();
+
   app.classificationsService.load('/classifications.all.json');
 
   detectTouchscreen();

--- a/site/templates/collection/wishlist.jet
+++ b/site/templates/collection/wishlist.jet
@@ -44,36 +44,4 @@
     </div>
   </div>
 </s72-userwishlist>
-
-<script language="javascript">
-  var wishlist = document.querySelector('s72-userwishlist');
-  var originalFunction = wishlist.classList.remove;
-  wishlist.classList.remove = function(className){
-    if(className == 's72-hide')
-    {
-      // Hide this from view
-      wishlist.style.opacity = '0';
-
-      // Remove class
-      originalFunction.apply(this, [ className ]);
-
-      /* Convert this to a swiper */
-      var containers = wishlist.getElementsByClassName('swiper-container');
-      if(containers.length > 0) {
-        var container = containers[0];
-        var swiper = initializeSwiper(container, true);
-
-        init(swiper);
-        toggleButtons(container);
-      }
-
-      // Now show it
-      wishlist.style.opacity = '1';
-    }
-    else
-    {
-      originalFunction.apply(this, [ className ]);
-    }
-  }
-</script>
 {{end}}


### PR DESCRIPTION
This bug is an unexpected side-effect of adding rollup.js.
The script in the wishlist file was trying to call the `initializeSwiper` function which now get encapsulated by rollup so was causing an error.  I've fixed it by moving the wishlist code into main.js (and checked that there are no similar problems elsewhere).

I think all shift72-template sites that have been created since I did the ES6 stuff will need core updating after this is merged.