### PR TITLE
better screenreader support and tooltips for social media buttons

### DIFF
--- a/site/templates/common/social-media-buttons.jet
+++ b/site/templates/common/social-media-buttons.jet
@@ -4,9 +4,15 @@
 			<h5>{{i18n("social_media_buttons_title")}}</h5>
 		</div>
 		<div class="social-media-buttons-container">
-			<a target="_blank" title="Share on Facebook" href="https://www.facebook.com/sharer/sharer.php?u={{site.SiteConfig.SiteURL + path | url}}" class="btn btn-social btn-social-facebook"><i class="fa fa-facebook"></i></a>
-			<a target="_blank" title="Tweet" href="https://twitter.com/intent/tweet?text={{title + " " + site.SiteConfig.SiteURL + path | url}}" class="btn btn-social btn-social-twitter"><i class="fa fa-twitter"></i></a>
-			<a target="_blank" title="Share on LinkedIn" href="https://www.linkedin.com/shareArticle?mini=true&url={{site.SiteConfig.SiteURL + path | url}}&title={{title|url}}" class="btn btn-social btn-social-linkedin"><i class="fa fa-linkedin"></i></a>
+			<a class="btn btn-social btn-social-facebook" aria-label="Share on Facebook" href="https://www.facebook.com/sharer/sharer.php?u={{site.SiteConfig.SiteURL + path | url}}" target="_blank">
+				<i class="fa fa-facebook" title="Share on Facebook" aria-hidden="true"></i>
+			</a>
+			<a class="btn btn-social btn-social-twitter" aria-label="Share on Twitter" href="https://twitter.com/intent/tweet?text={{title + " " + site.SiteConfig.SiteURL + path | url}}" target="_blank">
+				<i class="fa fa-twitter" title="Share on Twitter" aria-hidden="true"></i>
+			</a>
+			<a class="btn btn-social btn-social-linkedin" aria-label="Share on LinkedIn" href="https://www.linkedin.com/shareArticle?mini=true&url={{site.SiteConfig.SiteURL + path | url}}&title={{title|url}}" target="_blank">
+				<i class="fa fa-linkedin" title="Share on LinkedIn" aria-hidden="true"></i>
+			</a>
 		</div>
 	</div>
 {{end}}


### PR DESCRIPTION
https://dev.azure.com/S72/SHIFT72/_workitems/edit/4146

I think it's a bit overkill to use title and aria-label but TIFF asked for it specifically because it is recommended on the Font Awesome accessibility page.