### PR TITLE
Ab#5116 fix npm vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "font-awesome": "^4.7.0",
         "minify": "^4.1.1",
         "npm-run-all": "^4.0.2",
+        "postcss": "^8.3.11",
         "postcss-cli": "^9.0.1",
         "rollup": "^2.23.0",
         "rollup-plugin-terser": "^6.1.0",
@@ -4309,7 +4310,6 @@
       "version": "3.1.30",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
       "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4828,7 +4828,6 @@
       "version": "8.3.11",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
       "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
@@ -6388,7 +6387,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11257,8 +11255,7 @@
     "nanoid": {
       "version": "3.1.30",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
-      "peer": true
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11636,7 +11633,6 @@
       "version": "8.3.11",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
       "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
-      "peer": true,
       "requires": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
@@ -12762,8 +12758,7 @@
     "source-map-js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-      "peer": true
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-support": {
       "version": "0.5.12",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "font-awesome": "^4.7.0",
     "minify": "^4.1.1",
     "npm-run-all": "^4.0.2",
+    "postcss": "^8.3.11",
     "postcss-cli": "^9.0.1",
     "rollup": "^2.23.0",
     "rollup-plugin-terser": "^6.1.0",


### PR DESCRIPTION
https://dev.azure.com/S72/SHIFT72/_workitems/edit/5116

This brings core-template down to 0 npm vulnerabilities.  Will look at shift72-template next.

- ran `npm audit fix` to automatically squash all of the non-breaking version updates.
- removed `cssnano` vulnerability by updating `cssnano` which required `postcss-cli` to be updated too.
- removed `watch` vulnerability by removing `watch`.  I can't find any usage of it in this repo.
- added some eslint plugin dev dependencies whose absence was causing eslint to fail.
- added postcss because the github action was failing on the css:lint task... postcss fixes it for some reason?

The site runs fine locally.  Running `npm run css:build` now produces a very slightly different minified `main.css` file... I suspect the differences are related to `cssnano` optimisations in the newer version.  Removing `watch` had no noticeable effect on anything.