### PR TITLE
S72 element switcher

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -590,5 +590,11 @@
     },
     "awards_in_competition": {
       "other": "في المنافسة"
+    },
+    "meta_description_expand": {
+      "other": "أظهر المزيد"
+    },
+    "meta_description_collapse": {
+      "other": "عرض أقل"
     }
   } 

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1261,5 +1261,11 @@
   },
   "awards_winner_of": {
     "other": "Guanyador de"
+  },
+  "meta_description_expand": {
+    "other": "Mostra més"
+  },
+  "meta_description_collapse": {
+    "other": "Mostra menys"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1164,5 +1164,11 @@
     },
     "awards_winner_of": {
       "other": "Vinder af"
+    },
+    "meta_description_expand": {
+      "other": "Vis mere"
+    },
+    "meta_description_collapse": {
+      "other": "Vis mindre"
     }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -477,5 +477,11 @@
   },
   "awards_winner_of": {
     "other": "Gewinner von"
+  },
+  "meta_description_expand": {
+    "other": "Zeig mehr"
+  },
+  "meta_description_collapse": {
+    "other": "Zeige weniger"
   }
 }

--- a/site/ee_EE.all.json
+++ b/site/ee_EE.all.json
@@ -527,14 +527,20 @@
     "plan_free_link_text": {
       "other": "Registreeru tasuta"
     },
-  "awards_nominated_for": {
-    "other": "Kandideeritud"
-  },
-  "awards_in_competition": {
-    "other": "Võistluses"
-  },
-  "awards_winner_of": {
-    "other": "Võitja"
-  }
+    "awards_nominated_for": {
+      "other": "Kandideeritud"
+    },
+    "awards_in_competition": {
+      "other": "Võistluses"
+    },
+    "awards_winner_of": {
+      "other": "Võitja"
+    },
+    "meta_description_expand": {
+      "other": "Näita rohkem"
+    },
+    "meta_description_collapse": {
+      "other": "Näita vähem"
+    }
   }
   

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -531,5 +531,11 @@
   },
   "awards_winner_of": {
     "other": "Νικητής του"
+  },
+  "meta_description_expand": {
+    "other": "Δείτε περισσότερα"
+  },
+  "meta_description_collapse": {
+    "other": "Δείξε λιγότερο"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -558,5 +558,8 @@
 
   "awards_nominated_for": { "other": "Nominated for" },
   "awards_in_competition": { "other": "In Competition" },
-  "awards_winner_of": { "other": "الفائز ب" }
+  "awards_winner_of": { "other": "Winner of" },
+
+  "meta_description_expand": { "other": "Show more" },
+  "meta_description_collapse": { "other": "Show less" }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -477,5 +477,11 @@
   },
   "awards_winner_of": {
     "other": "Ganador de"
+  },
+  "meta_description_expand": {
+    "other": "Mostrar más"
+  },
+  "meta_description_collapse": {
+    "other": "Muestra menos"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -418,5 +418,11 @@
     "other": "En competición"
   },
 
-  "awards_winner_of": { "other": "Ganador de" }
+  "awards_winner_of": { "other": "Ganador de" },
+  "meta_description_expand": {
+    "other": "Mostrar más"
+  },
+  "meta_description_collapse": {
+    "other": "Muestra menos"
+  }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -441,5 +441,11 @@
   },
   "awards_winner_of": {
     "other": "Voittaja"
+  },
+  "meta_description_expand": {
+    "other": "Näytä lisää"
+  },
+  "meta_description_collapse": {
+    "other": "Näytä vähemmän"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -476,5 +476,11 @@
   },
   "awards_winner_of": {
     "other": "Vainqueur de"
+  },
+  "meta_description_expand": {
+    "other": "Montre plus"
+  },
+  "meta_description_collapse": {
+    "other": "Montrer moins"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -483,5 +483,11 @@
   },
   "awards_winner_of": {
     "other": "Pobjednik od"
+  },
+  "meta_description_expand": {
+    "other": "Prikaži više"
+  },
+  "meta_description_collapse": {
+    "other": "Pokažite manje"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -534,6 +534,12 @@
     },
     "awards_winner_of": {
       "other": "nyertese"
+    },
+    "meta_description_expand": {
+      "other": "Mutass többet"
+    },
+    "meta_description_collapse": {
+      "other": "Mutass kevesebbet"
     }
   }
   

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -477,5 +477,11 @@
   },
   "awards_winner_of": {
     "other": "Vincitore di"
+  },
+  "meta_description_expand": {
+    "other": "Mostra di più"
+  },
+  "meta_description_collapse": {
+    "other": "Mostra meno"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -441,5 +441,11 @@
   },
   "awards_winner_of": {
     "other": "の勝者"
+  },
+  "meta_description_expand": {
+    "other": "もっと見せる"
+  },
+  "meta_description_collapse": {
+    "other": "表示を減らす"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -562,5 +562,11 @@
   },
   "awards_winner_of": {
     "other": "Nugalėtojas iš"
+  },
+  "meta_description_expand": {
+    "other": "Rodyti daugiau"
+  },
+  "meta_description_collapse": {
+    "other": "Rodyti mažiau"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -563,5 +563,11 @@
   },
   "awards_winner_of": {
     "other": "Winnaar van"
+  },
+  "meta_description_expand": {
+    "other": "Laat meer zien"
+  },
+  "meta_description_collapse": {
+    "other": "Laat minder zien"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -534,6 +534,12 @@
     },
     "awards_winner_of": {
       "other": "Vinner av"
+    },
+    "meta_description_expand": {
+      "other": "Vis mer"
+    },
+    "meta_description_collapse": {
+      "other": "Vis mindre"
     }
   }
   

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -498,5 +498,11 @@
   },
   "awards_winner_of": {
     "other": "Zwycięzca"
+  },
+  "meta_description_expand": {
+    "other": "Pokaż więcej"
+  },
+  "meta_description_collapse": {
+    "other": "Pokaż mniej"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1261,5 +1261,11 @@
   },
   "awards_winner_of": {
     "other": "Vencedor de"
+  },
+  "meta_description_expand": {
+    "other": "Mostre mais"
+  },
+  "meta_description_collapse": {
+    "other": "Mostre menos"
   }
  }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -531,5 +531,11 @@
     },
     "awards_winner_of": {
       "other": "Vencedor de"
+    },
+    "meta_description_expand": {
+      "other": "Mostre mais"
+    },
+    "meta_description_collapse": {
+      "other": "Mostre menos"
     }
   }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -569,5 +569,11 @@
   },
   "awards_winner_of": {
     "other": "Победитель"
+  },
+  "meta_description_expand": {
+    "other": "Показать больше"
+  },
+  "meta_description_collapse": {
+    "other": "Показывай меньше"
   }
 }

--- a/site/se_SE.all.json
+++ b/site/se_SE.all.json
@@ -569,5 +569,11 @@
     },
     "awards_winner_of": {
       "other": "Победник од"
+    },
+    "meta_description_expand": {
+      "other": "Прикажи више"
+    },
+    "meta_description_collapse": {
+      "other": "Прикажи мање"
     }
   }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -238,7 +238,7 @@
   }
 
   .meta-detail-synopsis,
-  s72-element-switcher .meta-detail-tagline {
+  .meta-detail-switcher-tagline {
     padding-top: 10px;
 
     p {

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -237,7 +237,8 @@
     }
   }
 
-  .meta-detail-synopsis {
+  .meta-detail-synopsis,
+  s72-element-switcher .meta-detail-tagline {
     padding-top: 10px;
 
     p {

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -65,7 +65,7 @@
           {{yield awardNominations() film}}
           <s72-element-switcher>
             {{if isEnabled("element_switcher_enabled")}}
-              <div class="meta-detail-tagline">
+              <div class="meta-detail-switcher-tagline">
                 <p>{{film.Tagline}}</p>
               </div>
             {{end}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -69,7 +69,7 @@
                 <p>{{film.Tagline}}</p>
               </div>
             {{end}}
-            <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}">
+            <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}"> {* hide class prevents FOUC *}
               <div class="meta-detail-synopsis">{{film.Overview | raw}}</div>
               <div class="meta-detail-cast">
               {{if len(film.Cast) > 0 }}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -68,7 +68,6 @@
                 <p>{{film.Tagline}}</p>
               </div>
             {{end}}
-<<<<<<< HEAD
             <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}"> {* hide class prevents FOUC *}
               <div class="meta-detail-synopsis">{{film.Overview | raw}}</div>
               <div class="meta-detail-cast">
@@ -97,11 +96,35 @@
                   <p>{{ film.Languages }}</p>
                 </div>
               {{end}}
-              {{if len(film.GetSubtitles()) > 0 }}
-                <div class="meta-detail-subtitle">
-                  <h2>{{i18n("meta_detail_subtitles")}}</h2>
-                  <p>{{ film.GetSubtitles() }}</p>
-                </div>
+              {{allSubtitles := film.GetSubtitles()}}
+              {{if len(allSubtitles) > 0 }}
+                {{subtitles := ""}}
+                {{captions := ""}}
+                {{if len(film.SubtitleTracks) == 0}}
+                  {{subtitles = allSubtitles}}
+                {{else}}
+                  {{range subTrack := film.SubtitleTracks}}
+                    {{if len(subTrack) >= 3}}
+                      {{if subTrack[2] == "caption"}}
+                          {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
+                      {{else}}
+                          {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
+                      {{end}}
+                    {{end}}
+                  {{end}}
+                {{end}}
+                {{if subtitles}}
+                  <div class="meta-detail-subtitle">
+                    <h2>{{i18n("meta_detail_subtitles")}}</h2>
+                    <p>{{subtitles}}</p>
+                  </div>
+                {{end}}
+                {{if captions}}
+                  <div class="meta-detail-subtitle">
+                    <h2>{{i18n("meta_detail_captions")}}</h2>
+                    <p>{{captions}}</p>
+                  </div>
+                {{end}}
               {{end}}
               {{if len(film.Countries) > 0 }}
                 <div class="meta-detail-country">
@@ -123,63 +146,6 @@
                   <p>{{ studios }}</p>
                 </div>
               {{end}}
-=======
-          </div>
-          {{if len(film.Languages) > 0 }}
-            <div class="meta-detail-language">
-              <h2>{{i18n("meta_detail_languages", len(film.Languages))}}</h2>
-              <p>{{ film.Languages }}</p>
-            </div>
-          {{end}}
-          {{allSubtitles := film.GetSubtitles()}}
-          {{if len(allSubtitles) > 0 }}
-            {{subtitles := ""}}
-            {{captions := ""}}
-            {{if len(film.SubtitleTracks) == 0}}
-              {{subtitles = allSubtitles}}
-            {{else}}
-              {{range subTrack := film.SubtitleTracks}}
-                {{if len(subTrack) >= 3}}
-                  {{if subTrack[2] == "caption"}}
-                      {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
-                  {{else}}
-                      {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
-                  {{end}}
-                {{end}}
-              {{end}}
-            {{end}}
-            {{if subtitles}}
-              <div class="meta-detail-subtitle">
-                <h2>{{i18n("meta_detail_subtitles")}}</h2>
-                <p>{{subtitles}}</p>
-              </div>
-            {{end}}
-            {{if captions}}
-              <div class="meta-detail-subtitle">
-                <h2>{{i18n("meta_detail_captions")}}</h2>
-                <p>{{captions}}</p>
-              </div>
-            {{end}}
-          {{end}}
-          {{if len(film.Countries) > 0 }}
-            <div class="meta-detail-country">
-              <h2>{{i18n("meta_detail_countries", len(film.Countries))}}</h2>
-              <p>{{ film.Countries }}</p>
-            </div>
-          {{end}}
-          {{if len(film.Studio) > 0 }}
-            <div class="meta-detail-studio">
-              <h2>{{i18n("meta_detail_studios", len(film.Studio))}}</h2>
-              {*{ FORMAT STUDIOS }*}
-              {{ studios := "" }}
-              {{ range studio := film.Studio }}
-                {{ studios = studios + studio + ", "}}
-              {{ end }}
-              {{ if len(studios) > 0 }}
-                {{ studios = studios[0:len(studios) - 2] }}
-              {{ end }}
-              <p>{{ studios }}</p>
->>>>>>> develop
             </div>
           </s72-element-switcher>
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -63,60 +63,68 @@
           <s72-availability-label data-slug="{{film.Slug}}"></s72-availability-label>
 
           {{yield awardNominations() film}}
-
-          <div class="meta-detail-synopsis">{{film.Overview | raw}}</div>
-          <div class="meta-detail-cast">
-          {{if len(film.Cast) > 0 }}
-            <h2>{{i18n("meta_detail_cast_title")}}</h2>
-          {{end}}
-            <p>
-              {{range index, member := film.Cast}}
-                {{ path := "/search.html?q=" + member.Name }}
-                <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if index < len(film.Cast) - 1}}, {{end}}
-              {{end}}
-            </p>
-          </div>
-          <div class="meta-detail-crew d-flex">
-            {{range index, member := film.Crew}}
-              <div class="crew-member">
-                <h2>{{member.Job}}</h2>
-                {{ path := "/search.html?q=" + member.Name }}
-                <a href="{{ routeToPath(path) }}">{{member.Name}}</a>
+          <s72-element-switcher>
+            {{if isEnabled("element_switcher_enabled")}}
+              <div class="meta-detail-tagline">
+                <p>{{film.Tagline}}</p>
               </div>
             {{end}}
-          </div>
-          {{if len(film.Languages) > 0 }}
-            <div class="meta-detail-language">
-              <h2>{{i18n("meta_detail_languages", len(film.Languages))}}</h2>
-              <p>{{ film.Languages }}</p>
+            <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}">
+              <div class="meta-detail-synopsis">{{film.Overview | raw}}</div>
+              <div class="meta-detail-cast">
+              {{if len(film.Cast) > 0 }}
+                <h2>{{i18n("meta_detail_cast_title")}}</h2>
+              {{end}}
+                <p>
+                  {{range index, member := film.Cast}}
+                    {{ path := "/search.html?q=" + member.Name }}
+                    <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if index < len(film.Cast) - 1}}, {{end}}
+                  {{end}}
+                </p>
+              </div>
+              <div class="meta-detail-crew d-flex">
+                {{range index, member := film.Crew}}
+                  <div class="crew-member">
+                    <h2>{{member.Job}}</h2>
+                    {{ path := "/search.html?q=" + member.Name }}
+                    <a href="{{ routeToPath(path) }}">{{member.Name}}</a>
+                  </div>
+                {{end}}
+              </div>
+              {{if len(film.Languages) > 0 }}
+                <div class="meta-detail-language">
+                  <h2>{{i18n("meta_detail_languages", len(film.Languages))}}</h2>
+                  <p>{{ film.Languages }}</p>
+                </div>
+              {{end}}
+              {{if len(film.GetSubtitles()) > 0 }}
+                <div class="meta-detail-subtitle">
+                  <h2>{{i18n("meta_detail_subtitles")}}</h2>
+                  <p>{{ film.GetSubtitles() }}</p>
+                </div>
+              {{end}}
+              {{if len(film.Countries) > 0 }}
+                <div class="meta-detail-country">
+                  <h2>{{i18n("meta_detail_countries", len(film.Countries))}}</h2>
+                  <p>{{ film.Countries }}</p>
+                </div>
+              {{end}}
+              {{if len(film.Studio) > 0 }}
+                <div class="meta-detail-studio">
+                  <h2>{{i18n("meta_detail_studios", len(film.Studio))}}</h2>
+                  {*{ FORMAT STUDIOS }*}
+                  {{ studios := "" }}
+                  {{ range studio := film.Studio }}
+                    {{ studios = studios + studio + ", "}}
+                  {{ end }}
+                  {{ if len(studios) > 0 }}
+                    {{ studios = studios[0:len(studios) - 2] }}
+                  {{ end }}
+                  <p>{{ studios }}</p>
+                </div>
+              {{end}}
             </div>
-          {{end}}
-          {{if len(film.GetSubtitles()) > 0 }}
-            <div class="meta-detail-subtitle">
-              <h2>{{i18n("meta_detail_subtitles")}}</h2>
-              <p>{{ film.GetSubtitles() }}</p>
-            </div>
-          {{end}}
-          {{if len(film.Countries) > 0 }}
-            <div class="meta-detail-country">
-              <h2>{{i18n("meta_detail_countries", len(film.Countries))}}</h2>
-              <p>{{ film.Countries }}</p>
-            </div>
-          {{end}}
-          {{if len(film.Studio) > 0 }}
-            <div class="meta-detail-studio">
-              <h2>{{i18n("meta_detail_studios", len(film.Studio))}}</h2>
-              {*{ FORMAT STUDIOS }*}
-              {{ studios := "" }}
-              {{ range studio := film.Studio }}
-                {{ studios = studios + studio + ", "}}
-              {{ end }}
-              {{ if len(studios) > 0 }}
-                {{ studios = studios[0:len(studios) - 2] }}
-              {{ end }}
-              <p>{{ studios }}</p>
-            </div>
-          {{end}}
+          </s72-element-switcher>
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}
             <section class="meta-detail-bonus-content" aria-label="{{i18n("meta_detail_bonus_title")}}">
               <h2>{{i18n("meta_detail_bonus_title")}}</h2>

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -538,6 +538,12 @@
     },
     "awards_winner_of": {
       "other": "kazanan"
+    },
+    "meta_description_expand": {
+      "other": "Daha fazla göster"
+    },
+    "meta_description_collapse": {
+      "other": "Daha az göster"
     }
   }
   

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1191,5 +1191,11 @@
   },
   "awards_winner_of": {
     "other": "Переможець"
+  },
+  "meta_description_expand": {
+    "other": "Показати більше"
+  },
+  "meta_description_collapse": {
+    "other": "Показати менше"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1254,5 +1254,11 @@
   },
   "awards_winner_of": {
     "other": "获奖者"
+  },
+  "meta_description_expand": {
+    "other": "展示更多"
+  },
+  "meta_description_collapse": {
+    "other": "显示较少"
   }
 }


### PR DESCRIPTION
This PR:
- Adds component that toggles between Short/Long description divs via button
- does nothing unless `"element_switcher_enabled" = "true"`
- must point to the latest version of relish to work
- Also please view the changes below with GitHub diff setting 'ignore whitespace'


[AB#4745](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Web%20team/Stories/?workitem=4745)