### PR TITLE
remove alt tags from bg images

### DIFF
--- a/site/templates/bundle/item.jet
+++ b/site/templates/bundle/item.jet
@@ -19,7 +19,7 @@
 
     <div class="meta-detail-bg">
       <div class="meta-detail-bg-gradient"></div>
-      <s72-image src="{{bundle.Images.Background}}" alt="" class="meta-detail-bg-img"></s72-image>
+      <s72-image src="{{bundle.Images.Background}}" class="meta-detail-bg-img"></s72-image>
     </div>
 
     <div class="container">

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -20,7 +20,7 @@
   <div class="page page-film meta-detail meta-detail-film">
     <div class="meta-detail-bg">
       <div class="right-gradient"></div>
-      <s72-image src="{{film.Images.Background}}" alt="" class="meta-detail-bg-img"></s72-image>
+      <s72-image src="{{film.Images.Background}}" class="meta-detail-bg-img"></s72-image>
     </div>
     <div class="container">
       <div class="meta-detail-main">

--- a/site/templates/page/curated.jet
+++ b/site/templates/page/curated.jet
@@ -10,7 +10,7 @@
 <div class="page {{page.PageType}}-page">
   <div class="page-bg">
     <div class="right-gradient"></div>
-    <s72-image src="{{page.Images.Background}}" alt="" class="page-bg-img"></s72-image>
+    <s72-image src="{{page.Images.Background}}" class="page-bg-img"></s72-image>
   </div>
   <div class="container-fluid">
     <div class="page-header">

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -19,7 +19,7 @@
   <div class="page page-tvseason meta-detail meta-detail-tvseason">
     <div class="meta-detail-bg">
       <div class="right-gradient"></div>
-      <s72-image src="{{tvseason.Images.Background}}" alt="" class="meta-detail-bg-img"></s72-image>
+      <s72-image src="{{tvseason.Images.Background}}" class="meta-detail-bg-img"></s72-image>
     </div>
     <div class="container">
       <div class="meta-detail-main">


### PR DESCRIPTION
Based on [this card](https://dev.azure.com/S72/SHIFT72/_workitems/edit/4140/).

However, the s72-image component isn't just used for the bg images, so I think only needs to be removed where bg images are being used.