### PR TITLE
Include title in the fix for long strings

### DIFF
--- a/site/styles/main.scss
+++ b/site/styles/main.scss
@@ -341,6 +341,6 @@ s72-classification-label {
 }
 
 //text wrap fix
-h1, h2, h3, h4, h5, h6, p {
+h1, h2, h3, h4, h5, h6, p, .title {
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
Based on [this](https://dev.azure.com/S72/SHIFT72/_workitems/edit/1598/) card. I think I had made this fix couple of months ago for headings, paragraphs, etc. Just included .title in this which would wrap the over flowing text.