### PR TITLE
0.3.0 beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,25 @@
 # Changelog
 
-## [Unreleased](https://github.com/shift72/core-template/compare/0.2.0-beta.1...HEAD)
+## [Unreleased](https://github.com/shift72/core-template/compare/0.3.0-beta.1...HEAD)
+
+## [0.3.0-beta.1](https://github.com/shift72/core-template/compare/0.2.0-beta.1...0.3.0-beta.1) - 2021-08-13
+
+### Added
+- Added Croatian (`hr_HR`) translations file.
 
 ### Fixed
 - The sign out button can now be selected with keyboard controls.
 - Prevent rollup.js from clearing console output when rebuilding.
+- Headed banner height replaced with min-height.
+- Removed hardcoded English minutes reference in tagline.
 
 ### Changed
 - Changed from Node Sass to Dart Sass.
 - Improved linter rule sets.
 - Major refactor of JS and SCSS files.
+- Subnav dropdown width increased for mobile.
 
-## [0.2.0-beta.1](https://github.com/shift72/core-template/compare/0.1.0...0.2.0-beta.1) -2021-08-05
+## [0.2.0-beta.1](https://github.com/shift72/core-template/compare/0.1.0...0.2.0-beta.1) - 2021-08-05
 
 ### Added
 - Added Stylelint, Prettier, and ESLint.

--- a/kibble.json
+++ b/kibble.json
@@ -27,7 +27,8 @@
     "uk": { "code": "uk_UA", "name": "Український" },
     "fi": { "code": "fi_FI", "name": "Suomi" },
     "ar": { "code": "ar_LB", "name": "عربى" },
-    "zh-tw": { "code": "zh_TW", "name": "中文" }
+    "zh-tw": { "code": "zh_TW", "name": "中文" },
+    "hr": { "code": "hr_HR", "name": "Hrvatski" }
   },
   "siteRootPath": "site",
   "liveReload": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shift72/core-template",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.1",
   "description": "Shift72 core template",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
### Added
- Added Croatian (`hr_HR`) translations file.

### Fixed
- The sign out button can now be selected with keyboard controls.
- Prevent rollup.js from clearing console output when rebuilding.
- Headed banner height replaced with min-height.
- Removed hardcoded English minutes reference in tagline.

### Changed
- Changed from Node Sass to Dart Sass.
- Improved linter rule sets.
- Major refactor of JS and SCSS files.
- Subnav dropdown width increased for mobile.