### PR TITLE
Ab#5032 use image map for films

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/0.4.4...HEAD)
 
+### Changed
+- Upgrade kibble to version 0.16.6
+- Moved references to film.Images to film.ImageMap
+
 ### Added
 - Start the site with an admin build: `npm start --admin`.
 - Added Core Template version to head.

--- a/kibble.json
+++ b/kibble.json
@@ -2,7 +2,7 @@
   "name": "core-template",
   "version": "0.0.1",
   "siteUrl": "https://abccinemas.screenplus.co",
-  "builderVersion": "0.16.5",
+  "builderVersion": "0.16.6",
   "defaultLanguage": "en",
   "languages": {
     "ar": { "code": "ar_LB", "name": "عربى" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "postcss-cli": "^9.0.1",
         "rollup": "^2.23.0",
         "rollup-plugin-terser": "^6.1.0",
-        "s72-kibble": "^0.16.5",
+        "s72-kibble": "^0.16.6",
         "sass": "^1.36.0"
       },
       "devDependencies": {
@@ -6232,9 +6232,9 @@
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "node_modules/s72-kibble": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/s72-kibble/-/s72-kibble-0.16.5.tgz",
-      "integrity": "sha512-dO8ZX275yEVvj67opXS1Kjlmlme96DYixmlxa8oq2bCtTCj+77Yz3nwVI1KVWPw1av7PB7qf0POnZr4rqeqzyA==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/s72-kibble/-/s72-kibble-0.16.6.tgz",
+      "integrity": "sha512-0u8gVxCLPnykY+J4PwueR6amh23YSD5K1jucnpDYTOiVRy6oMaEREITpr+3oR1V2aEdB6q7AMfM6CqfpopFNMA==",
       "hasInstallScript": true,
       "dependencies": {
         "binwrap": "^0.2.0"
@@ -12650,9 +12650,9 @@
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "s72-kibble": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/s72-kibble/-/s72-kibble-0.16.5.tgz",
-      "integrity": "sha512-dO8ZX275yEVvj67opXS1Kjlmlme96DYixmlxa8oq2bCtTCj+77Yz3nwVI1KVWPw1av7PB7qf0POnZr4rqeqzyA==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/s72-kibble/-/s72-kibble-0.16.6.tgz",
+      "integrity": "sha512-0u8gVxCLPnykY+J4PwueR6amh23YSD5K1jucnpDYTOiVRy6oMaEREITpr+3oR1V2aEdB6q7AMfM6CqfpopFNMA==",
       "requires": {
         "binwrap": "^0.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss-cli": "^9.0.1",
     "rollup": "^2.23.0",
     "rollup-plugin-terser": "^6.1.0",
-    "s72-kibble": "^0.16.5",
+    "s72-kibble": "^0.16.6",
     "sass": "^1.36.0"
   },
   "devDependencies": {

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -21,16 +21,15 @@
   <main id="main" class="page page-film meta-detail meta-detail-film">
     <div class="meta-detail-bg">
       <div class="right-gradient"></div>
-      <s72-image src="{{film.Images.Background}}" alt="" class="meta-detail-bg-img"></s72-image>
+      <s72-image src="{{film.ImageMap["Background"]}}" alt="" class="meta-detail-bg-img"></s72-image>
     </div>
     <div class="container">
       <div class="meta-detail-main">
         {{if config("default_image_type") == "portrait"}}
             <div class="poster poster-portrait">
               <s72-availability-status data-slug="{{film.Slug}}"></s72-availability-status>
-              <s72-image src="{{film.Images.Classification}}" alt="" class="classification-image">
-
-              <s72-image src="{{film.Images.Portrait}}" alt="{{film.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
+              <s72-image src="{{film.ImageMap["Classification"]}}" alt="" class="classification-image">
+              <s72-image src="{{film.ImageMap["Portrait"]}}" alt="{{film.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
 
             </div>
         {{end}}


### PR DESCRIPTION
- upgrade to Kibble 0.16.6, which introduces ImageMap for film objects (in parallel with Images but does not care what they are called)
- references to film.Images changed to film.ImageMap
- update changelog