### PR TITLE
remove offset height from padding

### DIFF
--- a/site/static/js/main.js
+++ b/site/static/js/main.js
@@ -489,7 +489,7 @@ function togglePageTopPadding() {
   if (subnavOverflowing()) {
     if (page.hasAttribute('style')) return;
     var padding = parseFloat(window.getComputedStyle(page, null).getPropertyValue('padding-top'));
-    page.style.paddingTop = (padding + navItem.offsetHeight) + 'px';
+    page.style.paddingTop = (padding) + 'px';
   } else {
     page.removeAttribute('style');
   }

--- a/site/static/js/main.js
+++ b/site/static/js/main.js
@@ -479,21 +479,6 @@ function subnavOverflowing() {
   return childrenWidth > window.innerWidth - padding;
 }
 
-function togglePageTopPadding() {
-  var navItem = document.querySelector('.sub-nav .nav-item');
-  if (!navItem) return;
-
-  var page = document.querySelector('.page');
-  if (!page) return;
-
-  if (subnavOverflowing()) {
-    if (page.hasAttribute('style')) return;
-    var padding = parseFloat(window.getComputedStyle(page, null).getPropertyValue('padding-top'));
-    page.style.paddingTop = (padding) + 'px';
-  } else {
-    page.removeAttribute('style');
-  }
-}
 
 function documentReady(app) {
   initializeWishlist();
@@ -528,8 +513,6 @@ function documentReady(app) {
     nav.classList.remove('s72-hide');
   });
 
-  togglePageTopPadding();
-  window.addEventListener('resize', s72.utils.fn.throttle(togglePageTopPadding, 100));
 }
 
 function detectTouchscreen(){


### PR DESCRIPTION
Based on [this](https://dev.azure.com/S72/SHIFT72/_workitems/edit/2655/) issue. Looks like the overflow was happening due to offset height being added in the subnavOverflowing function. This might not be required anymore since couple of weeks ago the default padding was adjusted in the variable file.