### PR TITLE
Release 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [Unreleased](https://github.com/shift72/core-template/compare/0.3.7...HEAD)
+## [Unreleased](https://github.com/shift72/core-template/compare/0.3.8...HEAD)
+
+## [0.3.8](https://github.com/shift72/core-template/compare/0.3.7...0.3.8)
 
 ### Fixed
 - Genre limit on meta-item-tagline now works again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Genre limit on meta-item-tagline now works again.
+- Typo in English translations file.
 
 ## [0.3.7](https://github.com/shift72/core-template/compare/0.3.6...0.3.7)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shift72/core-template",
-  "version": "0.3.6",
+  "version": "0.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shift72/core-template",
-      "version": "0.3.6",
+      "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-buble": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shift72/core-template",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Shift72 core template",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
### Fixed
- Genre limit on meta-item-tagline now works again.
- Typo in English translations file.