### PR TITLE
AB#4821 unescaped html tags in kibble template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/0.3.1...HEAD)
 
+### Fixed
+- html tags were not being escaped in some places
+
 ## [0.3.1](https://github.com/shift72/core-template/compare/0.3.0-beta.4...0.3.1)
 
 ### Added

--- a/site/templates/items/meta_item.jet
+++ b/site/templates/items/meta_item.jet
@@ -75,7 +75,7 @@
 
   {{if displayTitleAndGenreBelowPosters}}
     <div class="caption">
-      <div class="title" title="{{item.Title}}">{{title|raw}}
+      <div class="title" title="{{item.Title}}">{{title|stripHTML}}
         {{if isset(item.InnerItem["ReleaseDate"]) && item.InnerItem.ReleaseDate.Year() > 1}}
           <small>({{item.InnerItem.ReleaseDate.Year()}})</small>
         {{end}}


### PR DESCRIPTION
Have added stripHTML to meta item
Checked various places across the site and haven't seen issues elsewhere