### PR TITLE
Adjust font size of disabled text fields

### DIFF
--- a/site/styles/_shift72.scss
+++ b/site/styles/_shift72.scss
@@ -135,9 +135,11 @@
 
 // some fields which are "readonly" shouldn't have the padding and font-size applied to them because they are text (not masked "****" values)
 .s72-readonly-text .s72-form-control-readonly {
+  @extend .py-0;
+
   font-size: unset;
-  padding: 0 0.875rem;
-  border-radius: 0.25rem !important;
+  border-radius: $border-radius !important;
+  border: 1px solid transparent;
 }
 
 s72-useraccount-form {

--- a/site/styles/_shift72.scss
+++ b/site/styles/_shift72.scss
@@ -136,7 +136,8 @@
 // some fields which are "readonly" shouldn't have the padding and font-size applied to them because they are text (not masked "****" values)
 .s72-readonly-text .s72-form-control-readonly {
   font-size: unset;
-  padding: 0 0.75rem;
+  padding: 0 0.875rem;
+  border-radius: 0.25rem !important;
 }
 
 s72-useraccount-form {

--- a/site/styles/_shift72.scss
+++ b/site/styles/_shift72.scss
@@ -133,6 +133,12 @@
   }
 }
 
+// some fields which are "readonly" shouldn't have the padding and font-size applied to them because they are text (not masked "****" values)
+.s72-readonly-text .s72-form-control-readonly {
+  font-size: unset;
+  padding: 0 0.75rem;
+}
+
 s72-useraccount-form {
 
   .s72-form-control-readonly {


### PR DESCRIPTION
Don't increase the font size or padding of read-only fields when they are text fields (not masked "****" fields)

This is with reference to when dates of birth aren't editable

![Screen Shot 2020-11-20 at 3 37 16 PM](https://user-images.githubusercontent.com/3870133/99751022-49c0a880-2b46-11eb-99aa-f5a2435dc427.png)
