### PR TITLE
Removed broken tv season divs

### DIFF
--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -47,12 +47,6 @@
             <s72-userwishlist-button data-slug="{{tvseason.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
             {{yield socialMediaButtons(path=currentUrlPath)}}
           </div>
-          </div>
-          <s72-availability-label data-slug="{{tvseason.Slug}}"></s72-availability-label>
-          <div class="meta-detail-synopsis">{{tvseason.Overview | raw}}</div>
-          </div>
-          <s72-availability-label data-slug="{{tvseason.Slug}}"></s72-availability-label>
-          <div class="meta-detail-synopsis">{{tvseason.Overview | raw}}</div>
           <div class="meta-detail-cast">
           {{if len(tvseason.Cast) > 0 }}
             <h2>{{i18n("meta_detail_cast_title")}}</h2>


### PR DESCRIPTION
TV seasons have been broken as of 0.4.0 due to some unintended code being left in from a previous merge and revert around engagement icons: 
[Initial Merge](https://github.com/shift72/core-template/commit/74e5195b4a2ef3de0b3f82f31363fd27d3dfed77#diff-685e2c69e0cd5ba9d30c38583488cee9e801c82585ab4faa6ccf3f49195d84a3)
[Reverting merge](https://github.com/shift72/core-template/commit/16be9cfce87b16366d7136367948f3c64cb0dde3#diff-685e2c69e0cd5ba9d30c38583488cee9e801c82585ab4faa6ccf3f49195d84a3)

Looks like code was copy pasted instead of removed