### PR TITLE
feat: added variables for search bar left position

### DIFF
--- a/site/styles/_nav.scss
+++ b/site/styles/_nav.scss
@@ -296,7 +296,7 @@
 // Header Form Search
 .navbar-nav-search {
   position: absolute;
-  left: 160px;
+  left: $navbar-search-left;
   width: 150px;
   top: $navbar-search-top;
   @include media-breakpoint-up(sm) {
@@ -305,7 +305,7 @@
     margin-right: $subnav-nav-item-margin-x;
   }
   @include media-breakpoint-up(md) {
-    left: 165px;
+    left: $navbar-search-left-md;
   }
   @include media-breakpoint-up(lg) {
     top: $navbar-search-top;

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -63,6 +63,8 @@ $navbar-brand-min-width-md: 126px !default;
 $navbar-brand-min-width-lg: 126px !default;
 $navbar-brand-min-width-xl: 126px !default;
 $navbar-search-top: 30px !default;
+$navbar-search-left: 160px !default;
+$navbar-search-left-md: 165px !default;
 
 // Sub Navivgation
 $subnav-background-color: #302e30 !default;


### PR DESCRIPTION
The search bar's md left value was lowered when the new placeholder logos were added.  This means that 2x client logos overlap the search bar in md sized windows.  These new variables provide a quick and easy way to change the search bar position on client sites without needing to manually override the css.

As much as I dislike adding new variables, this seems like the easiest way to solve this problem while we get the new nav sorted.