### PR TITLE
translations for share modal

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -73,6 +73,13 @@
     "play_button_resume": { "other" : "تابع "},
   
     "social_media_buttons_title": { "other": "النشر " },
+    "social_media_buttons_facebook": { "other": "انشر في الفيسبوك" },
+    "social_media_buttons_twitter": { "other": "حصة على التغريد" },
+    "social_media_buttons_linkedin": { "other": "انشر على لينكد إن" },
+    "social_media_buttons_email": { "other": "سهم عبر البريد الإلكتروني" },
+    "social_media_buttons_email_subject": { "other": "مشاركة الارتباط" },
+    "social_media_buttons_copied_link": { "other": "تم نسخ الرابط إلى الحافظة!" },
+    "social_media_buttons_copy_link": { "other": "نسخ إلى الحافظة" },
   
     "accept_invite_page_header": { "other": "أهلا بك" },
     "acceptinvite_form_invalid_reset_password_token": { "other": "يبدو أنك طالبت بهذه الدعوة من قبل ، يجب عليك <a href=\"{{.SigninURL}}\"> تسجيل الدخول </a> بدلاً من ذلك. إذا نسيت كلمة المرور ، فيمكنك أيضًا <a href=\"{{.ForgotPasswordURL}}\"> إعادة تعيين كلمة المرور </a>." },

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -139,6 +139,13 @@
   "social_media_buttons_title": {
    "other": "Compartir"
   },
+  "social_media_buttons_facebook": { "other": "Comparteix a Facebook" },
+  "social_media_buttons_twitter": { "other": "Comparteix a Twitter" },
+  "social_media_buttons_linkedin": { "other": "Comparteix a Linkedin" },
+  "social_media_buttons_email": { "other": "Comparteix per correu electrònic" },
+  "social_media_buttons_email_subject": { "other": "Compartir enllaç" },
+  "social_media_buttons_copied_link": { "other": "S'ha copiat l'enllaç al porta-retalls!" },
+  "social_media_buttons_copy_link": { "other": "Copiar al portapapers" },
   "accept_invite_page_header": {
    "other": "Benvingut"
   },

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -124,6 +124,13 @@
   "social_media_buttons_title": {
     "other": "Del"
   },
+  "social_media_buttons_facebook": { "other": "Del på facebook" },
+  "social_media_buttons_twitter": { "other": "Del på Twitter" },
+  "social_media_buttons_linkedin": { "other": "Del på Linkedin" },
+  "social_media_buttons_email": { "other": "Del via e-mail" },
+  "social_media_buttons_email_subject": { "other": "Linkdeling" },
+  "social_media_buttons_copied_link": { "other": "Link kopieret til udklipsholder!" },
+  "social_media_buttons_copy_link": { "other": "Kopier til udklipsholder" },
   "accept_invite_page_header": {
     "other": "Velkommen"
   },

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -67,6 +67,13 @@
   "play_button_resume": { "other" : "Fortsetzen"},
 
   "social_media_buttons_title": { "other": "Teilen" },
+  "social_media_buttons_facebook": { "other": "Auf Facebook teilen" },
+  "social_media_buttons_twitter": { "other": "Auf Twitter teilen" },
+  "social_media_buttons_linkedin": { "other": "Auf Linkedin teilen" },
+  "social_media_buttons_email": { "other": "Per E-Mail teilen" },
+  "social_media_buttons_email_subject": { "other": "Link teilen" },
+  "social_media_buttons_copied_link": { "other": "Link in die Zwischenablage kopiert!" },
+  "social_media_buttons_copy_link": { "other": "In die Zwischenablage kopieren" },
 
   "accept_invite_page_header": { "other": "Willkommen" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Sie haben diese Einladung bereits angenommen. <a href=\"{{.SigninURL}}\">Loggen Sie sich hier ein</a>. Falls Sie Ihr Passwort vergessen haben, können Sie es <a href=\"{{.ForgotPasswordURL}}\">hier zurücksetzen</a>." },

--- a/site/ee_EE.all.json
+++ b/site/ee_EE.all.json
@@ -73,7 +73,14 @@
     "play_button_resume": { "other" : "Jätka"},
   
     "social_media_buttons_title": { "other": "Jaga" },
-  
+    "social_media_buttons_facebook": { "other": "Jaga Facebookis" },
+    "social_media_buttons_twitter": { "other": "Jaga Twitteris" },
+    "social_media_buttons_linkedin": { "other": "Jaga Linkedinis" },
+    "social_media_buttons_email": { "other": "Jaga meili teel" },
+    "social_media_buttons_email_subject": { "other": "Lingi jagamine" },
+    "social_media_buttons_copied_link": { "other": "Link on lõikelauale kopeeritud!" },
+    "social_media_buttons_copy_link": { "other": "Kopeerida lõikelauale" },
+
     "accept_invite_page_header": { "other": "Tere tulemast" },
     "acceptinvite_form_invalid_reset_password_token": { "other": "Näib, et sa oled kutse juba vastu võtnud. Sa peaksid hoopis <a href=\"{{.SigninURL}}\">sisse logima</a>. Kui oled salasõna unustanud, saad selle <a href=\"{{.ForgotPasswordURL}}\">uuendada</a>." },
     "acceptinvite_complete": { "other": "Aitäh! Sinu konto on loodud." },

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -73,6 +73,13 @@
   "play_button_resume": { "other" : "Συνέχιση"},
 
   "social_media_buttons_title": { "other": "Μοιράσου το" },
+  "social_media_buttons_facebook": { "other": "Κοινοποίηση στο Facebook" },
+  "social_media_buttons_twitter": { "other": "Μοιραστείτε το στο Twitter" },
+  "social_media_buttons_linkedin": { "other": "Κοινή χρήση στο Linkedin" },
+  "social_media_buttons_email": { "other": "Κοινοποίηση μέσω email" },
+  "social_media_buttons_email_subject": { "other": "Κοινή χρήση συνδέσμου" },
+  "social_media_buttons_copied_link": { "other": "Ο σύνδεσμος αντιγράφηκε στο πρόχειρο!" },
+  "social_media_buttons_copy_link": { "other": "Αντιγραφή στο πρόχειρο" },
 
   "accept_invite_page_header": { "other": "Καλώς ορίσατε" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Φαίνεται πως έχετε ήδη αποδεχθεί αυτή την πρόσκληση, πρέπει να <a href=\"{{.SigninURL}}\">εισέλθετε</a> στο λογαριασμό σας." },

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -78,6 +78,7 @@
   "social_media_buttons_twitter": { "other": "Share on Twitter" },
   "social_media_buttons_linkedin": { "other": "Share on Linkedin" },
   "social_media_buttons_email": { "other": "Share via email" },
+  "social_media_buttons_email_subject": { "other": "Link share" },
   "social_media_buttons_copied_link": { "other": "Link copied to clipboard!" },
   "social_media_buttons_copy_link": { "other": "Copy to clipboard" },
 

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -73,6 +73,13 @@
   "play_button_resume": { "other" : "Reproducir"},
 
   "social_media_buttons_title": { "other": "Compartir" },
+  "social_media_buttons_facebook": { "other": "Compartir en Facebook" },
+  "social_media_buttons_twitter": { "other": "Compartir en Twitter" },
+  "social_media_buttons_linkedin": { "other": "Compartir en Linkedin" },
+  "social_media_buttons_email": { "other": "Compartir via correo electrónico" },
+  "social_media_buttons_email_subject": { "other": "Compartir enlace" },
+  "social_media_buttons_copied_link": { "other": "¡Link copiado al portapapeles!" },
+  "social_media_buttons_copy_link": { "other": "Copiar al portapapeles" },
 
   "accept_invite_page_header": { "other": "Bienvenido" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Parece que ya ha reclamado esta invitación, usted debe <a href=\"{{.SigninURL}}\">iniciar sesión</a> sin embargo. Si ha olvidado su contraseña, usted puede <a href=\"{{.ForgotPasswordURL}}\">recuperar su contraseña</a>." },

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -73,6 +73,13 @@
   "play_button_resume": { "other" : "Continuar"},
 
   "social_media_buttons_title": { "other": "Compartir" },
+  "social_media_buttons_facebook": { "other": "Compartir en Facebook" },
+  "social_media_buttons_twitter": { "other": "Compartir en Twitter" },
+  "social_media_buttons_linkedin": { "other": "Compartir en Linkedin" },
+  "social_media_buttons_email": { "other": "Compartir via correo electrónico" },
+  "social_media_buttons_email_subject": { "other": "Compartir enlace" },
+  "social_media_buttons_copied_link": { "other": "¡Link copiado al portapapeles!" },
+  "social_media_buttons_copy_link": { "other": "Copiar al portapapeles" },
 
   "accept_invite_page_header": { "other": "Bienvenido" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Parece que ya ha canjeado esta invitación, debería  <a href=\"{{.SigninURL}}\">ingresar</a>. Si has olvidado tu contraseña, puedes también <a href=\"{{.ForgotPasswordURL}}\">reestablecer tu contraseña</a>." },

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -51,6 +51,13 @@
   "play_button_resume": { "other" : "Jatka"},
 
   "social_media_buttons_title": { "other": "Jaa" },
+  "social_media_buttons_facebook": { "other": "Jaa Facebookissa" },
+  "social_media_buttons_twitter": { "other": "Jaa Twitterissä" },
+  "social_media_buttons_linkedin": { "other": "Jaa Linkedinissä" },
+  "social_media_buttons_email": { "other": "Jaa sähköpostilla" },
+  "social_media_buttons_email_subject": { "other": "Linkin jakaminen" },
+  "social_media_buttons_copied_link": { "other": "Linkki kopioitu leikepöydälle!" },
+  "social_media_buttons_copy_link": { "other": "Kopioi leikepöydälle" },
 
   "accept_invite_page_header": { "other": "Tervetuloa" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Vaikuttaa siltä, että olet jo käyttänyt tämän kutsun. Kokeile <a href=\"signin.html\">kirjautua sisään</a> palveluun. Jos olet unohtanut salasanasi, voit <a href=\"forgotpassword.html\">tilata uuden salasanan</a>." },

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -71,6 +71,13 @@
   "play_button_resume": { "other" : "Continuer"},
 
   "social_media_buttons_title": { "other": "Partager" },
+  "social_media_buttons_facebook": { "other": "Partager sur Facebook" },
+  "social_media_buttons_twitter": { "other": "Partager sur Twitter" },
+  "social_media_buttons_linkedin": { "other": "Partager sur Linkedin" },
+  "social_media_buttons_email": { "other": "Partager par e-mail" },
+  "social_media_buttons_email_subject": { "other": "Lien de partage" },
+  "social_media_buttons_copied_link": { "other": "Lien copié dans le presse-papiers !" },
+  "social_media_buttons_copy_link": { "other": "Copier dans le presse-papier" },
 
   "accept_invite_page_header": { "other": "Bienvenue" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Il semble que vous ayez déjà utilisé ce lien, vous devriez essayer de <a href=\"{{.SigninURL}}\">vous connecter</a>. Si vous avez oublié votre mot de passe, vous pouvez aussi <a href=\"{{.ForgotPasswordURL}}\">réinitialiser votre mot de passe</a>." },

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -48,6 +48,13 @@
   "play_button_resume": { "other": "Nastavi" },
 
   "social_media_buttons_title": { "other": "Podijeli" },
+  "social_media_buttons_facebook": { "other": "Podijeli na Facebooku" },
+  "social_media_buttons_twitter": { "other": "Podijelite na Twitteru" },
+  "social_media_buttons_linkedin": { "other": "Podijelite na Linkedinu" },
+  "social_media_buttons_email": { "other": "Podijelite putem e-pošte" },
+  "social_media_buttons_email_subject": { "other": "Dijeljenje veze" },
+  "social_media_buttons_copied_link": { "other": "Veza je kopirana u međuspremnik!" },
+  "social_media_buttons_copy_link": { "other": "Kopirati u međuspremnikKopirati u međuspremnik" },
 
   "accept_invite_page_header": { "other": "Dobrodošli" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Ovaj pozivni kod je već iskorišten i potrebna je ponovna <a href=\"{{.SigninURL}}\">prijava</a>. Ako ste zaboravili lozinku, možete je <a href=\"{{.ForgotPasswordURL}}\">resetirati</a>." },

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -73,7 +73,14 @@
     "play_button_resume": { "other" : "Folytatás"},
   
     "social_media_buttons_title": { "other": "Megosztás" },
-  
+    "social_media_buttons_facebook": { "other": "Megosztani Facebookon" },
+    "social_media_buttons_twitter": { "other": "Oszd meg a Twitteren" },
+    "social_media_buttons_linkedin": { "other": "Oszd meg a Linkedin-en" },
+    "social_media_buttons_email": { "other": "Oszd meg e-mailben" },
+    "social_media_buttons_email_subject": { "other": "Link megosztás" },
+    "social_media_buttons_copied_link": { "other": "Link a vágólapra másolva!" },
+    "social_media_buttons_copy_link": { "other": "Másolja a vágólapra" },
+
     "accept_invite_page_header": { "other": "Üdvözöljük" },
     "acceptinvite_form_invalid_reset_password_token": { "other": "Úgy tűnik, már felhasználtad a meghívódat, próbálj meg <a href=\"{{.SigninURL}}\">bejelentkezni</a>. Ha elfelejtetted a jelszavadat, <a href=\"{{.ForgotPasswordURL}}\">állíts be újat</a>." },
     "acceptinvite_complete": { "other": "Köszönjük. A fiókodat létrehoztuk." },

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -73,6 +73,13 @@
   "play_button_resume": { "other" : "Continua"},
 
   "social_media_buttons_title": { "other": "Condividi" },
+  "social_media_buttons_facebook": { "other": "Condividi su Facebook" },
+  "social_media_buttons_twitter": { "other": "Condividi su Twitter" },
+  "social_media_buttons_linkedin": { "other": "Condividi su Linkedin" },
+  "social_media_buttons_email": { "other": "Condividi via e-mail" },
+  "social_media_buttons_email_subject": { "other": "Condividi link" },
+  "social_media_buttons_copied_link": { "other": "Link copiato negli appunti!" },
+  "social_media_buttons_copy_link": { "other": "Copia negli appunti" },
 
   "accept_invite_page_header": { "other": "Accoglienza" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Questo Invito è già stato usato." },

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -50,6 +50,13 @@
   "play_button_resume": { "other" : "続きから見る"},
 
   "social_media_buttons_title": { "other": "共有" },
+  "social_media_buttons_facebook": { "other": "Facebookでシェア" },
+  "social_media_buttons_twitter": { "other": "Twitterで共有する" },
+  "social_media_buttons_linkedin": { "other": "Linkedinで共有する" },
+  "social_media_buttons_email": { "other": "メールで共有する" },
+  "social_media_buttons_email_subject": { "other": "リンクシェア" },
+  "social_media_buttons_copied_link": { "other": "リンクがクリップボードにコピーされました！" },
+  "social_media_buttons_copy_link": { "other": "クリップボードにコピー" },
 
   "accept_invite_page_header": { "other": "ようこそ" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "すでに招待リクエスト済みですので、サインインしてください。" },

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -73,6 +73,13 @@
   "play_button_resume": { "other" : "Tęsti"},
 
   "social_media_buttons_title": { "other": "Dalintis" },
+  "social_media_buttons_facebook": { "other": "Dalintis Facebook" },
+  "social_media_buttons_twitter": { "other": "Bendrinti Twitter" },
+  "social_media_buttons_linkedin": { "other": "Dalintis Linkedin" },
+  "social_media_buttons_email": { "other": "Bendrinkite el. paštu" },
+  "social_media_buttons_email_subject": { "other": "Nuorodos bendrinimas" },
+  "social_media_buttons_copied_link": { "other": "Nuoroda nukopijuota į mainų sritį!" },
+  "social_media_buttons_copy_link": { "other": "Nukopijuoti į iškarpinę" },
 
   "accept_invite_page_header": { "other": "Sveiki" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Panašu, kad jau patvirtinote šį kvietimą, prašome <a href=\"{{.SigninURL}}\">prisijungti</a>. Pamiršus slaptažodį, galite <a href=\"{{.ForgotPasswordURL}}\">susikurti naują</a>." },

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -73,6 +73,13 @@
   "play_button_resume": { "other" : "Ga verder"},
 
   "social_media_buttons_title": { "other": "Deel" },
+  "social_media_buttons_facebook": { "other": "Delen op Facebook" },
+  "social_media_buttons_twitter": { "other": "Delen op Twitter" },
+  "social_media_buttons_linkedin": { "other": "Deel op Linkedin" },
+  "social_media_buttons_email": { "other": "Deel via e-mail" },
+  "social_media_buttons_email_subject": { "other": "Link delen" },
+  "social_media_buttons_copied_link": { "other": "Link gekopieerd naar klembord!" },
+  "social_media_buttons_copy_link": { "other": "Kopieer naar klembord" },
 
   "accept_invite_page_header": { "other": "Welkom" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Het lijkt erop dat u deze uitnodiging al hebt gebruikt. U dient zich hier <a href=\"{{.SigninURL}}\">in te loggen</a>. <a href=\"{{.ForgotPasswordURL}}\">Wachtwoord vergeten?</a>." },

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -73,7 +73,14 @@
     "play_button_resume": { "other" : "Fortsett"},
   
     "social_media_buttons_title": { "other": "Del" },
-  
+    "social_media_buttons_facebook": { "other": "Del på Facebook" },
+    "social_media_buttons_twitter": { "other": "Del på Twitter" },
+    "social_media_buttons_linkedin": { "other": "Del på Linkedin" },
+    "social_media_buttons_email": { "other": "Del via e-post" },
+    "social_media_buttons_email_subject": { "other": "Linkdeling" },
+    "social_media_buttons_copied_link": { "other": "Linken er kopiert til utklippstavlen!" },
+    "social_media_buttons_copy_link": { "other": "Kopiere til utklippstavle" },
+
     "accept_invite_page_header": { "other": "Velkommen" },
     "acceptinvite_form_invalid_reset_password_token": { "other": "Det ser ut til at du allerede har godtatt denne invitasjonen, forsøk i stedet å <a href=\"{{.SigninURL}}\">logge inn</a>. Hvis du har glemt passordet kan du også <a href=\"{{.ForgotPasswordURL}}\">tilbakestille passordet</a>." },
     "acceptinvite_complete": { "other": "Takk! Din konto er opprettet." },

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -50,6 +50,13 @@
   "play_button_resume": { "other" : "Kontynuuj"},
 
   "social_media_buttons_title": { "other": "Udostępnij" },
+  "social_media_buttons_facebook": { "other": "Udostępnij na Facebooku" },
+  "social_media_buttons_twitter": { "other": "Podziel się na Twitterze" },
+  "social_media_buttons_linkedin": { "other": "Udostępnij na Linkedin" },
+  "social_media_buttons_email": { "other": "Udostępnij przez e-mail" },
+  "social_media_buttons_email_subject": { "other": "Udostępnianie linków" },
+  "social_media_buttons_copied_link": { "other": "Link skopiowany do schowka!" },
+  "social_media_buttons_copy_link": { "other": "Skopiuj do schowka" },
 
   "accept_invite_page_header": { "other": "Witamy" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Wygląda na to, że już odebrałeś to zaproszenie. Kliknij zatem <a href=\"{{.SigninURL}}\"> zaloguj się </a>. Jeśli zapomniałeś hasła, możesz je odzyskać <a href=\"{{.ForgotPasswordURL}}\"> resetując hasło </a>." },

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -139,6 +139,13 @@
   "social_media_buttons_title": {
    "other": "Compartilhar"
   },
+  "social_media_buttons_facebook": { "other": "Compartilhar no Facebook" },
+  "social_media_buttons_twitter": { "other": "Compartilhar no Twitter" },
+  "social_media_buttons_linkedin": { "other": "Compartilhar no Linkedin" },
+  "social_media_buttons_email": { "other": "Compartilhe via e-mail" },
+  "social_media_buttons_email_subject": { "other": "Compartilhamento de link" },
+  "social_media_buttons_copied_link": { "other": "Link copiado para a área de transferência!" },
+  "social_media_buttons_copy_link": { "other": "Copiar para área de transferência" },
   "accept_invite_page_header": {
    "other": "Acolher"
   },

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -73,6 +73,13 @@
     "play_button_resume": { "other" : "Continuar"},
 
     "social_media_buttons_title": { "other": "Compartilhar" },
+    "social_media_buttons_facebook": { "other": "Compartilhar no Facebook" },
+    "social_media_buttons_twitter": { "other": "Compartilhar no Twitter" },
+    "social_media_buttons_linkedin": { "other": "Compartilhar no Linkedin" },
+    "social_media_buttons_email": { "other": "Compartilhe via e-mail" },
+    "social_media_buttons_email_subject": { "other": "Compartilhamento de link" },
+    "social_media_buttons_copied_link": { "other": "Link copiado para a área de transferência!" },
+    "social_media_buttons_copy_link": { "other": "Copiar para área de transferência" },
 
     "accept_invite_page_header": { "other": "Acolher" },
     "acceptinvite_form_invalid_reset_password_token": { "other": "Parece que você já aceitou esse convite, você deve <a href=\"{{.SigninURL}}\">entrar em sua conta</a>. Se você esqueceu sua senha, você também pode <a href=\"{{.ForgotPasswordURL}}\">alterar sua senha</a>." },

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -74,6 +74,13 @@
   "play_button_resume": { "other" : "Поделиться"},
 
   "social_media_buttons_title": { "other": "Поделиться" },
+  "social_media_buttons_facebook": { "other": "Поделиться через фейсбук" },
+  "social_media_buttons_twitter": { "other": "Поделиться в Твиттере" },
+  "social_media_buttons_linkedin": { "other": "Поделиться в Linkedin" },
+  "social_media_buttons_email": { "other": "Поделиться по электронной почте" },
+  "social_media_buttons_email_subject": { "other": "Поделиться ссылкой" },
+  "social_media_buttons_copied_link": { "other": "Ссылка скопирована в буфер обмена!" },
+  "social_media_buttons_copy_link": { "other": "Скопировать в буфер обмена" },
 
   "accept_invite_page_header": { "other": "Добро пожаловать" },
   "acceptinvite_form_invalid_reset_password_token": { "other": "Вы уже подтвердили регистрацию, вам надо <a href=\"{{.SigninURL}}\">войти</a> . Если вы забыли свой пароль, вы можете <a href=\"{{.ForgotPasswordURL}}\">сбросить пароль</a>." },

--- a/site/se_SE.all.json
+++ b/site/se_SE.all.json
@@ -73,6 +73,13 @@
     "play_button_resume": { "other" : "Наставите"},
   
     "social_media_buttons_title": { "other": "Поделите" },
+    "social_media_buttons_facebook": { "other": "Поделите на Фејсбуку" },
+    "social_media_buttons_twitter": { "other": "Делите на Твитеру" },
+    "social_media_buttons_linkedin": { "other": "Делите на Линкедину" },
+    "social_media_buttons_email": { "other": "Делите путем е-поште" },
+    "social_media_buttons_email_subject": { "other": "Дељење везе" },
+    "social_media_buttons_copied_link": { "other": "Линк је копиран у међуспремник!" },
+    "social_media_buttons_copy_link": { "other": "Копирај у међуспремник" },
   
     "accept_invite_page_header": { "other": "Добродошли" },
     "acceptinvite_form_invalid_reset_password_token": { "other": "Изгледа да сте већ активирали овај позив. Потребно је да се <a href=\"{{.SigninURL}}\">пријавите</a>. Ако сте заборавили лозинку, можете и да <a href=\"{{.ForgotPasswordURL}}\">ресетујете лозинку</a>." },

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -73,7 +73,14 @@
     "play_button_resume": { "other" : "Devam et"},
   
     "social_media_buttons_title": { "other": "Paylaş" },
-  
+    "social_media_buttons_facebook": { "other": "Facebook'ta Paylaş" },
+    "social_media_buttons_twitter": { "other": "Twitter'da paylaş" },
+    "social_media_buttons_linkedin": { "other": "Linkedin'de paylaş" },
+    "social_media_buttons_email": { "other": "E-mail ile paylaş" },
+    "social_media_buttons_email_subject": { "other": "Bağlantı paylaşımı" },
+    "social_media_buttons_copied_link": { "other": "Link kopyalandı!" },
+    "social_media_buttons_copy_link": { "other": "Panoya kopyala" },
+
     "accept_invite_page_header": { "other": "Hoşgeldiniz" },
     "acceptinvite_form_invalid_reset_password_token": { "other": "Görünüşe göre bu davet talebini zaten yapmışsınız, onun yerine <a href=\"{{.SigninURL}}\">sign in</a> denemelisiniz. Parolanızı unuttuysanız, parolanızı ayrıca <a href=\"{{.ForgotPasswordURL}}\"> sıfırlayabilirsiniz." },
     "acceptinvite_complete": { "other": "Teşekkürler. Hesabınız oluşturuldu." },

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -126,6 +126,13 @@
   "social_media_buttons_title": {
    "other": "Поділитися"
   },
+  "social_media_buttons_facebook": { "other": "Поділіться на Facebook" },
+  "social_media_buttons_twitter": { "other": "Поділіться у Twitter" },
+  "social_media_buttons_linkedin": { "other": "Поділіться на Linkedin" },
+  "social_media_buttons_email": { "other": "Поділіться електронною поштою" },
+  "social_media_buttons_email_subject": { "other": "Поділитися посиланням" },
+  "social_media_buttons_copied_link": { "other": "Посилання скопійовано в буфер обміну!" },
+  "social_media_buttons_copy_link": { "other": "Копіювати в буфер обміну" },
   "accept_invite_page_header": {
    "other": "Ласкаво просимо"
   },

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -139,6 +139,13 @@
   "social_media_buttons_title": {
    "other": "分享"
   },
+  "social_media_buttons_facebook": { "other": "在脸书上分享" },
+  "social_media_buttons_twitter": { "other": "分享到Twitter" },
+  "social_media_buttons_linkedin": { "other": "在领英上分享" },
+  "social_media_buttons_email": { "other": "通过电子邮件分享" },
+  "social_media_buttons_email_subject": { "other": "链接分享" },
+  "social_media_buttons_copied_link": { "other": "链接已复制到剪贴板！" },
+  "social_media_buttons_copy_link": { "other": "复制到剪贴板" },
   "accept_invite_page_header": {
    "other": "歡迎"
   },


### PR DESCRIPTION
This PR adds all the share button related translation phrases:
"social_media_buttons_facebook"
"social_media_buttons_twitter"
"social_media_buttons_linkedin"
"social_media_buttons_email"
"social_media_buttons_email_subject"
"social_media_buttons_copied_link"
"social_media_buttons_copy_link"