### PR TITLE
fix(accessibility): added missing config check to bundle partial title

### DIFF
--- a/site/templates/bundle/partial.jet
+++ b/site/templates/bundle/partial.jet
@@ -1,5 +1,7 @@
 {{import "../items/tagline.jet"}}
 
+{{ displayTitleAndGenreBelowPosters = config("media_item_caption") == "true" }}
+
 <div class="partial partial-bundle">
   <a href="{{routeToSlug(bundle.Slug)}}" aria-label="{{bundle.Title}}">
     <div class="poster poster-{{config("default_image_type")}}">
@@ -12,18 +14,15 @@
       {{end}}
       <div class="hover">
         <div class="content">
-          <div class="titles">
-            <h4 title="{{bundle.Title}}">{{bundle.Title|raw}}</h4>
-            <div class="strap">
-              {{yield metaItemTagline() bundle}}
+          {{ if !displayTitleAndGenreBelowPosters }}
+            <div class="titles">
+              <h4 title="{{bundle.Title}}">{{bundle.Title|raw}}</h4>
+              <div class="strap">
+                {{yield metaItemTagline() bundle}}
+              </div>
             </div>
-          </div>
+          {{ end }}
           <s72-play-button data-slug="{{bundle.Slug}}" title="{{bundle.Title}}"></s72-play-button>
-          <!-- {{if isset(bundle["Tagline"])}}
-            <div class="meta-item-synopsis hidden-md">
-              <p>{{bundle.Tagline}}</p>
-            </div>
-          {{end}} -->
           <div class="buttons">
             {{if isset(bundle["Trailers"]) && len(bundle.Trailers) > 0}}
               <s72-trailer-button data-slug="{{bundle.Slug}}" data-url="{{bundle.Trailers}}" button-class="btn-sm"></s72-trailer-button>


### PR DESCRIPTION
https://dev.azure.com/S72/SHIFT72/_workitems/edit/4153?src=WorkItemMention&src-action=artifact_link

'Fixes' the bundle title header that shows in search results.

TBH this fix is sidestepping the issue because it just stops the header from showing (I don't think any clients have this config on anyway).  But this brings the bundle partial in line with the other partials... SiteImprove couldn't see them with the config off.

We can come back to this later for a redesign!