### PR TITLE
New meta-item-tagline jet + homepage padding fix when carousel is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - App badges now display automatically when configured in Uber Admin.
 - Added Brazilian Portuguese (`pt_BR`) translations file.
 
+### Changed
+- Moved year from film/tv titles into tagline.
+- Redesigned meta item tagline jet for easier development.
+
 ### Fixed
 - Carousel tagline now uses theme colour.
 - Signin button on VIP sites now has primary button styling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Redesigned meta item tagline jet for easier development.
 
 ### Fixed
+- Homepage has correct top-padding when carousel is empty.
 - Carousel tagline now uses theme colour.
 - Signin button on VIP sites now has primary button styling.
 

--- a/site/styles/_pages.scss
+++ b/site/styles/_pages.scss
@@ -59,7 +59,8 @@
 .wishlist-page,
 .search-page,
 .collection-page,
-.devices-page {
+.devices-page,
+.carousel-len-0 {
   padding-top: $page-padding-top;
   @include media-breakpoint-up(md) {
     padding: $page-padding-top-md 0 0 0;

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -34,7 +34,7 @@
             </div>
         {{end}}
         <div class="meta-detail-content">
-          <h1>{{ film.Title }} {{if film.ReleaseDate.Year() > 1}}<small>({{film.ReleaseDate.Year()}})</small>{{end}}</h1>
+          <h1>{{ film.Title }}</h1>
           <div class="meta-detail-tagline-and-classification">
             <div class="meta-detail-tagline">
               {{yield metaItemTagline() film}}

--- a/site/templates/items/featured_item.jet
+++ b/site/templates/items/featured_item.jet
@@ -15,11 +15,7 @@
       <s72-userwishlist-button data-slug="{{item.Slug}}" class="btn-wishlist" data-layout="quick-button"></s72-userwishlist-button>
 
       <div class="meta-item-body featured-meta-item-body">
-        <div class="meta-item-title">{{item.Title}}
-          {{if isset(item.InnerItem["ReleaseDate"]) && item.InnerItem.ReleaseDate.Year() > 1}}
-            <small>({{item.InnerItem.ReleaseDate.Year()}})</small>
-          {{end}}
-        </div>
+        <div class="meta-item-title">{{item.Title}}</div>
 
         <div class="meta-item-text">
           {{yield metaItemTagline() item.InnerItem}}

--- a/site/templates/items/meta_item.jet
+++ b/site/templates/items/meta_item.jet
@@ -47,11 +47,7 @@
 
             {{ if !displayTitleAndGenreBelowPosters }}
             <div class="titles">
-              <h4 title="{{item.Title}}">{{title|raw}}
-                {{if isset(item.InnerItem["ReleaseDate"]) && item.InnerItem.ReleaseDate.Year() > 1}}
-                  <small>({{item.InnerItem.ReleaseDate.Year()}})</small>
-                {{end}}
-              </h4>
+              <h4 title="{{item.Title}}">{{title|raw}}</h4>
               <div class="strap">
                 <s72-classification-label data-slug="{{item.Slug}}"></s72-classification-label>
                 {{yield metaItemTagline(genres=true, genresLimit=genresLimit, classification=false) item.InnerItem}}
@@ -75,11 +71,7 @@
 
   {{if displayTitleAndGenreBelowPosters}}
     <div class="caption">
-      <div class="title" title="{{item.Title}}">{{title|raw}}
-        {{if isset(item.InnerItem["ReleaseDate"]) && item.InnerItem.ReleaseDate.Year() > 1}}
-          <small>({{item.InnerItem.ReleaseDate.Year()}})</small>
-        {{end}}
-      </div>
+      <div class="title" title="{{item.Title}}">{{title|raw}}</div>
       {{yield metaItemTagline(genres=true, genresLimit=genresLimit, classification=false) item.InnerItem}}
     </div>
   {{end}}

--- a/site/templates/items/tagline.jet
+++ b/site/templates/items/tagline.jet
@@ -1,48 +1,90 @@
 {{block metaItemTagline(genres=true, genresLimit=-1, classification=true)}}
   <div class="meta-item-tagline">
-    {{if classification==true}}
+    {{itemGenres := makeSlice()}}
+    {{if genres}}
+      {{if isset(.Genres)}}
+        {{itemGenres = .Genres}}
+      {{else if isset(.ShowInfo) && isset(.ShowInfo.Genres)}}
+        {{itemGenres = .ShowInfo.Genres}}
+      {{end}}
+    {{end}}
+
+    {*{ FIGURE OUT HOW MANY DIVIDERS }*}
+    {{dividers := 0}}
+    {{if genres && len(itemGenres) > 0}}
+      {{dividers = dividers + 1}}
+    {{end}}
+    {{if isset(.Runtime)}}
+      {{dividers = dividers + 1}}
+    {{end}}
+    {{if isset(.Items)}}
+      {{dividers = dividers + 1}}
+    {{end}}
+    {{if isset(.Episodes)}}
+      {{dividers = dividers + 1}}
+    {{end}}
+    {{if isset(.ReleaseDate) && .ReleaseDate.Year() > 1}}
+      {{dividers = dividers + 1}}
+    {{end}}
+    {*{ THERE SHOULD BE ONE LESS DIVIDERS THAN TAGLINE ITEMS }*}
+    {{dividers = dividers - 1}}
+    
+    {{if classification}}
       <s72-classification-label data-slug="{{.Slug}}" data-layout="tooltip"></s72-classification-label>
     {{end}}
 
-    {{if genres == true}}
-      {{if isset(.Genres) && len(.Genres) > 0}}
-        {{itemGenres := .Genres}}
-        {{if genresLimit > -1  && len(itemGenres) > genresLimit}}
-          {{itemGenres = itemGenres[:genresLimit]}}
-        {{end}}
-
-        {{if isset(itemGenres)}}
-          <span class="meta-item-tagline-item">{{itemGenres}}</span>
-        {{end}}
-
-        {{if isset(.Runtime) || isset(.Episodes)}}
-          <span class="meta-item-tagline-divider">•</span>
-        {{end}}
+    {{if genres && len(itemGenres) > 0}}
+      {{yield taglineItem() content}}
+        {{itemGenres}}
       {{end}}
-
-      {{if isset(.ShowInfo) && isset(.ShowInfo.Genres)}}
-        <span class="meta-item-tagline-item">{{.ShowInfo.Genres}}</span>
-
-        {{if isset(.Runtime) || isset(.Episodes)}}
-          <span class="meta-item-tagline-divider">•</span>
-        {{end}}
-      {{end}}
+      {{yield taglineDivider(dividers=dividers)}}
+      {{dividers = dividers - 1}}
     {{end}}
 
     {{if isset(.Runtime)}}
-      {{if .Runtime > 60}}
-        <span class="meta-item-tagline-item">{{.Runtime.Hours()}}{{i18n("runtime_hours")}} {{.Runtime.Minutes()}}{{i18n("runtime_minutes")}}</span>
-      {{else}}
-        <span class="meta-item-tagline-item">{{.Runtime}}{{i18n("runtime_minutes")}}</span>
+      {{yield taglineItem() content}}
+        {{if .Runtime > 60}}
+          {{.Runtime.Hours()}}{{i18n("runtime_hours")}} {{.Runtime.Minutes()}}{{i18n("runtime_minutes")}}
+        {{else}}
+          {{.Runtime}}{{i18n("runtime_minutes")}}
+        {{end}}
       {{end}}
+      {{yield taglineDivider(dividers=dividers)}}
+      {{dividers = dividers - 1}}
     {{end}}
 
     {{if isset(.Items)}}
-      <span class="meta-item-tagline-item">{{i18n("bundle_items_all_films", len(.Items))}}</span>
+      {{yield taglineItem() content}}
+        {{i18n("bundle_items_all_films", len(.Items))}}
+      {{end}}
+      {{yield taglineDivider(dividers=dividers)}}
+      {{dividers = dividers - 1}}
     {{end}}
 
     {{if isset(.Episodes)}}
-      <span class="meta-item-tagline-item">{{i18n("episode_count", len(.Episodes))}}</span>
+      {{yield taglineItem() content}}
+        {{i18n("episode_count", len(.Episodes))}}
+      {{end}}
+      {{yield taglineDivider(dividers=dividers)}}
+      {{dividers = dividers - 1}}
+    {{end}}
+
+    {{if isset(.ReleaseDate) && .ReleaseDate.Year() > 1}}
+      {{yield taglineItem() content}}
+        {{.ReleaseDate.Year()}}
+      {{end}}
+      {{yield taglineDivider(dividers=dividers)}}
+      {{dividers = dividers - 1}}
     {{end}}
   </div>
+{{end}}
+
+{{block taglineItem()}}
+  <span class="meta-item-tagline-item">{{yield content}}</span>
+{{end}}
+
+{{block taglineDivider(dividers)}}
+  {{if dividers > 0}}
+    <span class="meta-item-tagline-divider">•</span>
+  {{end}}
 {{end}}

--- a/site/templates/page/homepage.jet
+++ b/site/templates/page/homepage.jet
@@ -17,8 +17,9 @@
 
 {{block body()}}
   <h1 class="sr-only">{{i18n("wcag_homepage_h1")}}</h1>
-  <main id="main" class="page page-{{page.PageType|lower}}">
+
   <main id="main" class="page page-{{page.PageType|lower}} carousel-len-{{len(page.PageCollections[0])}}">
+    {{yield pageCollectionCarousel() page.PageCollections[0]}}
 
     <div class="other-sliders">
       <h2 class="sr-only">{{i18n("wcag_collections_h2")}}</h2>

--- a/site/templates/page/homepage.jet
+++ b/site/templates/page/homepage.jet
@@ -18,7 +18,7 @@
 {{block body()}}
   <h1 class="sr-only">{{i18n("wcag_homepage_h1")}}</h1>
   <main id="main" class="page page-{{page.PageType|lower}}">
-    {{yield pageCollectionCarousel() page.PageCollections[0]}}
+  <main id="main" class="page page-{{page.PageType|lower}} carousel-len-{{len(page.PageCollections[0])}}">
 
     <div class="other-sliders">
       <h2 class="sr-only">{{i18n("wcag_collections_h2")}}</h2>


### PR DESCRIPTION
I'm going to slow down working on the carousel redesign until the backlog is empty again to give design a chance to flesh out their latest mock-ups (and because it's not high priority) so might as well merge the finished bits from this branch now.

- Homepage top-padding fix for when carousel is empty.
- `meta-item-tagline.jet` total rewrite:
  - Added release year to `metaItemTagline` and removed it from everywhere else (various titles).
  - Added more intelligent way of deciding how many divider dots to use (the old way was pretty easy to break and a total mess to read).
  - Added tidier way of showing info from the meta item.