### PR TITLE
fix(accessibility): added aria labels to anchors that confuse screen …

### DIFF
--- a/site/templates/bundle/partial.jet
+++ b/site/templates/bundle/partial.jet
@@ -1,7 +1,7 @@
 {{import "../items/tagline.jet"}}
 
 <div class="partial partial-bundle">
-  <a href="{{routeToSlug(bundle.Slug)}}">
+  <a href="{{routeToSlug(bundle.Slug)}}" aria-label="{{bundle.Title}}">
     <div class="poster poster-{{config("default_image_type")}}">
       <s72-availability-status data-slug="{{bundle.Slug}}"></s72-availability-status>
       <s72-availability-label data-slug="{{bundle.Slug}}"></s72-availability-label>

--- a/site/templates/collection/carousel_item.jet
+++ b/site/templates/collection/carousel_item.jet
@@ -10,7 +10,7 @@
   {{ end }}
 
   <div class="s72-carousel-item" data-slug="{{item.Slug}}">
-    <a href="{{routeToSlug(item.Slug)}}" class="carousel-item-link">
+    <a href="{{routeToSlug(item.Slug)}}" class="carousel-item-link" aria-label="{{item.Title}}">
 
       {{if isset(item.Images["Carousel"])}}
         <s72-image src="{{item.Images.Carousel}}" alt="{{item.Title}}" class="carousel-item-image"></s72-image>

--- a/site/templates/collection/partial.jet
+++ b/site/templates/collection/partial.jet
@@ -1,5 +1,5 @@
 <div class="partial partial-collection">
-  <a href="{{routeToSlug(collection.Slug)}}" class="meta-item-link">
+  <a href="{{routeToSlug(collection.Slug)}}" class="meta-item-link" aria-label="{{collection.Title}}">
 
     {{if config("default_image_type") == "portrait"}}
       <div class="poster poster-portrait">

--- a/site/templates/items/featured_item.jet
+++ b/site/templates/items/featured_item.jet
@@ -2,7 +2,7 @@
 
 {{block featuredItem(item, image="Landscape")}}
 <div class="meta-item featured-meta-item meta-item-{{item.ItemType|lower}}">
-  <a href="{{routeToSlug(item.Slug)}}">
+  <a href="{{routeToSlug(item.Slug)}}" aria-label="{{item.Title}}">
     {{if isset(item.Images[image])}}
       <s72-image src="{{item.Images[image]}}" alt="{{item.Title}}" class="meta-item-img featured-meta-item-img"></s72-image>
     {{end}}

--- a/site/templates/items/meta_item.jet
+++ b/site/templates/items/meta_item.jet
@@ -36,7 +36,7 @@
   {{if wrapper_class != ""}}
   <div class="{{wrapper_class}}">
   {{end}}
-  <a href="{{routeToSlug(item.Slug)}}" class="meta-item-link" target="{{isExternalPage ? "_blank" : ""}}">
+  <a href="{{routeToSlug(item.Slug)}}" class="meta-item-link" aria-label="{{item.Title}}" target="{{isExternalPage ? "_blank" : ""}}">
     <div class="poster poster-{{layout}}">
       <s72-availability-status data-slug="{{item.Slug}}"></s72-availability-status>
       <s72-availability-label data-slug="{{item.Slug}}"></s72-availability-label>

--- a/site/templates/page/partial.jet
+++ b/site/templates/page/partial.jet
@@ -1,5 +1,5 @@
 <div class="partial partial-page">
-  <a href="{{routeToSlug(page.Slug)}}">
+  <a href="{{routeToSlug(page.Slug)}}" aria-label="{{page.Title}}">
 
   {{if config("default_image_type") == "portrait"}}
     <div class="poster poster-portrait">


### PR DESCRIPTION
…readers

https://dev.azure.com/S72/SHIFT72/_workitems/edit/4150

You could argue that these are false positives on SiteImprove because the anchors do in fact have content inside them but the screen readers don't handle them nicely.  If the anchor has an aria-label (`<a aria-label="The Matrix"><div>stuff</div></a>`) or some text before the other content (`<a>The Matrix<div>stuff</div></a>`), the screen reader will simply say "The Matrix, link".  If the anchor doesn't have either of those, then the screen reader will do a full info dump of the contents starting with availability labels, multiple instances of the film title, and repeating the word "link" at the end of every line _even if it is technically incorrect_.

In the interest of not introducing breaking changes for accessibility _just yet_, I think aria-labels are the quickest and safest solution.