### PR TITLE
Full width carousel v2

### DIFF
--- a/kibble.json
+++ b/kibble.json
@@ -1,7 +1,7 @@
 {
   "name": "core-template",
   "version": "0.0.1",
-  "siteUrl": "https://staging-abccinemas.screenplus.co",
+  "siteUrl": "https://abccinemas.screenplus.co",
   "builderVersion": "0.15.6",
   "defaultLanguage": "en",
   "languages": {

--- a/kibble.json
+++ b/kibble.json
@@ -1,7 +1,7 @@
 {
   "name": "core-template",
   "version": "0.0.1",
-  "siteUrl": "https://abccinemas.screenplus.co",
+  "siteUrl": "https://staging-abccinemas.screenplus.co",
   "builderVersion": "0.15.6",
   "defaultLanguage": "en",
   "languages": {

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -22,6 +22,8 @@ s72-carousel {
   s72-image {
     width: 100%;
     height: $carousel-height;
+    position: relative;
+    overflow: hidden;
     @include media-breakpoint-up(sm) {
       height: $carousel-height-sm;
     }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -22,10 +22,6 @@ s72-carousel {
   s72-image {
     width: 100%;
     height: $carousel-height;
-    max-width: 1600px;
-    position: relative;
-    float: right;
-    overflow: hidden;
     @include media-breakpoint-up(sm) {
       height: $carousel-height-sm;
     }
@@ -50,16 +46,23 @@ s72-carousel {
       }
     }
     img {
+      position: absolute;
       height: $carousel-height;
-      margin-left: 50%;
-      transform: translateX(-50%);
-
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
       @include media-breakpoint-up(sm) {
         height: $carousel-height-sm;
       }
       @include media-breakpoint-up(md) {
         width: auto;
         height: $carousel-height-md;
+      }
+      // Finds the width of the image given the carousel height and a fixed aspect ratio of 1600:600
+      $carousel-image-width: (1600 / 600) * $carousel-height-md;
+      @media only screen and (min-width: $carousel-image-width) {
+        width: 100%;
+        height: auto;
       }
     }
   }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -60,8 +60,8 @@ s72-carousel {
         width: auto;
         height: $carousel-height-md;
       }
-      // Finds the width of the image given the carousel height and a fixed aspect ratio of 1600:600
-      $carousel-image-width: (1600 / 600) * $carousel-height-md;
+      // Finds the width of the image given the carousel height and a fixed aspect ratio of 1600:600 (by default)
+      $carousel-image-width: ($background-image-width / $background-image-height) * $carousel-height-md;
       @media only screen and (min-width: $carousel-image-width) {
         width: 100%;
         height: auto;

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -106,11 +106,13 @@ $left-gradient-bg-color: $body-bg !default;
 
 // Carousel
 $carousel-bg-color: $body-bg !default;
-$carousel-height: 470px !default;
+$carousel-height: 700px !default;
 $carousel-height-sm: 470px !default;
 $carousel-height-md: 620px !default;
 $carousel-caption-top: 150px !default;
 $carousel-caption-top-md: 175px !default;
+$background-image-width: 1600px !default;
+$background-image-height: 600px !default;
 
 // Pages
 $page-padding-top: 100px !default;

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -106,7 +106,7 @@ $left-gradient-bg-color: $body-bg !default;
 
 // Carousel
 $carousel-bg-color: $body-bg !default;
-$carousel-height: 700px !default;
+$carousel-height: 470px !default;
 $carousel-height-sm: 470px !default;
 $carousel-height-md: 620px !default;
 $carousel-caption-top: 150px !default;


### PR DESCRIPTION
This method is a lot cleaner but uses `@media`. Like the current method, it assumes that the image will be 1600 x 600. You can see the differences between the methods here:
https://shift72.slack.com/files/U0183MW9TNK/F01K5STE3FA/background-matrix-v2.jpg
