### PR TITLE
Ab#6003 carousel keyboard control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 - Added Core Template version to head.
 - Added script which pulls Core Template version from package.json and adds it to kibble.json during builds/releases.
 
-
 ### Changed
 - Removed minimum page height from content pages
+
+### Fixed
+- Carousel keyboard control.
 
 
 ## [0.4.4](https://github.com/shift72/core-template/compare/0.4.3...0.4.4)

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -499,6 +499,7 @@
     "wcag_aria_label_toggle_nav": { "other": "تبديل التنقل" },
     "wcag_aria_label_bundle_items": { "other": "عناصر الحزمات" },
     "wcag_aria_label_carousel": { "other": "المشاركات الدائرية" },
+    "wcag_aria_label_carousel_pagination": { "other": "ترقيم الصفحات" },
     "wcag_aria_label_page_collection": { "other": "صفحة المجموعات" },
     "wcag_aria_label_collection_list": { "other": "لائحة المجموعات" },
     "wcag_aria_label_collection_slider": { "other": "شريط تمرير المجموعات" },

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1128,6 +1128,7 @@
   "wcag_aria_label_carousel": {
    "other": "Carrusel"
   },
+  "wcag_aria_label_carousel_pagination": { "other": "Paginació" },
   "wcag_aria_label_page_collection": {
    "other": "Col·lecció de pàgines"
   },

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1164,6 +1164,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Slå navigation til/fra" },
   "wcag_aria_label_bundle_items": { "other": "Pak varer" },
   "wcag_aria_label_carousel": { "other": "Karrusel" },
+  "wcag_aria_label_carousel_pagination": { "other": "Sideinddeling" },
   "wcag_aria_label_page_collection": { "other": "Sidesamling" },
   "wcag_aria_label_collection_list": { "other": "Samlingsliste" },
   "wcag_aria_label_collection_slider": { "other": "Indsamlingsskyder" },

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -550,6 +550,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Navigation umschalten" },
   "wcag_aria_label_bundle_items": { "other": "Bundle-Artikel" },
   "wcag_aria_label_carousel": { "other": "Karussell" },
+  "wcag_aria_label_carousel_pagination": { "other": "Seitennummerierung" },
   "wcag_aria_label_page_collection": { "other": "Seitensammlung" },
   "wcag_aria_label_collection_list": { "other": "Sammlungsliste" },
   "wcag_aria_label_collection_slider": { "other": "Sammlungsschieber" },

--- a/site/ee_EE.all.json
+++ b/site/ee_EE.all.json
@@ -544,6 +544,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Lülitage navigeerimine sisse" },
   "wcag_aria_label_bundle_items": { "other": "Komplekti esemed" },
   "wcag_aria_label_carousel": { "other": "Karussell" },
+  "wcag_aria_label_carousel_pagination": { "other": "Leheküljed" },
   "wcag_aria_label_page_collection": { "other": "Lehekülje kollektsioon" },
   "wcag_aria_label_collection_list": { "other": "Kollektsioonide loend" },
   "wcag_aria_label_collection_slider": { "other": "Kogumise liugur" },

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -540,6 +540,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Εναλλαγή πλοήγησης" },
   "wcag_aria_label_bundle_items": { "other": "Είδη Δέσμης" },
   "wcag_aria_label_carousel": { "other": "Στροβιλοδρόμιο" },
+  "wcag_aria_label_carousel_pagination": { "other": "Σελιδοποίηση" },
   "wcag_aria_label_page_collection": { "other": "Συλλογή σελίδων" },
   "wcag_aria_label_collection_list": { "other": "Λίστα συλλογής" },
   "wcag_aria_label_collection_slider": { "other": "Ρυθμιστικό συλλογής" },

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -527,6 +527,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Toggle Navigation" },
   "wcag_aria_label_bundle_items": { "other": "Bundle Items" },
   "wcag_aria_label_carousel": { "other": "Carousel" },
+  "wcag_aria_label_carousel_pagination": { "other": "Pagination" },
   "wcag_aria_label_page_collection": { "other": "Page Collection" },
   "wcag_aria_label_collection_list": { "other": "Collection List" },
   "wcag_aria_label_collection_slider": { "other": "Collection Slider" },

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -499,6 +499,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Navegación de palanca"},
   "wcag_aria_label_bundle_items": { "other": "Paquete de artículos" },
   "wcag_aria_label_carousel": { "other": "Carrusel" },
+  "wcag_aria_label_carousel_pagination": { "other": "Pagination" },
   "wcag_aria_label_page_collection": { "other": "Colección de páginas" },
   "wcag_aria_label_collection_list": { "other": "Lista de colecciones" },
   "wcag_aria_label_collection_slider": { "other": "Control deslizante de colección" },

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -499,7 +499,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Navegación de palanca"},
   "wcag_aria_label_bundle_items": { "other": "Paquete de artículos" },
   "wcag_aria_label_carousel": { "other": "Carrusel" },
-  "wcag_aria_label_carousel_pagination": { "other": "Pagination" },
+  "wcag_aria_label_carousel_pagination": { "other": "Paginación" },
   "wcag_aria_label_page_collection": { "other": "Colección de páginas" },
   "wcag_aria_label_collection_list": { "other": "Lista de colecciones" },
   "wcag_aria_label_collection_slider": { "other": "Control deslizante de colección" },

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -436,6 +436,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Navegación de palanca" },
   "wcag_aria_label_bundle_items": { "other": "Paquete de artículos" },
   "wcag_aria_label_carousel": { "other": "Carrusel" },
+  "wcag_aria_label_carousel_pagination": { "other": "Paginación" },
   "wcag_aria_label_page_collection": { "other": "Colección de páginas" },
   "wcag_aria_label_collection_list": { "other": "Lista de colecciones" },
   "wcag_aria_label_collection_slider": { "other": "Control deslizante de colección" },

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -463,6 +463,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Navigointi päälle/pois" },
   "wcag_aria_label_bundle_items": { "other": "Niputa kohteita" },
   "wcag_aria_label_carousel": { "other": "Karuselli" },
+  "wcag_aria_label_carousel_pagination": { "other": "Sivunumerointi" },
   "wcag_aria_label_page_collection": { "other": "Sivujen kokoelma" },
   "wcag_aria_label_collection_list": { "other": "Kokoelmaluettelo" },
   "wcag_aria_label_collection_slider": { "other": "Kokoelman liukusäädin" },

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -499,6 +499,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Basculer la navigation" },
   "wcag_aria_label_bundle_items": { "other": "Articles groupés" },
   "wcag_aria_label_carousel": { "other": "Carrousel" },
+  "wcag_aria_label_carousel_pagination": { "other": "Pagination" },
   "wcag_aria_label_page_collection": { "other": "Collecte de pages" },
   "wcag_aria_label_collection_list": { "other": "Liste de collecte" },
   "wcag_aria_label_collection_slider": { "other": "Curseur de collecte" },

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -414,6 +414,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Način prikaza" },
   "wcag_aria_label_bundle_items": { "other": "Naslovi iz paketa" },
   "wcag_aria_label_carousel": { "other": "Kružni prikaz" },
+  "wcag_aria_label_carousel_pagination": { "other": "Paginacija" },
   "wcag_aria_label_page_collection": { "other": "Zbirka stranica" },
   "wcag_aria_label_collection_list": { "other": "Popis zbirki" },
   "wcag_aria_label_collection_slider": { "other": "Klizač s naslovima iz zbirke" },

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -542,6 +542,7 @@
     "wcag_aria_label_toggle_nav": { "other": "Kapcsolja be a navigációt" },
     "wcag_aria_label_bundle_items": { "other": "Csomag tételek" },
     "wcag_aria_label_carousel": { "other": "Körhinta" },
+    "wcag_aria_label_carousel_pagination": { "other": "Lapszámozás" },
     "wcag_aria_label_page_collection": { "other": "Oldalgyűjtemény" },
     "wcag_aria_label_collection_list": { "other": "Gyűjteménylista" },
     "wcag_aria_label_collection_slider": { "other": "Gyűjteménycsúszka" },

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -498,6 +498,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Attiva/disattiva navigazione" },
   "wcag_aria_label_bundle_items": { "other": "Articoli in bundle" },
   "wcag_aria_label_carousel": { "other": "Giostra" },
+  "wcag_aria_label_carousel_pagination": { "other": "Impaginazione" },
   "wcag_aria_label_page_collection": { "other": "Collezione di pagine" },
   "wcag_aria_label_collection_list": { "other": "Elenco di raccolta" },
   "wcag_aria_label_collection_slider": { "other": "Dispositivo di scorrimento della raccolta" },

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -462,6 +462,7 @@
   "wcag_aria_label_toggle_nav": { "other": "ナビゲーションの切り替え" },
   "wcag_aria_label_bundle_items": { "other": "バンドルアイテム" },
   "wcag_aria_label_carousel": { "other": "カルーセル" },
+  "wcag_aria_label_carousel_pagination": { "other": "ページ付け" },
   "wcag_aria_label_page_collection": { "other": "ページコレクション" },
   "wcag_aria_label_collection_list": { "other": "コレクションリスト" },
   "wcag_aria_label_collection_slider": { "other": "コレクションスライダー" },

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -569,6 +569,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Perjungti navigaciją" },
   "wcag_aria_label_bundle_items": { "other": "Supakuoti daiktai" },
   "wcag_aria_label_carousel": { "other": "Karuselė" },
+  "wcag_aria_label_carousel_pagination": { "other": "Puslapių rašymas" },
   "wcag_aria_label_page_collection": { "other": "Puslapių kolekcija" },
   "wcag_aria_label_collection_list": { "other": "Kolekcijos sąrašas" },
   "wcag_aria_label_collection_slider": { "other": "Kolekcijos slankiklis" },

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -569,6 +569,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Navigatie wisselen" },
   "wcag_aria_label_bundle_items": { "other": "Bundelartikelen" },
   "wcag_aria_label_carousel": { "other": "Carrousel" },
+  "wcag_aria_label_carousel_pagination": { "other": "Paginering" },
   "wcag_aria_label_page_collection": { "other": "Page Collecties" },
   "wcag_aria_label_collection_list": { "other": "Collecties List" },
   "wcag_aria_label_collection_slider": { "other": "Collecties Slider" },

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -538,6 +538,7 @@
     "wcag_aria_label_toggle_nav": { "other": "Slå på navigering" },
     "wcag_aria_label_bundle_items": { "other": "Bunt varers" },
     "wcag_aria_label_carousel": { "other": "Karusell" },
+    "wcag_aria_label_carousel_pagination": { "other": "Paginering" },
     "wcag_aria_label_page_collection": { "other": "Page Karusell" },
     "wcag_aria_label_collection_list": { "other": "Karusell List" },
     "wcag_aria_label_collection_slider": { "other": "Karusell Slider" },

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -519,6 +519,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Przełącz nawigację" },
   "wcag_aria_label_bundle_items": { "other": "Zestaw przedmiotów" },
   "wcag_aria_label_carousel": { "other": "Karuzela" },
+  "wcag_aria_label_carousel_pagination": { "other": "Paginacja" },
   "wcag_aria_label_page_collection": { "other": "Kolekcja stron" },
   "wcag_aria_label_collection_list": { "other": "Lista kolekcji" },
   "wcag_aria_label_collection_slider": { "other": "Suwak kolekcji" },

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1062,6 +1062,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Alternar de navegação" },
   "wcag_aria_label_bundle_items": { "other": "Itens do pacote" },
   "wcag_aria_label_carousel": { "other": "Carrossel" },
+  "wcag_aria_label_carousel_pagination": { "other": "Paginação" },
   "wcag_aria_label_page_collection": { "other": "Página Coleções" },
   "wcag_aria_label_collection_list": { "other": "Coleções Lista" },
   "wcag_aria_label_collection_slider": { "other": "Coleções Controle deslizante" },

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -540,6 +540,7 @@
     "wcag_aria_label_toggle_nav": { "other": "Alternar de navegação" },
     "wcag_aria_label_bundle_items": { "other": "Itens do pacote" },
     "wcag_aria_label_carousel": { "other": "Carrossel" },
+    "wcag_aria_label_carousel_pagination": { "other": "Paginação" },
     "wcag_aria_label_page_collection": { "other": "Página Coleções" },
     "wcag_aria_label_collection_list": { "other": "Coleções Lista" },
     "wcag_aria_label_collection_slider": { "other": "Coleções Controle deslizante" },

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -575,6 +575,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Переключить навигацию" },
   "wcag_aria_label_bundle_items": { "other": "Пучок предметов" },
   "wcag_aria_label_carousel": { "other": "Карусель" },
+  "wcag_aria_label_carousel_pagination": { "other": "Пагинация" },
   "wcag_aria_label_page_collection": { "other": "Коллекция страницы" },
   "wcag_aria_label_collection_list": { "other": "Список коллекции" },
   "wcag_aria_label_collection_slider": { "other": "Сладер коллекции" },

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -572,6 +572,7 @@
     "wcag_aria_label_toggle_nav": { "other": "Переключить навигацию" },
     "wcag_aria_label_bundle_items": { "other": "Пучок предметаs" },
     "wcag_aria_label_carousel": { "other": "Карусель" },
+    "wcag_aria_label_carousel_pagination": { "other": "Пагинација" },
     "wcag_aria_label_page_collection": { "other": "Коллекция страницы" },
     "wcag_aria_label_collection_list": { "other": "Список коллекции" },
     "wcag_aria_label_collection_slider": { "other": "Сладер коллекции" },

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -98,6 +98,16 @@ s72-carousel {
   .carousel-item-link {
     display: block;
     height: 500px;
+
+    &:focus-visible {
+      outline: none;
+
+      .carousel-item-caption {
+        border-radius: 4px; 
+        outline: 1px solid var(--body-color);
+        
+      }
+    }
   }
 }
 
@@ -274,7 +284,11 @@ s72-carousel {
   transform: translateX(-50%);
 
   .s72-carousel-page {
+    background: none;
+    border: none;
     color: rgba(var(--body-color-rgb), 0.2);
+    padding: 0px;
+
     @include media-breakpoint-up(md) {
       margin: 0 5px;
     }

--- a/site/templates/collection/carousel.jet
+++ b/site/templates/collection/carousel.jet
@@ -14,7 +14,7 @@
 
 		<div class="s72-carousel-pagination">
 			{{range index, item := .Items}}
-				<div class="s72-carousel-page" data-page-index="{{index}}" data-slug="{{item.Slug}}"><span class="fa fa-circle"></span></div>
+				<button class="s72-carousel-page" data-page-index="{{index}}" data-slug="{{item.Slug}}" aria-label="{{i18n("wcag_aria_label_carousel_pagination")}} {{item.Title}}"><span class="fa fa-circle"></span></button>
 			{{end}}
 		</div>
 

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -545,6 +545,7 @@
     "wcag_aria_label_toggle_nav": { "other": "Gezinme geçişi" },
     "wcag_aria_label_bundle_items": { "other": "Paket eşyaları" },
     "wcag_aria_label_carousel": { "other": "Atlıkarınca" },
+    "wcag_aria_label_carousel_pagination": { "other": "sayfalandırma" },
     "wcag_aria_label_page_collection": { "other": "Sayfa Koleksiyonu" },
     "wcag_aria_label_collection_list": { "other": "Koleksiyon Listesi" },
     "wcag_aria_label_collection_slider": { "other": "Toplama kaydırıcısı" },

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1159,6 +1159,7 @@
   "wcag_aria_label_toggle_nav": { "other": "Перемикання навігації" },
   "wcag_aria_label_bundle_items": { "other": "Пункти пучки" },
   "wcag_aria_label_carousel": { "other": "Карусель" },
+  "wcag_aria_label_carousel_pagination": { "other": "Пагінація" },
   "wcag_aria_label_page_collection": { "other": "Колекція сторінок" },
   "wcag_aria_label_collection_list": { "other": "Список зборів"},
   "wcag_aria_label_collection_slider": { "other": "Колекція слайдер" },

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1095,6 +1095,7 @@
   "wcag_aria_label_carousel": {
    "other": "輪播"
   },
+  "wcag_aria_label_carousel_pagination": { "other": "分页" },
   "wcag_aria_label_page_collection": {
    "other": "收藏頁面"
   },


### PR DESCRIPTION
- Removed existing broken focus ring from `.carousel-item-link`.
- Added focus ring to `.carousel-item-caption` when `.carousel-item-link` is focused.
- Changed pagination dots to button elements so they can be focused.
- Added aria-label to pagination dots with translations for screen readers.