### PR TITLE
fix: hover preview text for content pages is now center aligned

### DIFF
--- a/site/styles/_collections.scss
+++ b/site/styles/_collections.scss
@@ -162,6 +162,9 @@
               }
             }
           }
+          .meta-item-synopsis {
+            text-align: center;
+          }
           .synopsis {
             p {
               font-size: 12px;


### PR DESCRIPTION
https://dev.azure.com/S72/SHIFT72/_workitems/edit/4095