### PR TITLE
fix: prevent rollup.js from clearing console output when rebuilding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/0.1.0-beta.2...HEAD)
 
+### Fixed
+- Prevent rollup.js from clearing console output when rebuilding.
+
 ## [0.2.0-beta.1](https://github.com/shift72/core-template/compare/0.1.0...0.2.0-beta.1) -2021-08-05
 
 ### Added

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,5 +21,8 @@ export default {
   plugins: [
     buble({ jsx: 's72.ui.h', objectAssign: 'Object.assign' }),
     (production && terser())
-  ]
+  ],
+  watch: {
+    clearScreen: false
+  }
 };


### PR DESCRIPTION
Might be a good idea to test this on your machines before approving to make sure it really works.