### PR TITLE
fix: changed tagline from <ul> to <div> to fix hidden margin issue

### DIFF
--- a/site/styles/_meta-item-tagline.scss
+++ b/site/styles/_meta-item-tagline.scss
@@ -10,9 +10,6 @@
     &:not(:last-child) {
       margin-right: map-get($spacers, 1); // Currently 0.25rem
     }
-    &.meta-item-tagline-item-classification {
-      margin-right: 0;
-    }
   }
 }
 .meta-item-classification {

--- a/site/templates/items/tagline.jet
+++ b/site/templates/items/tagline.jet
@@ -1,63 +1,48 @@
-{{block metaItemTagline(genres=true, genresLimit=-1, classification=true)}}
-  <ul class="meta-item-tagline">
-
-    {*<li class="meta-item-tagline-item">
-      <span class="meta-item-classification meta-item-classification-mature">M</span>
-    </li>*}
-
-    {{if classification==true}}
-    <li class="meta-item-tagline-item meta-item-tagline-item-classification">
+{{ block metaItemTagline(genres=true, genresLimit=-1, classification=true) }}
+  <div class="meta-item-tagline">
+    {{ if classification==true }}
       <s72-classification-label data-slug="{{.Slug}}" data-layout="tooltip"></s72-classification-label>
-    </li>
-    {{end}}
+    {{ end }}
 
-    {{if genres == true}}
+    {{ if genres == true }}
       {{ if isset(.Genres) && len(.Genres) > 0 }}
-
         {{ itemGenres := .Genres }}
         {{ if genresLimit > -1  && len(itemGenres) > genresLimit }}
           {{ itemGenres = itemGenres[:genresLimit] }}
         {{ end }}
 
-        {{if isset(itemGenres)}}
-          <li class="meta-item-tagline-item">{{itemGenres}}</li>
-        {{end}}
+        {{ if isset(itemGenres) }}
+          <span class="meta-item-tagline-item">{{ itemGenres }}</span>
+        {{ end }}
 
-        {{if isset(.Runtime) || isset(.Episodes)}}
-          <li class="meta-item-tagline-divider">•</li>
-        {{end}}
+        {{ if isset(.Runtime) || isset(.Episodes) }}
+          <span class="meta-item-tagline-divider">•</span>
+        {{ end }}
+      {{ end }}
 
-      {{end}}
+      {{ if isset(.ShowInfo) && isset(.ShowInfo.Genres) }}
+        <span class="meta-item-tagline-item">{{ .ShowInfo.Genres }}</span>
 
-      {{if isset(.ShowInfo) && isset(.ShowInfo.Genres)}}
-        <li class="meta-item-tagline-item">{{.ShowInfo.Genres}}</li>
+        {{ if isset(.Runtime) || isset(.Episodes) }}
+          <span class="meta-item-tagline-divider">•</span>
+        {{ end }}
+      {{ end }}
+    {{ end }}
 
-        {{if isset(.Runtime) || isset(.Episodes)}}
-          <li class="meta-item-tagline-divider">•</li>
-        {{end}}
+    {{ if isset(.Runtime) }}
+      {{ if .Runtime > 60 }}
+        <span class="meta-item-tagline-item">{{ .Runtime.Hours() }}{{ i18n("runtime_hours") }} {{ .Runtime.Minutes() }}{{ i18n("runtime_minutes") }}</span>
+      {{ else }}
+        <span class="meta-item-tagline-item">{{ .Runtime }}min</span>
+      {{ end }}
+    {{ end }}
 
-      {{end}}
-
+    {{ if isset(.Items) }}
+      <span class="meta-item-tagline-item">{{ i18n("bundle_items_all_films", len(.Items)) }}</span>
     {{end}}
 
-    {{if isset(.Runtime)}}
-
-      {{if .Runtime > 60}}
-        <li class="meta-item-tagline-item">{{.Runtime.Hours()}}{{i18n("runtime_hours")}} {{.Runtime.Minutes()}}{{i18n("runtime_minutes")}}</li>
-      {{else}}
-        <li class="meta-item-tagline-item">{{.Runtime}}min</li>
-      {{end}}
-
-      {*<li class="meta-item-tagline-item">{{.Runtime}}min</li>*}
-    {{end}}
-
-    {{if isset(.Items)}}
-      <li class="meta-item-tagline-item">{{i18n("bundle_items_all_films", len(.Items))}}</li>
-    {{end}}
-
-    {{if isset(.Episodes)}}
-      <li class="meta-item-tagline-item">{{i18n("episode_count", len(.Episodes))}}</li>
-    {{end}}
-
-  </ul>
-{{end}}
+    {{ if isset(.Episodes) }}
+      <span class="meta-item-tagline-item">{{ i18n("episode_count", len(.Episodes)) }}</span>
+    {{ end }}
+  </div>
+{{ end }}

--- a/site/templates/items/tagline.jet
+++ b/site/templates/items/tagline.jet
@@ -1,48 +1,48 @@
-{{ block metaItemTagline(genres=true, genresLimit=-1, classification=true) }}
+{{block metaItemTagline(genres=true, genresLimit=-1, classification=true)}}
   <div class="meta-item-tagline">
-    {{ if classification==true }}
+    {{if classification==true}}
       <s72-classification-label data-slug="{{.Slug}}" data-layout="tooltip"></s72-classification-label>
-    {{ end }}
-
-    {{ if genres == true }}
-      {{ if isset(.Genres) && len(.Genres) > 0 }}
-        {{ itemGenres := .Genres }}
-        {{ if genresLimit > -1  && len(itemGenres) > genresLimit }}
-          {{ itemGenres = itemGenres[:genresLimit] }}
-        {{ end }}
-
-        {{ if isset(itemGenres) }}
-          <span class="meta-item-tagline-item">{{ itemGenres }}</span>
-        {{ end }}
-
-        {{ if isset(.Runtime) || isset(.Episodes) }}
-          <span class="meta-item-tagline-divider">•</span>
-        {{ end }}
-      {{ end }}
-
-      {{ if isset(.ShowInfo) && isset(.ShowInfo.Genres) }}
-        <span class="meta-item-tagline-item">{{ .ShowInfo.Genres }}</span>
-
-        {{ if isset(.Runtime) || isset(.Episodes) }}
-          <span class="meta-item-tagline-divider">•</span>
-        {{ end }}
-      {{ end }}
-    {{ end }}
-
-    {{ if isset(.Runtime) }}
-      {{ if .Runtime > 60 }}
-        <span class="meta-item-tagline-item">{{ .Runtime.Hours() }}{{ i18n("runtime_hours") }} {{ .Runtime.Minutes() }}{{ i18n("runtime_minutes") }}</span>
-      {{ else }}
-        <span class="meta-item-tagline-item">{{ .Runtime }}min</span>
-      {{ end }}
-    {{ end }}
-
-    {{ if isset(.Items) }}
-      <span class="meta-item-tagline-item">{{ i18n("bundle_items_all_films", len(.Items)) }}</span>
     {{end}}
 
-    {{ if isset(.Episodes) }}
-      <span class="meta-item-tagline-item">{{ i18n("episode_count", len(.Episodes)) }}</span>
-    {{ end }}
+    {{if genres == true}}
+      {{if isset(.Genres) && len(.Genres) > 0}}
+        {{itemGenres := .Genres}}
+        {{if genresLimit > -1  && len(itemGenres) > genresLimit}}
+          {{itemGenres = itemGenres[:genresLimit]}}
+        {{end}}
+
+        {{if isset(itemGenres)}}
+          <span class="meta-item-tagline-item">{{itemGenres}}</span>
+        {{end}}
+
+        {{if isset(.Runtime) || isset(.Episodes)}}
+          <span class="meta-item-tagline-divider">•</span>
+        {{end}}
+      {{end}}
+
+      {{if isset(.ShowInfo) && isset(.ShowInfo.Genres)}}
+        <span class="meta-item-tagline-item">{{.ShowInfo.Genres}}</span>
+
+        {{if isset(.Runtime) || isset(.Episodes)}}
+          <span class="meta-item-tagline-divider">•</span>
+        {{end}}
+      {{end}}
+    {{end}}
+
+    {{if isset(.Runtime)}}
+      {{if .Runtime > 60}}
+        <span class="meta-item-tagline-item">{{.Runtime.Hours()}}{{i18n("runtime_hours")}} {{.Runtime.Minutes()}}{{i18n("runtime_minutes")}}</span>
+      {{else}}
+        <span class="meta-item-tagline-item">{{.Runtime}}min</span>
+      {{end}}
+    {{end}}
+
+    {{if isset(.Items)}}
+      <span class="meta-item-tagline-item">{{i18n("bundle_items_all_films", len(.Items))}}</span>
+    {{end}}
+
+    {{if isset(.Episodes)}}
+      <span class="meta-item-tagline-item">{{i18n("episode_count", len(.Episodes))}}</span>
+    {{end}}
   </div>
-{{ end }}
+{{end}}


### PR DESCRIPTION
https://dev.azure.com/S72/SHIFT72/_workitems/edit/3852

Decided to have another look at this task.  The mystery margin was caused by the first `<li>` containing an empty `<s72-classification-label>`... not exactly sure why it was doing that but I suspect something to do with the Bootstrap list item styles.  Fixed by changing from an `<ul>` to a `<div>` full of `<span>`.

Pro-tip: hide whitespace changes to make the jet diff easier to understand.