### PR TITLE
Added captions translation + split CC and Subs

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -346,6 +346,7 @@
     "meta_detail_studios": { "one": "الاستديو", "other": "الاستوديوهات" },
     "meta_detail_countries": { "one": "البلد", "other": "البلدان" },
     "meta_detail_subtitles": { "other": "الترجمة" },
+    "meta_detail_captions": { "other": "الترجمة [CC]" },
     "meta_detail_episodes_title": { "other": "الحلفات" },
     "meta_detail_bonus_title": { "other": "محتوى إضافي" },
     "meta_detail_recommendations_title": { "other": "قد يعجبك أيضا" },

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -757,6 +757,7 @@
   "meta_detail_subtitles": {
    "other": "Subtítols"
   },
+  "meta_detail_captions": { "other": "Subtítols [CC]" },
   "meta_detail_episodes_title": {
    "other": "Episodis"
   },

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -722,6 +722,7 @@
   "meta_detail_subtitles": {
     "other": "Undertekster"
   },
+  "meta_detail_captions": { "other": "Undertekster [CC]" },
   "meta_detail_episodes_title": {
     "other": "Episodes"
   },

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -321,6 +321,7 @@
   "meta_detail_studios": { "one": "Studio", "other": "Studios" },
   "meta_detail_countries": { "one": "Land", "other": "Länder" },
   "meta_detail_subtitles": { "other": "Untertitel" },
+  "meta_detail_captions": { "other": "Untertitel [CC]" },
   "meta_detail_episodes_title": { "other": "Episoden" },
   "meta_detail_bonus_title": { "other": "Bonusinhalt" },
   "meta_detail_recommendations_title": { "other": "Das könnte Ihnen auch gefallen" },

--- a/site/ee_EE.all.json
+++ b/site/ee_EE.all.json
@@ -321,6 +321,7 @@
     "meta_detail_studios": { "one": "Stuudiod", "other": "Stuudiod" },
     "meta_detail_countries": { "one": "Riigid", "other": "Riigid" },
     "meta_detail_subtitles": { "other": "Subtiitrid" },
+    "meta_detail_captions": { "other": "Subtiitrid [CC]" },
     "meta_detail_episodes_title": { "other": "Episoodid" },
     "meta_detail_bonus_title": { "other": "Lisasisu" },
     "meta_detail_recommendations_title": { "other": "Sulle võib veel meeldida" },

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -318,6 +318,7 @@
   "meta_detail_studios": { "one": "Εταιρίες", "other": "Εταιρίες" },
   "meta_detail_countries": { "one": "Χώρες", "other": "Χώρες" },
   "meta_detail_subtitles": { "other": "Υπότιτλοι" },
+  "meta_detail_captions": { "other": "Υπότιτλοι [CC]" },
   "meta_detail_episodes_title": { "other": "Επεισόδια" },
   "meta_detail_bonus_title": { "other": "Έξτρα υλικό" },
   "meta_detail_recommendations_title": { "other": "Ίσως σας αρέσουν και τα" },

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -350,6 +350,7 @@
   "meta_detail_studios": { "one": "Studio", "other": "Studios" },
   "meta_detail_countries": { "one": "Country", "other": "Countries" },
   "meta_detail_subtitles": { "other": "Subtitles" },
+  "meta_detail_captions": { "other": "Closed Captions [CC]" },
   "meta_detail_episodes_title": { "other": "Episodes" },
   "meta_detail_bonus_title": { "other": "Bonus Content" },
   "meta_detail_recommendations_title": { "other": "You may also like" },

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -325,6 +325,7 @@
   "meta_detail_studios": { "one": "Estudio", "other": "Estudios" },
   "meta_detail_countries": { "one": "País", "other": "Países" },
   "meta_detail_subtitles": { "other": "Subtítulos" },
+  "meta_detail_captions": { "other": "Subtítulos [CC]" },
   "meta_detail_episodes_title": { "other": "Episodios" },
   "meta_detail_bonus_title": { "other": "Contenido extra" },
   "meta_detail_recommendations_title": { "other": "También le puede interesar" },

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -318,6 +318,7 @@
   "meta_detail_studios": { "one": "Productora", "other": "Productoras" },
   "meta_detail_countries": { "one": "País", "other": "Países" },
   "meta_detail_subtitles": { "other": "Subtítulos" },
+  "meta_detail_captions": { "other": "Subtítulos [CC]" },
   "meta_detail_episodes_title": { "other": "Capítulos" },
   "meta_detail_bonus_title": { "other": "Contenido adicional" },
   "meta_detail_recommendations_title": { "other": "Te podría interesar" },

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -292,6 +292,7 @@
   "meta_detail_studios": { "one": "Tuotantoyhtiö", "other": "Tuotantoyhtiöt" },
   "meta_detail_countries": { "one": "Maa", "other": "Maat" },
   "meta_detail_subtitles": { "other": "Tekstitys" },
+  "meta_detail_captions": { "other": "Tekstitys [CC]" },
   "meta_detail_episodes_title": { "other": "Jaksot" },
   "meta_detail_bonus_title": { "other": "Bonusmateriaali" },
   "meta_detail_recommendations_title": { "other": "Saatat pitää myös:" },

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -335,6 +335,7 @@
   "meta_detail_studios": { "one": "Studio", "other": "Studios" },
   "meta_detail_countries": { "one": "Pays", "other": "Pays" },
   "meta_detail_subtitles": { "other": "Sous-titres" },
+  "meta_detail_captions": { "other": "Sous-titres [CC]" },
   "meta_detail_episodes_title": { "other": "Épisodes" },
   "meta_detail_bonus_title": { "other": "Contenu Bonus" },
   "meta_detail_recommendations_title": { "other": "Vous pourriez également apprécier" },

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -286,6 +286,7 @@
   "meta_detail_studios": { "other": "Studiji" },
   "meta_detail_countries": { "other": "Zemlje" },
   "meta_detail_subtitles": { "other": "Podnaslovi" },
+  "meta_detail_captions": { "other": "Podnaslovi [CC]" },
   "meta_detail_episodes_title": { "other": "Epizode" },
   "meta_detail_bonus_title": { "other": "Bonus sadržaj" },
   "meta_detail_recommendations_title": { "other": "Nalovi koji bi vam se mogli svidjeti" },

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -321,6 +321,7 @@
     "meta_detail_studios": { "one": "Gyártó", "other": "Gyártó" },
     "meta_detail_countries": { "one": "Ország", "other": "Ország" },
     "meta_detail_subtitles": { "other": "Felirat" },
+    "meta_detail_captions": { "other": "Felirat [CC]" },
     "meta_detail_episodes_title": { "other": "Epizódok" },
     "meta_detail_bonus_title": { "other": "Extra tartalom" },
     "meta_detail_recommendations_title": { "other": "Talán ez is tetszene" },

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -329,6 +329,7 @@
   "meta_detail_studios": { "one": "Studio", "other": "Studios" },
   "meta_detail_countries": { "one": "Paese", "other": "Paese" },
   "meta_detail_subtitles": { "other": "Sottotitoli" },
+  "meta_detail_captions": { "other": "Sottotitoli [CC]" },
   "meta_detail_episodes_title": { "other": "Episodi" },
   "meta_detail_bonus_title": { "other": "Contenuti Extra" },
   "meta_detail_recommendations_title": { "other": "Potrebbe piacerti anche" },

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -295,6 +295,7 @@
   "meta_detail_studios": { "one": "製作", "other": "製作" },
   "meta_detail_countries": { "one": "製作国", "other": "製作国" },
   "meta_detail_subtitles": { "other": "字幕" },
+  "meta_detail_captions": { "other": "字幕 [CC]" },
   "meta_detail_episodes_title": { "other": "エピソード" },
   "meta_detail_bonus_title": { "other": "特典映像" },
   "meta_detail_recommendations_title": { "other": "おすすめ作品" },

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -334,6 +334,7 @@
   "meta_detail_studios": { "one": "Kompanija", "other": "Kompanijos" },
   "meta_detail_countries": { "one": "Šalis", "other": "Šalys" },
   "meta_detail_subtitles": { "other": "Subtitrai" },
+  "meta_detail_captions": { "other": "Subtitrai [CC]" },
   "meta_detail_episodes_title": { "other": "Epizodai" },
   "meta_detail_bonus_title": { "other": "Specialus papildomas turinys" },
   "meta_detail_recommendations_title": { "other": "Taip pat gali patikti" },

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -334,6 +334,7 @@
   "meta_detail_studios": { "one": "Studio", "other": "Studios" },
   "meta_detail_countries": { "one": "Land", "other": "Landen" },
   "meta_detail_subtitles": { "other": "Ondertitels" },
+  "meta_detail_captions": { "other": "Ondertitels [CC]" },
   "meta_detail_episodes_title": { "other": "Afleveringen" },
   "meta_detail_bonus_title": { "other": "Bonusinhoud" },
   "meta_detail_recommendations_title": { "other": "Dit vindt u misschien ook leuk" },

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -321,6 +321,7 @@
     "meta_detail_studios": { "one": "Distributører", "other": "Distributør" },
     "meta_detail_countries": { "one": "Land", "other": "Land" },
     "meta_detail_subtitles": { "other": "Undertekster" },
+    "meta_detail_captions": { "other": "Undertekster [CC]" },
     "meta_detail_episodes_title": { "other": "Episoder" },
     "meta_detail_bonus_title": { "other": "Bonusinnhold" },
     "meta_detail_recommendations_title": { "other": "Relaterte filmer" },

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -334,6 +334,7 @@
   "meta_detail_studios": { "one": "Studio", "other": "Studio" },
   "meta_detail_countries": { "one": "Kraj", "other": "Kraje" },
   "meta_detail_subtitles": { "other": "Napisy" },
+  "meta_detail_captions": { "other": "Napisy [CC]" },
   "meta_detail_episodes_title": { "other": "Odcinki" },
   "meta_detail_bonus_title": { "other": "Materiał dodatkowy" },
   "meta_detail_recommendations_title": { "other": "Propozycje dla Ciebie" },

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -757,6 +757,9 @@
   "meta_detail_subtitles": {
    "other": "Legendas"
   },
+  "meta_detail_captions": {
+    "other": "Legendas [CC]"
+   },
   "meta_detail_episodes_title": {
    "other": "Episódios"
   },

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -318,6 +318,7 @@
     "meta_detail_studios": { "one": "Estúdio", "other": "Estúdios" },
     "meta_detail_countries": { "one": "País", "other": "Países" },
     "meta_detail_subtitles": { "other": "Legendas" },
+    "meta_detail_captions": { "other": "Legendas [CC]" },
     "meta_detail_episodes_title": { "other": "Episódios" },
     "meta_detail_bonus_title": { "other": "Conteúdo Adicional" },
     "meta_detail_recommendations_title": { "other": "Você também pode gostar de..." },

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -346,6 +346,7 @@
   "meta_detail_studios": { "one": "студия", "other": "Студии" },
   "meta_detail_countries": { "one": "Страна", "other": "страны" },
   "meta_detail_subtitles": { "other": "Субтитры" },
+  "meta_detail_captions": { "other": "Субтитры [CC]" },
   "meta_detail_episodes_title": { "other": "Эпизоды" },
   "meta_detail_bonus_title": { "other": "Бонус" },
   "meta_detail_recommendations_title": { "other": "Вам также может понравиться" },

--- a/site/se_SE.all.json
+++ b/site/se_SE.all.json
@@ -334,6 +334,7 @@
     "meta_detail_studios": { "one": "Студио", "other": "Студији" },
     "meta_detail_countries": { "one": "Држава", "other": "Државе" },
     "meta_detail_subtitles": { "other": "Титлови" },
+    "meta_detail_captions": { "other": "Титлови [CC]" },
     "meta_detail_episodes_title": { "other": "Епизоде" },
     "meta_detail_bonus_title": { "other": "Додатни садржај" },
     "meta_detail_recommendations_title": { "other": "Можда Вам се допадне" },

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -91,15 +91,20 @@
               <p>{{ film.Languages }}</p>
             </div>
           {{end}}
-          {{if len(film.GetSubtitles()) > 0 }}
+          {{allSubtitles := film.GetSubtitles()}}
+          {{if len(allSubtitles) > 0 }}
             {{subtitles := ""}}
             {{captions := ""}}
-            {{range subTrack := film.SubtitleTracks}}
-              {{if len(subTrack) >= 3}}
-                {{if subTrack[2] == "caption"}}
-                    {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
-                {{else}}
-                    {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
+            {{if len(film.SubtitleTracks) == 0}}
+              {{subtitles = allSubtitles}}
+            {{else}}
+              {{range subTrack := film.SubtitleTracks}}
+                {{if len(subTrack) >= 3}}
+                  {{if subTrack[2] == "caption"}}
+                      {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
+                  {{else}}
+                      {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
+                  {{end}}
                 {{end}}
               {{end}}
             {{end}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -92,14 +92,14 @@
             </div>
           {{end}}
           {{if len(film.GetSubtitles()) > 0 }}
-            {{subtitles:= ""}}
-            {{captions:= ""}}
-            {{range film.SubtitleTracks}}
-              {{if len(.) >= 3}}
-                {{if .[2] == "caption"}}
-                    {{captions = captions ? captions + ", " + .[1] : .[1]}}
+            {{subtitles := ""}}
+            {{captions := ""}}
+            {{range subTrack := film.SubtitleTracks}}
+              {{if len(subTrack) >= 3}}
+                {{if subTrack[2] == "caption"}}
+                    {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
                 {{else}}
-                    {{subtitles = subtitles ? subtitles + ", " + .[1] : .[1]}}
+                    {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
                 {{end}}
               {{end}}
             {{end}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -92,10 +92,29 @@
             </div>
           {{end}}
           {{if len(film.GetSubtitles()) > 0 }}
-            <div class="meta-detail-subtitle">
-              <h2>{{i18n("meta_detail_subtitles")}}</h2>
-              <p>{{ film.GetSubtitles() }}</p>
-            </div>
+            {{subtitles:= ""}}
+            {{captions:= ""}}
+            {{range film.SubtitleTracks}}
+              {{if len(.) >= 3}}
+                {{if .[2] == "caption"}}
+                    {{captions = captions ? captions + ", " + .[1] : .[1]}}
+                {{else}}
+                    {{subtitles = subtitles ? subtitles + ", " + .[1] : .[1]}}
+                {{end}}
+              {{end}}
+            {{end}}
+            {{if subtitles}}
+              <div class="meta-detail-subtitle">
+                <h2>{{i18n("meta_detail_subtitles")}}</h2>
+                <p>{{subtitles}}</p>
+              </div>
+            {{end}}
+            {{if captions}}
+              <div class="meta-detail-subtitle">
+                <h2>{{i18n("meta_detail_captions")}}</h2>
+                <p>{{captions}}</p>
+              </div>
+            {{end}}
           {{end}}
           {{if len(film.Countries) > 0 }}
             <div class="meta-detail-country">

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -322,6 +322,7 @@
     "meta_detail_studios": { "one": "Stüdyo", "other": "Stüdyolar" },
     "meta_detail_countries": { "one": "Ülke", "other": "Ülkeler" },
     "meta_detail_subtitles": { "other": "Altyazılar" },
+    "meta_detail_captions": { "other": "Altyazılar [CC]" },
     "meta_detail_episodes_title": { "other": "Bölümler" },
     "meta_detail_bonus_title": { "other": "Bonus İçerik" },
     "meta_detail_recommendations_title": { "other": "Bunu da beğenebilirsiniz" },

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -745,6 +745,7 @@
   "meta_detail_subtitles": {
    "other": "Субтитри"
   },
+  "meta_detail_captions": { "other": "Субтитри [CC]" },
   "meta_detail_episodes_title": {
    "other": "Епізоди"
   },

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -751,6 +751,7 @@
   "meta_detail_subtitles": {
    "other": "字幕"
   },
+  "meta_detail_captions": { "other": "字幕 [CC]" },
   "meta_detail_episodes_title": {
    "other": "集數"
   },


### PR DESCRIPTION
#AB3859 - Captions appearing as subtitles: updated item.jet to split out captions and subtitles and display them separately, 
updated all translations files to use new "meta_detail_captions" translation key, place holders are subtitle string + [CC] as that symbol seems universal eg: fr-FR `"meta_detail_subtitles": { "other": "Sous-titres" },
  "meta_detail_captions": { "other": "Sous-titres [CC]" `
