### PR TITLE
Ab#4153 heading alerts

### DIFF
--- a/site/404.html.jet
+++ b/site/404.html.jet
@@ -8,7 +8,7 @@
 <div class="container page not-found">
 
   <div class="page-header text-center">
-    <h2>{{ i18n("404_page_header") }}</h2>
+    <h1>{{ i18n("404_page_header") }}</h1>
   </div>
 
   <div class="text-center">

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -482,5 +482,7 @@
   "shopping_error_age_restricted": { "other": "This content is age restricted." },
   "shopping_error_close_button": { "other": "OK" },
 
-  "wcag_homepage_h1": { "other": "Homepage" }
+  "wcag_homepage_h1": { "other": "Homepage" },
+  "wcag_carousel_h2": { "other": "Carousel" },
+  "wcag_collections_h2": { "other": "Collections" }
 }

--- a/site/templates/collection/carousel.jet
+++ b/site/templates/collection/carousel.jet
@@ -5,6 +5,7 @@
 {{if len(.Items) > 0}}
 <s72-carousel>
 	<div class="page-collection page-collection-carousel">
+		<h2 class="sr-only">{{i18n("wcag_carousel_h2")}}</h2>
 		<div class="s72-carousel-slides">
 			{{range item := .Items}}
 				{{yield carouselItem(item=item)}}

--- a/site/templates/page/curated.jet
+++ b/site/templates/page/curated.jet
@@ -23,6 +23,7 @@
     </div>
   </div>
   <div class="page-collections">
+    <h2 class="sr-only">{{i18n("wcag_collections_h2")}}</h2>
     {{range index, pf := page.PageCollections}}
       {{yield pageCollection() pf}}
     {{end}}

--- a/site/templates/page/homepage.jet
+++ b/site/templates/page/homepage.jet
@@ -21,6 +21,7 @@
     {{yield pageCollectionCarousel() page.PageCollections[0]}}
 
     <div class="other-sliders">
+      <h2 class="sr-only">{{i18n("wcag_collections_h2")}}</h2>
       <div class="other-sliders-container">
         {{yield wishlistCollection()}}
         {{range index, pf := page.PageCollections}}

--- a/site/templates/page/landing.jet
+++ b/site/templates/page/landing.jet
@@ -1,7 +1,7 @@
 {{extends "templates/application.jet"}}
 {{block body()}}
   <div>
-    <h2>Landing - {{ page.Title }}</h2>
+    <h1>Landing - {{ page.Title }}</h1>
 
     <div>
       {{ page.Content }}


### PR DESCRIPTION
https://dev.azure.com/S72/SHIFT72/_workitems/edit/4153

- Swapped the h2 headings on 404 and landing pages for h1 headings.
- Added h2 headings to collection blocks to avoid skipping from h1 page heading to h3 collection item headings.