### PR TITLE
latest kibble version, stripHTML method on tagline

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "postcss-cli": "^7.1.1",
     "rollup": "^2.23.0",
     "rollup-plugin-terser": "^6.1.0",
-    "s72-kibble": "^0.15.17",
+    "s72-kibble": "^0.15.18",
     "watch": "^1.0.2"
   },
   "devDependencies": {

--- a/site/templates/collection/carousel_item.jet
+++ b/site/templates/collection/carousel_item.jet
@@ -41,7 +41,7 @@
             <s72-availability-label data-slug="{{item.Slug}}"></s72-availability-label>
 
             <div class="meta-item-synopsis">
-              <p>{{item.InnerItem.Tagline}}</p>
+              <p>{{item.InnerItem.Tagline | stripHTML}}</p>
             </div>
 
             <div class="meta-item-extras">

--- a/site/templates/items/featured_item.jet
+++ b/site/templates/items/featured_item.jet
@@ -27,7 +27,7 @@
 
         {{if isset(item.InnerItem["Tagline"])}}
           <div class="meta-item-synopsis hidden-md">
-            <p>{{item.InnerItem.Tagline}}</p>
+            <p>{{item.InnerItem.Tagline | stripHTML}}</p>
           </div>
         {{end}}
 

--- a/site/templates/items/meta_item.jet
+++ b/site/templates/items/meta_item.jet
@@ -29,7 +29,7 @@
   {{end}}
   {{title := item.Title}}
   {{if item.ItemType == "tvseason"}}
-    {{synopsis=item.InnerItem.Tagline}}
+    {{synopsis = stripHTML(item.InnerItem.Tagline)}}
     {{title = item.InnerItem.ShowInfo.Title}}
     {{pill = i18n("season_name") + " " + item.InnerItem.SeasonNumber}}
   {{end}}

--- a/site/templates/page/partial.jet
+++ b/site/templates/page/partial.jet
@@ -13,7 +13,7 @@
 
           {{if isset(page["Tagline"])}}
             <div class="meta-item-synopsis hidden-md">
-              <p>{{page.Tagline}}</p>
+              <p>{{page.Tagline | stripHTML}}</p>
             </div>
           {{end}}
         </div>


### PR DESCRIPTION
- This PR updates to the latest kibble which has a template method that strips html tags
- Here's [the card](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Core%20team/Stories/?workitem=4407)
- Basically, clients have assumed they can add HTML to the 'Short description' field in admin, because they can do so in the synopsis below it.