### PR TITLE
removed 'next' word from 'datetime_next' lang vars

### DIFF
--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -364,7 +364,7 @@
   "datetime_today": { "other": "heute {{.Date}}" },
   "datetime_tomorrow": { "other": "morgen {{.Date}}" },
   "datetime_yesterday": { "other": "gestern {{.Date}}" },
-  "datetime_next": { "other": "ab {{.Date}}" },
+  "datetime_next": { "other": "{{.Date}}" },
   "datetime_last": { "other": "{{.Date}}" },
 
   "modal_cancel": { "other": "Abbrechen" },

--- a/site/ee_EE.all.json
+++ b/site/ee_EE.all.json
@@ -59,7 +59,7 @@
     "datetime_today": { "other": "täna {{.Date}}" },
     "datetime_tomorrow": { "other": "homme {{.Date}}" },
     "datetime_yesterday": { "other": "eile {{.Date}}" },
-    "datetime_next": { "other": "järgmine {{.Date}}" },
+    "datetime_next": { "other": "{{.Date}}" },
     "datetime_last": { "other": "eelmine {{.Date}}" },
   
     "search_control_placeholder": { "other": "Otsing" },

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -59,7 +59,7 @@
   "datetime_today": { "other": "Σήμερα {{.Date}}" },
   "datetime_tomorrow": { "other": "Αύριο {{.Date}}" },
   "datetime_yesterday": { "other": "Χθες {{.Date}}" },
-  "datetime_next": { "other": "Επόμενη {{.Date}}" },
+  "datetime_next": { "other": "{{.Date}}" },
   "datetime_last": { "other": "Τελευταία {{.Date}}" },
 
   "search_control_placeholder": { "other": "Αναζήτηση" },

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -59,7 +59,7 @@
   "datetime_today": { "other": "today {{.Date}}" },
   "datetime_tomorrow": { "other": "tomorrow {{.Date}}" },
   "datetime_yesterday": { "other": "yesterday {{.Date}}" },
-  "datetime_next": { "other": "next {{.Date}}" },
+  "datetime_next": { "other": "{{.Date}}" },
   "datetime_last": { "other": "last {{.Date}}" },
 
   "search_control_placeholder": { "other": "Search" },

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -56,7 +56,7 @@
   "runtime_hours": { "other": "h" },
   "runtime_minutes": { "other": "m" },
 
-  "datetime_next": { "other": "este {{.Date}}" },
+  "datetime_next": { "other": "{{.Date}}" },
   "datetime_last": { "other": "pasado {{.Date}}" },
   "datetime_today": { "other": "hoy {{.Date}}" },
   "datetime_tomorrow": { "other": "mañana {{.Date}}" },

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -56,7 +56,7 @@
   "runtime_hours": { "other": "h" },
   "runtime_minutes": { "other": "m" },
 
-  "datetime_next": { "other": "próximo {{.Date}}" },
+  "datetime_next": { "other": "{{.Date}}" },
   "datetime_last": { "other": "último {{.Date}}" },
   "datetime_today": { "other": "hoy {{.Date}}" },
   "datetime_tomorrow": { "other": "mañana {{.Date}}" },

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -55,7 +55,7 @@
   "runtime_hours": { "other": "h" },
   "runtime_minutes": { "other": "m" },
 
-  "datetime_next": { "other": "ce {{.Date}}" },
+  "datetime_next": { "other": "{{.Date}}" },
 
   "search_control_placeholder": { "other": "Rechercher" },
 

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -59,7 +59,7 @@
     "datetime_today": { "other": "ma {{.Date}}" },
     "datetime_tomorrow": { "other": "holnap {{.Date}}" },
     "datetime_yesterday": { "other": "tegnap {{.Date}}" },
-    "datetime_next": { "other": "következő {{.Date}}" },
+    "datetime_next": { "other": "{{.Date}}" },
     "datetime_last": { "other": "utolsó {{.Date}}" },
   
     "search_control_placeholder": { "other": "Keresés" },

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -59,7 +59,7 @@
     "datetime_today": { "other": "i dag {{.Date}}" },
     "datetime_tomorrow": { "other": "i morgen {{.Date}}" },
     "datetime_yesterday": { "other": "i går {{.Date}}" },
-    "datetime_next": { "other": "neste {{.Date}}" },
+    "datetime_next": { "other": "{{.Date}}" },
     "datetime_last": { "other": "forrige {{.Date}}" },
   
     "search_control_placeholder": { "other": "Søk" },

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -59,7 +59,7 @@
     "datetime_today": { "other": "hoje {{.Date}}" },
     "datetime_tomorrow": { "other": "amanhã {{.Date}}" },
     "datetime_yesterday": { "other": "ontem {{.Date}}" },
-    "datetime_next": { "other": "próximo(a) {{.Date}}" },
+    "datetime_next": { "other": "{{.Date}}" },
     "datetime_last": { "other": "último(a) {{.Date}}" },
 
     "search_control_placeholder": { "other": "Buscar" },

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -58,7 +58,7 @@
     "datetime_today": { "other": "сегодня {{.Date}}" },
     "datetime_tomorrow": { "other": "завтра {{.Date}}" },
     "datetime_yesterday": { "other": "вчера {{.Date}}" },
-    "datetime_next": { "other": "Следующая {{.Date}}" },
+    "datetime_next": { "other": "{{.Date}}" },
     "datetime_last": { "other": "последняя {{.Date}}" },
 
     "search_control_placeholder": { "other": "Поиск" },

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -59,7 +59,7 @@
     "datetime_today": { "other": "bugün {{.Date}}" },
     "datetime_tomorrow": { "other": "yarın {{.Date}}" },
     "datetime_yesterday": { "other": "dün {{.Date}}" },
-    "datetime_next": { "other": "sonraki  {{.Date}}" },
+    "datetime_next": { "other": "{{.Date}}" },
     "datetime_last": { "other": "son {{.Date}}" },
   
     "search_control_placeholder": { "other": "Arama" },


### PR DESCRIPTION
I don't think doing this will upset anyone given that this key is used by a bugged function in Relish.