### PR TITLE
AB#4192 auto generate mobile support params / app links

### DIFF
--- a/site/supported-devices.json.jet
+++ b/site/supported-devices.json.jet
@@ -1,7 +1,16 @@
-
 {
+  {{if config("player_allow_mobile_drm_content") == "true"}}
+  "support": {
+    "safari": {
+      "ios": "yes"
+    },
+    "chrome": {
+      "android": "yes"
+    }
+  },
+  {{end}}
   "apps": {
-    "android": null,
-    "ios": null
+    "android": {{if len(config("app_link_android")) > 0}}"{{config("app_link_android")}}"{{else}}null{{end}},
+    "ios": {{if len(config("app_link_ios")) > 0}}"{{config("app_link_ios")}}"{{else}}null{{end}}
   }
 }


### PR DESCRIPTION
The existing problem is that the player relies on having an up to date supported-devices.json in order to show the user the correct information as to what they can and cant watch on / where to get the apps if they have them. At the moment its a manual process once apps are deployed but its a bit inconvenient having to do a site deploy to update it. 

I've added some logic into the supported-devices.json that will check;

1. IF mobile playback is enabled in uber and if so, add the support params for the mobile browsers.
2. IF the client has app links set in uber, and if so, adds the app param for the ios / android apps, otherwise leave as null. 

I've done some testing against ABC client 88 and set a couple of public configs (content  > configurations > app_link_ios  / app_link_android). I tried with and without the app links and mobile playback enabled / disabled / no config and seems to work fine. 

I suggest we add this into core template, and then remove from shift72-template so we dont override it. We will need to remove supported-devices.json from site local files as they are upgraded. not sure if there is a better way otherwise.