### PR TITLE
fixed datepicker on small screens

### DIFF
--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1,7 +1,7 @@
 {
   "site_owner": { "other": "ABC Cinemas" },
   "settings_title": { "other": "Settings" },
-  "powered_by_name": { "other": "ScreenPlus" },
+  "powered_by_name": { "other": "Shift72" },
   "powered_by_url": { "other": "https://www.screenplus.com" },
   "en": { "other": "English" },
   "fr": { "other": "French" },

--- a/site/styles/_forms.scss
+++ b/site/styles/_forms.scss
@@ -90,8 +90,8 @@ s72-activatedevice-form,
   @extend .d-flex;
   flex-direction: row;
   justify-content: space-between;
-  .s72-form-control {
-    width: auto;
+  .s72-datepicker-day, .s72-datepicker-year {
+    flex-shrink: 0;
   }
 }
 // Form Control Default


### PR DESCRIPTION
The flex items were not shrinking because they had their width set to auto. This was pushing them off the screen. The day and year are set to `flex-shrink: 0` to stop them from shrinking so much that they cut off the text inside. This leaves the month which shrinks instead.

Here's the card: https://dev.azure.com/S72/SHIFT72/_boards/board/t/Delivery%20team/Stories/?workitem=4525