### PR TITLE
Ab#3099 sitemap xml

### DIFF
--- a/site/robots.txt.jet
+++ b/site/robots.txt.jet
@@ -2,3 +2,4 @@
 User-agent: *
 Allow: /
 Sitemap: {{site.SiteConfig.SiteURL}}/sitemap.txt
+Sitemap: {{site.SiteConfig.SiteURL}}/sitemap.xml

--- a/site/sitemap.xml.jet
+++ b/site/sitemap.xml.jet
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    {{ range site.Pages }}
+      <loc>{{routeToSlug(.Slug)}}</loc>
+    {{ end }}
+
+    {{ range site.Films }}
+      <loc>{{routeToSlug(.Slug)}}</loc>
+    {{ end }}
+
+    {{ range site.TVSeasons }}
+      <loc>{{routeToSlug(.Slug)}}</loc>
+    {{ end }}
+
+    {{ range site.Collections }}
+      <loc>{{routeToSlug(.Slug)}}</loc>
+    {{ end }}
+
+    {{ range site.Bundles }}
+      <loc>{{routeToSlug(.Slug)}}</loc>
+    {{ end }}
+  </url>
+</urlset>

--- a/site/sitemap.xml.jet
+++ b/site/sitemap.xml.jet
@@ -1,24 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    {{ range site.Pages }}
-      <loc>{{routeToSlug(.Slug)}}</loc>
-    {{ end }}
+  {{ range site.Pages }}
+    <url>
+      {{ if .PageType == "external" }}
+        <loc>{{routeToSlug(.Slug)}}</loc>
+      {{ else }}
+        <loc>{{site.SiteConfig.SiteURL}}{{routeToSlug(.Slug)}}</loc>
+      {{ end }}
+    </url>
+  {{ end }}
 
-    {{ range site.Films }}
-      <loc>{{routeToSlug(.Slug)}}</loc>
-    {{ end }}
+  {{ range site.Films }}
+    <url>
+      <loc>{{site.SiteConfig.SiteURL}}{{routeToSlug(.Slug)}}</loc>
+    </url>
+  {{ end }}
 
-    {{ range site.TVSeasons }}
-      <loc>{{routeToSlug(.Slug)}}</loc>
-    {{ end }}
+  {{ range site.TVSeasons }}
+    <url>
+      <loc>{{site.SiteConfig.SiteURL}}{{routeToSlug(.Slug)}}</loc>
+    </url>
+  {{ end }}
 
-    {{ range site.Collections }}
-      <loc>{{routeToSlug(.Slug)}}</loc>
-    {{ end }}
+  {{ range site.Collections }}
+    <url>
+      <loc>{{site.SiteConfig.SiteURL}}{{routeToSlug(.Slug)}}</loc>
+    </url>
+  {{ end }}
 
-    {{ range site.Bundles }}
-      <loc>{{routeToSlug(.Slug)}}</loc>
-    {{ end }}
-  </url>
+  {{ range site.Bundles }}
+    <url>
+      <loc>{{site.SiteConfig.SiteURL}}{{routeToSlug(.Slug)}}</loc>
+    </url>
+  {{ end }}
 </urlset>


### PR DESCRIPTION
Graham reckons we probably switched to `.xml` in that robots_enabled file for a client so the best solution here is probably to add support for `.xml` and `.txt` in core-template.