### PR TITLE
Allow overriding of the cookie consent variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,48 +3,47 @@
 ## [Unreleased](https://github.com/shift72/core-template/compare/0.4.4...HEAD)
 
 ### Changed
-- Upgrade kibble to version 0.16.6
-- Moved references to film.Images to film.ImageMap
+- Upgrade to kibble `0.16.6`.
+- Moved references from `film.Images` to `film.ImageMap`.
+- Removed minimum page height from content pages.
 
 ### Added
 - Start the site with an admin build: `npm start --admin`.
-- Added Core Template version to head.
-- Added script which pulls Core Template version from package.json and adds it to kibble.json during builds/releases.
+- Added version to `<head>` and `kibble.json`.
 
-
-### Changed
-- Removed minimum page height from content pages
-
+### Fixed
+- Can now override the cookie consent styling.
 
 ## [0.4.4](https://github.com/shift72/core-template/compare/0.4.3...0.4.4)
-- Fixed usage of obsolete $primary var for trailer button
+### Fixed
+- Fixed obsolete `$primary` var for trailer button.
 
 ### Added
-- Awards categories
+- Awards categories.
 
 ## [0.4.3](https://github.com/shift72/core-template/compare/0.4.2...0.4.3)
 
 ### Added
-- Awards categories
-- Floating donate button
+- Awards categories.
+- Floating donate button.
 - External custom CSS link in head.
 - Scripts for downloading/uploading custom CSS files for use with local development.
 
 ### Changed
-- Replaced various SASS variables with CSS variables.
-- Added workarounds for SASS and Bootstrap functions that don't understand CSS variables.
-- Kibble 0.16.4
-- Split CC and Subtitles
-- Moved engagement icons
+- Replaced various Sass variables with CSS variables.
+- Added workarounds for Sass and Bootstrap functions that don't understand CSS variables.
+- Kibble `0.16.4`.
+- Split CC and Subtitles.
+- Moved engagement icons.
 
 ## [0.4.2](https://github.com/shift72/core-template/compare/0.4.1...0.4.2)
 
 ### Added
-- Lang files updated with entries for purchasing one-off passes
-- Sponsor banner that can be enabled/disabled in Uber Admin
+- Lang files updated with entries for purchasing one-off passes.
+- Sponsor banner.
 
-### Changed
-- Typo in English lang file
+### Fixed
+- Typo in English language file.
 
 ## [0.4.1](https://github.com/shift72/core-template/compare/0.4.0...0.4.1)
 
@@ -65,11 +64,11 @@ No changes from RC0.
 
 ### Changed
 - Moved separator line from footer jet into app badge jet.
-- Kibble upgraded to v0.15.22.
+- Kibble upgraded to `0.15.22`.
 - Application templates moved to `/site/templates/application/`.
 - Links (`<a>` tags) without a `class` attribute have `text-decoration: underline`.
 
-## Fixed
+### Fixed
 - Curated pages with a collection no longer has a `min-height` that was forcing a gap before the collection.
 
 ## [0.3.8](https://github.com/shift72/core-template/compare/0.3.7...0.3.8)

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -112,9 +112,9 @@ $spacers: (
 );
 
 // Cookie Consent
-$cookie-consent-color: #000;
-$cookie-consent-link-color: var(--primary);
-$cookie-consent-hover-link-color: var(--secondary);
+$cookie-consent-color: #000 !default;
+$cookie-consent-link-color: var(--primary) !default;
+$cookie-consent-hover-link-color: var(--secondary) !default;
 
 // Nav
 // ------------------------------------


### PR DESCRIPTION
1. The `$cookie-consent-*` vars were missing `!default` so couldn't override them.
2. Reformatted a bit of the changelog.