### PR TITLE
Language file to CSV script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 site/static/styles/main.css
 site/static/scripts/main.js
 .DS_Store
+scripts/language-file-to-csv/output

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "kibble:watch": "kibble render --watch --port 8081",
     "kibble:build": "kibble publish",
     "build": "npm-run-all css js:build css:build kibble:build",
-    "language:csv": "node scripts/language-file-to-csv/language-file-to-csv.js site/en_AU.all.json"
+    "language:csv": "node scripts/language-file-to-csv/language-file-to-csv.js site/en_AU.all.json",
+    "language:validate": "node scripts/language-file-validator.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "kibble": "kibble render",
     "kibble:watch": "kibble render --watch --port 8081",
     "kibble:build": "kibble publish",
-    "build": "npm-run-all css js:build css:build kibble:build"
+    "build": "npm-run-all css js:build css:build kibble:build",
+    "language:csv": "node scripts/language-file-to-csv/language-file-to-csv.js site/en_AU.all.json"
   },
   "repository": {
     "type": "git",

--- a/scripts/language-file-to-csv/language-file-to-csv.js
+++ b/scripts/language-file-to-csv/language-file-to-csv.js
@@ -29,13 +29,13 @@ for (const [key, value] of Object.entries(json)) {
 
 // Because this character '~' is not present in the English language file.
 // May have to change how this works in the future.
-let csvSeparator = '~'; 
+let csvSeparator = '","'; 
 
 let createRow = (key, value, singularValue) => {
-  return [key, '', value, '', singularValue].join(csvSeparator);
+  return '"' + [key, '', value.replace(/"/g, '""'), '', singularValue.replace(/"/g, '""')].join(csvSeparator) + '"';
 };
 
-let csvHeader = ['Term', 'Translated Value', 'Value', 'Singular Translated Value', 'Singular Value'].join(csvSeparator);
+let csvHeader = '"' + ['Term', 'Translated Value', 'Value', 'Singular Translated Value', 'Singular Value'].join(csvSeparator) + '"';
 let csv = [
   csvHeader
 ];

--- a/scripts/language-file-to-csv/language-file-to-csv.js
+++ b/scripts/language-file-to-csv/language-file-to-csv.js
@@ -32,10 +32,11 @@ for (const [key, value] of Object.entries(json)) {
 let csvSeparator = '","'; 
 
 let createRow = (key, value, singularValue) => {
-  return '"' + [key, '', value.replace(/"/g, '""'), '', singularValue.replace(/"/g, '""')].join(csvSeparator) + '"';
+  let row = [key, '', value.replace(/"/g, '""'), '', singularValue.replace(/"/g, '""')];
+  return `"${row.join(csvSeparator)}"`;
 };
 
-let csvHeader = '"' + ['Term', 'Translated Value', 'Value', 'Singular Translated Value', 'Singular Value'].join(csvSeparator) + '"';
+let csvHeader = `"${['Term', 'Translated Value', 'Value', 'Singular Translated Value', 'Singular Value'].join(csvSeparator)}"`;
 let csv = [
   csvHeader
 ];

--- a/scripts/language-file-to-csv/language-file-to-csv.js
+++ b/scripts/language-file-to-csv/language-file-to-csv.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const fs = require('fs');
+
+if (process.argv.length < 3) {
+  console.error('ERROR - Language file path argument missing!');
+  return;
+}
+
+let languageFilePath = process.argv[2];
+let validLanguageFilePath = /site\/[a-z]{2}\_[A-Z]{2}.all.json/;
+
+if (!languageFilePath.match(validLanguageFilePath)) {
+  console.error(`ERROR - Language file path argument '${languageFilePath}' invalid!`);
+  return;
+}
+
+let rawdata = fs.readFileSync(languageFilePath);
+let json = JSON.parse(rawdata);
+
+// Remove keys where value is same as key.
+// These keys are (hopefully) not used by festival clients.
+for (const [key, value] of Object.entries(json)) {
+  if (key === value.other) {
+    console.warn(`WARNING - Unused key '${key}' will be removed!`);
+    delete json[key];
+  }
+}
+
+// Because this character '~' is not present in the English language file.
+// May have to change how this works in the future.
+let csvSeparator = '~'; 
+
+let createRow = (key, value, singularValue) => {
+  return [key, '', value, '', singularValue].join(csvSeparator);
+};
+
+let csvHeader = ['Term', 'Translated Value', 'Value', 'Singular Translated Value', 'Singular Value'].join(csvSeparator);
+let csv = [
+  csvHeader
+];
+
+for (const [key, value] of Object.entries(json)) {
+  let singularValue = value.one ? value.one : '';
+  csv.push(createRow(key, value.other, singularValue));
+}
+
+let outputFilename = `scripts/language-file-to-csv/output/${Date.now()} - Translations.csv`;
+
+fs.writeFile(outputFilename, csv.join('\n'), err => {
+  if (err) {
+    console.error(`ERROR - CSV creation failed '${err}'!`)
+  }
+  console.log(`\nFile '${outputFilename}' created!`);
+});

--- a/scripts/language-file-to-csv/language-file-to-csv.js
+++ b/scripts/language-file-to-csv/language-file-to-csv.js
@@ -27,8 +27,6 @@ for (const [key, value] of Object.entries(json)) {
   }
 }
 
-// Because this character '~' is not present in the English language file.
-// May have to change how this works in the future.
 let csvSeparator = '","'; 
 
 let createRow = (key, value, singularValue) => {

--- a/scripts/language-file-to-csv/language-file-to-csv.js
+++ b/scripts/language-file-to-csv/language-file-to-csv.js
@@ -45,7 +45,7 @@ for (const [key, value] of Object.entries(json)) {
   csv.push(createRow(key, value.other, singularValue));
 }
 
-let outputFilename = `scripts/language-file-to-csv/output/${Date.now()} - Translations.csv`;
+let outputFilename = `scripts/language-file-to-csv/output/${new Date().toString()} - Translations.csv`;
 
 fs.writeFile(outputFilename, csv.join('\n'), err => {
   if (err) {

--- a/scripts/language-file-validator.js
+++ b/scripts/language-file-validator.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const masterFilename = 'en_AU.all.json';
+const masterFile = openFile(masterFilename);
+const masterFileKeys = Object.keys(masterFile);
+const languageFilenames = getFilenames();
+const languageFiles = openFiles(languageFilenames);
+
+let errors = [];
+
+const whitespacePaddedKeys = [
+  'accept_invite_page_header',
+  'shopping_info_release_date_title',
+  'shopping_info_available_until_date_title',
+  'shopping_info_rental_period_duration',
+  'shopping_info_watch_window_duration',
+  'classification_intro',
+  'classification_divider'
+];
+const emptyKeys = [
+  'classification_outro',
+  'plan_label_owned'
+];
+
+languageFilenames.forEach(language => {
+  console.log(`===== TESTING: ${language} =====`);
+
+  let file = languageFiles[language];
+  let keys = Object.keys(file);
+
+  masterFileKeys.forEach(key => {
+    testLanguageContainsKey(language, keys, key);
+
+    if (whitespacePaddedKeys.includes(key) && keys.includes(key)) {
+      testWhitespacePaddedKey(file, key);
+    }
+
+    if (emptyKeys.includes(key) && keys.includes(key)) {
+      testEmptyKey(file, key);
+    }
+  });
+
+  console.log('\n\n');
+});
+
+assert.ok(errors.length === 0, 'LANGUAGE FILE VALIDATION FAILED!');
+
+function getFilenames() {
+  return fs.readdirSync('./site/').filter(filename => {
+    return filename !== masterFilename && filename.match(/[a-z]{2}_[A-Z]{2}\.all\.json/);
+  });
+}
+
+function openFile(filename) {
+  let rawdata = fs.readFileSync(`./site/${filename}`);
+  return JSON.parse(rawdata);
+}
+
+function openFiles(filenames) {
+  return filenames.reduce((acc, filename) => {
+    acc[filename] = openFile(filename);
+    return acc;
+  }, {});
+}
+
+function testLanguageContainsKey(language, languageKeys, key) {
+  try {
+    assert.ok(languageKeys.includes(key), `${language} contains key ${key}`);
+  } catch(e) {
+    console.error(`${key} - missing from file.`);
+    errors.push(e);
+  }
+}
+
+function testWhitespacePaddedKey(file, key) {
+  try {
+    assert.ok(file[key].other.slice(-1) === ' ', `${key} ends with whitespace`);
+  } catch(e) {
+    console.error(`${key} - should end with whitespace.`);
+    errors.push(e);
+  }
+}
+
+function testEmptyKey(file, key) {
+  try {
+    assert.ok(file[key].other === '', `${key} is empty`);
+  } catch(e) {
+    console.error(`${key} - should be empty.`);
+    errors.push(e);
+  }
+}


### PR DESCRIPTION
Outputs an up-to-date language CSV which can be imported into Google Sheets using '~' as the separator.

Filters out language vars that don't have a value yet (subscription and pin code related stuff that we haven't used).

The idea here is to be able to quickly give the most up-to-date list of translations to Todd in a format 90% of the way to being presentable to a new client.  Thoughts @stajs @l0ud0gg?