### PR TITLE
Add a background image to the page content jet template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/0.4.0-rc.0...HEAD)
 
+### Added
+- Support for header images on content pages.
+
 ## [0.4.0-rc.0](https://github.com/shift72/core-template/compare/0.3.8...0.4.0-rc.0)
 
 ### Added

--- a/site/templates/page/content.jet
+++ b/site/templates/page/content.jet
@@ -1,6 +1,7 @@
 {{extends "templates/application/application.jet"}}
 {{import "templates/page/page-header.jet"}}
 {{import "templates/page/page-content.jet"}}
+{{import "templates/common/background-image.jet"}}
 
 {{block head()}}
   {{yield seo() page}}
@@ -8,6 +9,8 @@
 
 {{block body()}}
   <main id="main" class="page content-page">
+    {{yield backgroundImage(containerClass="page-bg", gradientClass="right-gradient", imageClass="page-bg-img", imageSrc=page.Images.Background)}}
+
     {{yield pageHeader(title=page.Title)}}
 
     {{yield pageContent(text=page.Content)}}


### PR DESCRIPTION
[USER STORY 5870 Template change to support header image on content page(s)](https://dev.azure.com/S72/SHIFT72/_workitems/edit/5870/)

[AC Google Doc](https://docs.google.com/document/d/1GBPVBiCEaF0NorQ0lPvGakW7nirrevRUo5WUWIIjHUk/edit#heading=h.ygly7pwv59is)