### PR TITLE
fix: added focus ring to language selector

### DIFF
--- a/site/styles/_language-selector.scss
+++ b/site/styles/_language-selector.scss
@@ -30,6 +30,10 @@ s72-language-selector {
     &:focus {
       color: $primary;
     }
+    &:focus-visible {
+      outline: 1px dotted $body-color;
+      outline: 5px auto -webkit-focus-ring-color;
+    }
   }
   .s72-dropdown-menu {
     left: auto;


### PR DESCRIPTION
https://dev.azure.com/S72/SHIFT72/_workitems/edit/4735

Looks like the new nav has a slightly different approach to focus rings than the old nav so the language selector styles needed a little tweak.