### PR TITLE
Relocate the trailer/wishlist/share buttons beside the play/rent/buy buttons. Adjust styling.

### DIFF
--- a/site/styles/_buttons.scss
+++ b/site/styles/_buttons.scss
@@ -172,6 +172,7 @@
     padding-bottom: 0;
     padding-left: 8px;
     padding-top: 0;
+    font-weight: 500;
 
     &::before {
       display: none;

--- a/site/styles/_buttons.scss
+++ b/site/styles/_buttons.scss
@@ -172,7 +172,7 @@
     padding-bottom: 0;
     padding-left: 8px;
     padding-top: 0;
-    font-weight: 500;
+    font-weight: $font-weight-bold;
 
     &::before {
       display: none;

--- a/site/styles/_can-be-watched-button.scss
+++ b/site/styles/_can-be-watched-button.scss
@@ -26,6 +26,8 @@
 .meta-item-buttons {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
 
   .owned-custom-container {
     display: none;

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -226,7 +226,7 @@ s72-carousel {
     margin-left: -0.5rem;
 
     /* stylelint-disable selector-max-compound-selectors */
-    s72-pricing-buttons .s72-btn, .meta-detail-extras, .meta-item-extras, s72-play-button, can-be-watched-button {
+    s72-pricing-buttons .s72-btn, .meta-detail-extras, .meta-item-extras, s72-play-button, can-be-watched-button:not(:empty) {
       margin-right: 0.5rem;
       margin-left: 0.5rem;
       margin-bottom: 10px;

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -225,14 +225,13 @@ s72-carousel {
     margin-right: -0.5rem;
     margin-left: -0.5rem;
 
-
+    /* stylelint-disable selector-max-compound-selectors */
     s72-pricing-buttons .s72-btn, .meta-detail-extras, .meta-item-extras, s72-play-button, can-be-watched-button {
       margin-right: 0.5rem;
       margin-left: 0.5rem;
       margin-bottom: 10px;
     }
 
-    /* stylelint-disable selector-max-compound-selectors */
     // Handles spacing when there is only rent, only buy, or only play button
     s72-pricing-buttons .s72-btn, s72-play-button {
       &:nth-child(1) {

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -225,11 +225,13 @@ s72-carousel {
     margin-right: -0.5rem;
     margin-left: -0.5rem;
 
-    s72-pricing-buttons .s72-btn, .meta-detail-extras, .meta-item-extras, s72-play-button {
+    /* stylelint-disable selector-max-compound-selectors */
+    s72-pricing-buttons .s72-btn, .meta-detail-extras, .meta-item-extras, s72-play-button, can-be-watched-button {
       margin-right: 0.5rem;
       margin-left: 0.5rem;
       margin-bottom: 10px;
     }
+    /* stylelint-enable selector-max-compound-selectors */
 
     // Handles spacing when there is only rent, only buy, or only play button
     s72-pricing-buttons .s72-btn, s72-play-button {

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -212,7 +212,6 @@ s72-carousel {
 
     .meta-item-extras {
       @extend .d-flex;
-      padding: 0 0 20px;
     }
 
     .btn-wishlist {
@@ -220,16 +219,25 @@ s72-carousel {
     }
   }
 
-  .s72-pricing-button-container {
-    .s72-btn {
+  // Purchase, play, trailer, wishlist and share are all in one group now
+  // Need similar bootstrap approach of handling/wrapping rows and columns via negative margin
+  .meta-item-buttons {
+    margin-right: -0.5rem;
+    margin-left: -0.5rem;
+
+    s72-pricing-buttons .s72-btn, .meta-detail-extras, .meta-item-extras, s72-play-button {
+      margin-right: 0.5rem;
+      margin-left: 0.5rem;
       margin-bottom: 10px;
+    }
 
+    // Handles spacing when there is only rent, only buy, or only play button
+    s72-pricing-buttons .s72-btn, s72-play-button {
       &:nth-child(1) {
-        margin-right: 0.5rem;
+        margin-right: 0rem;
       }
-
-      &:nth-child(2) {
-        margin-left: 0;
+      &:only-child {
+        margin-right: 0.5rem;
       }
     }
   }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -225,14 +225,14 @@ s72-carousel {
     margin-right: -0.5rem;
     margin-left: -0.5rem;
 
-    /* stylelint-disable selector-max-compound-selectors */
+
     s72-pricing-buttons .s72-btn, .meta-detail-extras, .meta-item-extras, s72-play-button, can-be-watched-button {
       margin-right: 0.5rem;
       margin-left: 0.5rem;
       margin-bottom: 10px;
     }
-    /* stylelint-enable selector-max-compound-selectors */
 
+    /* stylelint-disable selector-max-compound-selectors */
     // Handles spacing when there is only rent, only buy, or only play button
     s72-pricing-buttons .s72-btn, s72-play-button {
       &:nth-child(1) {
@@ -242,6 +242,7 @@ s72-carousel {
         margin-right: 0.5rem;
       }
     }
+    /* stylelint-enable selector-max-compound-selectors */
   }
 
   .s72-btn-play {

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -198,14 +198,14 @@
     margin-left: -0.5rem;
 
     /* stylelint-disable selector-max-compound-selectors */
-    s72-pricing-buttons .s72-btn, .meta-detail-extras, s72-play-button, can-be-watched-button {
+    s72-pricing-buttons .s72-btn, .meta-detail-extras, s72-play-button, can-be-watched-button:not(:empty) {
       margin-right: 0.5rem;
       margin-left: 0.5rem;
 
       animation: fadein 2s;
     }
 
-    s72-modal-player, s72-userwishlist-button, s72-pricing-buttons .s72-btn, s72-play-button, .social-media-buttons, can-be-watched-button {
+    s72-modal-player, s72-userwishlist-button, s72-pricing-buttons .s72-btn, s72-play-button, .social-media-buttons, can-be-watched-button:not(:empty) {
       margin-bottom: 10px;
     }
 

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -191,18 +191,31 @@
   .meta-detail-buttons {
     min-height: 45px;
 
-    .s72-btn {
+
+  // Purchase, play, trailer, wishlist are all in one group now
+  // Need similar bootstrap approach of handling/wrapping rows and columns via negative margin
+    margin-right: -0.5rem;
+    margin-left: -0.5rem;
+
+    s72-pricing-buttons .s72-btn, .meta-detail-extras, s72-play-button {
+      margin-right: 0.5rem;
+      margin-left: 0.5rem;
+
       animation: fadein 2s;
+    }
 
-      margin-bottom: 10px;
-
+    // Handles spacing when there is only rent, only buy, or only play button
+    s72-pricing-buttons .s72-btn, s72-play-button {
       &:nth-child(1) {
+        margin-right: 0rem;
+      }
+      &:only-child {
         margin-right: 0.5rem;
       }
+    }
 
-      &:nth-child(2) {
-        margin-left: 0;
-      }
+    s72-modal-player, s72-userwishlist-button, s72-pricing-buttons .s72-btn, s72-play-button, .social-media-buttons {
+      margin-bottom: 10px;
     }
   }
 
@@ -246,8 +259,6 @@
     @extend .d-flex;
     flex-direction: row;
     flex-wrap: wrap;
-    min-height: 48px;
-    padding-bottom: 15px;
     @include media-breakpoint-up(md) {
       flex-direction: row;
     }
@@ -540,7 +551,6 @@
   .meta-detail-extras {
     @extend .d-flex;
 
-    margin-bottom: 64px;
     min-height: min-content;
     padding: 0;
   }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -197,6 +197,7 @@
     margin-right: -0.5rem;
     margin-left: -0.5rem;
 
+    /* stylelint-disable selector-max-compound-selectors */
     s72-pricing-buttons .s72-btn, .meta-detail-extras, s72-play-button, can-be-watched-button {
       margin-right: 0.5rem;
       margin-left: 0.5rem;
@@ -208,7 +209,6 @@
       margin-bottom: 10px;
     }
 
-    /* stylelint-disable selector-max-compound-selectors */
     // Handles spacing when there is only rent, only buy, or only play button
     s72-pricing-buttons .s72-btn, s72-play-button {
       &:nth-child(1) {

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -197,25 +197,27 @@
     margin-right: -0.5rem;
     margin-left: -0.5rem;
 
-    s72-pricing-buttons .s72-btn, .meta-detail-extras, s72-play-button {
+    /* stylelint-disable selector-max-compound-selectors */
+    s72-pricing-buttons .s72-btn, .meta-detail-extras, s72-play-button, can-be-watched-button {
       margin-right: 0.5rem;
       margin-left: 0.5rem;
 
       animation: fadein 2s;
     }
 
+    s72-modal-player, s72-userwishlist-button, s72-pricing-buttons .s72-btn, s72-play-button, .social-media-buttons, can-be-watched-button {
+      margin-bottom: 10px;
+    }
+    /* stylelint-enable selector-max-compound-selectors */
+
     // Handles spacing when there is only rent, only buy, or only play button
     s72-pricing-buttons .s72-btn, s72-play-button {
       &:nth-child(1) {
-        margin-right: 0rem;
+        margin-right: 0;
       }
       &:only-child {
         margin-right: 0.5rem;
       }
-    }
-
-    s72-modal-player, s72-userwishlist-button, s72-pricing-buttons .s72-btn, s72-play-button, .social-media-buttons {
-      margin-bottom: 10px;
     }
   }
 

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -197,7 +197,6 @@
     margin-right: -0.5rem;
     margin-left: -0.5rem;
 
-    /* stylelint-disable selector-max-compound-selectors */
     s72-pricing-buttons .s72-btn, .meta-detail-extras, s72-play-button, can-be-watched-button {
       margin-right: 0.5rem;
       margin-left: 0.5rem;
@@ -208,8 +207,8 @@
     s72-modal-player, s72-userwishlist-button, s72-pricing-buttons .s72-btn, s72-play-button, .social-media-buttons, can-be-watched-button {
       margin-bottom: 10px;
     }
-    /* stylelint-enable selector-max-compound-selectors */
 
+    /* stylelint-disable selector-max-compound-selectors */
     // Handles spacing when there is only rent, only buy, or only play button
     s72-pricing-buttons .s72-btn, s72-play-button {
       &:nth-child(1) {
@@ -219,6 +218,7 @@
         margin-right: 0.5rem;
       }
     }
+    /* stylelint-enable selector-max-compound-selectors */
   }
 
   s72-availability-label {

--- a/site/styles/_wishlist.scss
+++ b/site/styles/_wishlist.scss
@@ -28,7 +28,7 @@
     @extend .btn;
     font-size: 12px;
     font-weight: $font-weight-bold;
-    margin-right: 32px; // was 10px before awards needed some space
+    margin-right: 0.5rem;
     padding-bottom: 3px;
     padding-left: 0;
     padding-top: 3px;

--- a/site/templates/bundle/buttons.jet
+++ b/site/templates/bundle/buttons.jet
@@ -1,5 +1,6 @@
-{{block bundleButtons(class, slug, title)}}
+{{block bundleButtons(class, slug, title, promoURL)}}
   <div class="{{class}}">
     <s72-pricing-buttons data-slug="{{slug}}" data-title="{{title}}"></s72-pricing-buttons>
+    {{yield bundleExtras(class="meta-detail-extras", slug=slug, promoURL=promoURL)}}
   </div>
 {{end}}

--- a/site/templates/bundle/item.jet
+++ b/site/templates/bundle/item.jet
@@ -28,11 +28,10 @@
 
           {{yield bundleTagline(class="meta-detail-tagline") bundle}}
 
-          {{yield bundleButtons(class="meta-detail-buttons", slug=bundle.Slug, title=bundle.Title)}}
+          {{yield bundleButtons(class="meta-detail-buttons", slug=bundle.Slug, title=bundle.Title, promoURL=bundle.PromoURL)}}
 
           {{yield bundleSynopsis(class="meta-detail-synopsis", synopsis=bundle.Description)}}
 
-          {{yield bundleExtras(class="meta-detail-extras", slug=bundle.Slug, promoURL=bundle.PromoURL)}}
         </div>
 
         {{yield bundleList(items=bundle.Items)}}

--- a/site/templates/collection/carousel_item.jet
+++ b/site/templates/collection/carousel_item.jet
@@ -35,25 +35,24 @@
               {{ if item.ItemType == "film" }}
                 <can-be-watched-button data-slug="{{item.InnerItem.Slug}}" data-url="{{ item.InnerItem.CustomFields.GetString("can_be_watched_button_link", "") }}" data-label="{{ item.InnerItem.CustomFields.GetString("can_be_watched_button_text", "can_be_watched_button_text") }}"></can-be-watched-button>
               {{ end }}
+              <div class="meta-item-extras">
+                {{if len(trailer) > 0 }}
+                  <div class="s72-btn-trailer btn-trailer" data-url="{{routeToSlug(item.Slug)}}?autoplay">
+                    <button class="s72-btn s72-btn-play btn-sm s72-btn-trailer">
+                      <span class="s72-btn-play-icon"><s72-play-icon></s72-play-icon></span>
+                      <span class="verb s72-btn-play-label">{{i18n("play_trailer")}}</span>
+                    </button>
+                  </div>
+                {{end}}
+                <s72-userwishlist-button data-slug="{{item.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
+                <s72-share-buttons item="::item.meta" class="hidden-sm hidden-xs pull-right"></s72-share-buttons>
+              </div>
             </div>
 
             <s72-availability-label data-slug="{{item.Slug}}"></s72-availability-label>
 
             <div class="meta-item-synopsis">
               <p>{{item.InnerItem.Tagline | stripHTML}}</p>
-            </div>
-
-            <div class="meta-item-extras">
-              {{if len(trailer) > 0 }}
-                <div class="s72-btn-trailer btn-trailer" data-url="{{routeToSlug(item.Slug)}}?autoplay">
-                  <button class="s72-btn s72-btn-play btn-sm s72-btn-trailer">
-                    <span class="s72-btn-play-icon"><s72-play-icon></s72-play-icon></span>
-                    <span class="verb s72-btn-play-label">{{i18n("play_trailer")}}</span>
-                  </button>
-                </div>
-              {{end}}
-              <s72-userwishlist-button data-slug="{{item.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
-              <s72-share-buttons item="::item.meta" class="hidden-sm hidden-xs pull-right"></s72-share-buttons>
             </div>
             {{yield awardsCarousel() item.InnerItem}}
           </div>

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -48,6 +48,13 @@
             <s72-play-button data-slug="{{film.Slug}}" data-title="{{film.Title}}"></s72-play-button>
             <s72-pricing-buttons data-slug="{{film.Slug}}" data-title="{{film.Title}}"></s72-pricing-buttons>
             <can-be-watched-button data-slug="{{film.Slug}}" data-url="{{ film.CustomFields.GetString("can_be_watched_button_link", "") }}" data-label="{{ film.CustomFields.GetString("can_be_watched_button_text", "can_be_watched_button_text") }}"></can-be-watched-button>
+            <div class="meta-detail-extras">
+              {{if len(film.Trailers) > 0 }}
+                  <s72-modal-player src="{{film.Trailers[0].URL}}" class="s72-btn-trailer" data-slug="{{film.Slug}}" data-label="{{i18n("play_trailer")}}" autoplay="querystring"></s72-modal-player>
+              {{end}}
+              <s72-userwishlist-button data-slug="{{film.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
+              {{yield socialMediaButtons(path=currentUrlPath, letterboxdID=film.Refs.LetterboxdID)}}
+            </div>
           </div>
           {{if config("default_image_type") != "portrait"}}
             <s72-availability-status data-slug="{{film.Slug}}"></s72-availability-status>
@@ -58,13 +65,6 @@
           {{yield awardNominations() film}}
 
           <div class="meta-detail-synopsis">{{film.Overview | raw}}</div>
-          <div class="meta-detail-extras">
-            {{if len(film.Trailers) > 0 }}
-                <s72-modal-player src="{{film.Trailers[0].URL}}" class="s72-btn-trailer" data-slug="{{film.Slug}}" data-label="{{i18n("play_trailer")}}" autoplay="querystring"></s72-modal-player>
-            {{end}}
-            <s72-userwishlist-button data-slug="{{film.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
-            {{yield socialMediaButtons(path=currentUrlPath, letterboxdID=film.Refs.LetterboxdID)}}
-          </div>
           <div class="meta-detail-cast">
           {{if len(film.Cast) > 0 }}
             <h2>{{i18n("meta_detail_cast_title")}}</h2>

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -37,16 +37,16 @@
           <div class="meta-detail-buttons">
             <s72-play-button data-slug="{{tvseason.Slug}}" data-title="{{tvseason.Title}}"></s72-play-button>
             <s72-pricing-buttons data-slug="{{tvseason.Slug}}" data-title="{{tvseason.Title}}"></s72-pricing-buttons>
+            <div class="meta-detail-extras">
+              {{if len(tvseason.Trailers) > 0 }}
+                <s72-modal-player src="{{tvseason.Trailers[0].URL}}" class="s72-btn-trailer" data-slug="{{tvseason.Slug}}" data-label="{{i18n("play_trailer")}}" autoplay="querystring"></s72-modal-player>
+              {{end}}
+              <s72-userwishlist-button data-slug="{{tvseason.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
+              {{yield socialMediaButtons(path=currentUrlPath)}}
+            </div>
           </div>
           <s72-availability-label data-slug="{{tvseason.Slug}}"></s72-availability-label>
           <div class="meta-detail-synopsis">{{tvseason.Overview | raw}}</div>
-          <div class="meta-detail-extras">
-            {{if len(tvseason.Trailers) > 0 }}
-              <s72-modal-player src="{{tvseason.Trailers[0].URL}}" class="s72-btn-trailer" data-slug="{{tvseason.Slug}}" data-label="{{i18n("play_trailer")}}" autoplay="querystring"></s72-modal-player>
-            {{end}}
-            <s72-userwishlist-button data-slug="{{tvseason.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
-            {{yield socialMediaButtons(path=currentUrlPath)}}
-          </div>
           <div class="meta-detail-cast">
           {{if len(tvseason.Cast) > 0 }}
             <h2>{{i18n("meta_detail_cast_title")}}</h2>


### PR DESCRIPTION
The purpose of this branch is to relocate the trailer, wishlist and share buttons, to beside the purchase and play buttons. In both the carousel, and detail pages.

This is a managable step towards implementing the [refreshed designs](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/62030a7db4a419bfc4e8371e).

Attention has been on consistent spacing between each button (accounting for elements not always present), gutter alignment, element wrapping at smaller viewports, and element vertical alignment.

[AB#5001](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Web%20team/Stories/?workitem=5001)