### PR TITLE
AB#6719 support ga ua legacy and ga4

### DIFF
--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -65,6 +65,8 @@
     </script>
 
     <script type="text/javascript" src="/scripts/swiper.min.js"></script>
+
+    {{yield googleGa4Script()}}
   </head>
   <body>
 

--- a/site/templates/application/google.jet
+++ b/site/templates/application/google.jet
@@ -1,5 +1,9 @@
 {{block googleScripts(tagManagerId=config("google_tag_manager_id"), analyticsId=config("google_analytics_id"))}}
   <!-- Google integration scripts -->
+  <!-- GA4 script if G tracking code is provided -->
+  {{ if hasPrefix(analyticsId,"G")}}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{analyticsId}}"></script>
+  {{ end }}
   <script>
     function loadGoogleTagManager() {
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -9,8 +13,16 @@
       })(window,document,'script','dataLayer','{{ tagManagerId }}')
     }
 
+    <!-- GA4 code snippet if G tracking code is provided, else use legacy UA code snippet -->
+    {{ if hasPrefix(analyticsId,"G")}}
+      function loadGoogleAnalytics() {
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-    {{ if hasPrefix(analyticsId,"UA")}}
+        gtag('config', '{{analyticsId}}');
+      }
+    {{else}}
       function loadGoogleAnalytics() {
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -20,17 +32,6 @@
         ga('create', '{{analyticsId}}', 'auto');
         ga('require', 'ecommerce');
         ga('send', 'pageview');
-      }
-    {{else}}
-      function loadGoogleAnalytics() {
-        <script async src="https://www.googletagmanager.com/gtag/js?id={{analyticsId}}"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', '{{analyticsId}}');
-        </script>
       }
     {{end}}
 

--- a/site/templates/application/google.jet
+++ b/site/templates/application/google.jet
@@ -1,9 +1,11 @@
+{{block googleGa4Script(analyticsId=config("google_analytics_id"))}}
+  {{if hasPrefix(analyticsId,"G")}}
+  <!-- GA4 script if G tracking code is provided -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{analyticsId}}"></script>
+  {{end}}
+{{end}}
 {{block googleScripts(tagManagerId=config("google_tag_manager_id"), analyticsId=config("google_analytics_id"))}}
   <!-- Google integration scripts -->
-  <!-- GA4 script if G tracking code is provided -->
-  {{ if hasPrefix(analyticsId,"G")}}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{analyticsId}}"></script>
-  {{ end }}
   <script>
     function loadGoogleTagManager() {
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -14,7 +16,7 @@
     }
 
     <!-- GA4 code snippet if G tracking code is provided, else use legacy UA code snippet -->
-    {{ if hasPrefix(analyticsId,"G")}}
+    {{if hasPrefix(analyticsId,"G")}}
       function loadGoogleAnalytics() {
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}

--- a/site/templates/application/google.jet
+++ b/site/templates/application/google.jet
@@ -10,16 +10,29 @@
     }
 
 
-    function loadGoogleAnalytics() {
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    {{ if hasPrefix(analyticsId,"UA")}}
+      function loadGoogleAnalytics() {
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-      ga('create', '{{analyticsId}}', 'auto');
-      ga('require', 'ecommerce');
-      ga('send', 'pageview');
-    }
+        ga('create', '{{analyticsId}}', 'auto');
+        ga('require', 'ecommerce');
+        ga('send', 'pageview');
+      }
+    {{else}}
+      function loadGoogleAnalytics() {
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{analyticsId}}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', '{{analyticsId}}');
+        </script>
+      }
+    {{end}}
 
     // Only load Google Tag Manager if a/ the frontend cookie consent isn't required or b/ they've agreed to the cookie consent
     var googleTagManagerEnabled = {{ (len(tagManagerId) > 0) ? "true" : "false" }};
@@ -51,4 +64,3 @@
   <!-- End Google Tag Manager (noscript) -->
   {{end}}
 {{end}}
-


### PR DESCRIPTION
Goal of this is to support Google Analytics 4 if thats the type of tracking code the client has provided. In admin the admin user can add a GA tracking code - at the moment our core template code can only ulitise a legacy UA prefixed tracking code. These changes check if its the newer G prefixed GA4 tracking code and if so loads the necessary script and code to log tracking to GA (before these changes it fails silently does nothing). It also still honors the cookie acceptance. It will only create a cookie / talk to GA if the cookie policy has been accepted.

Note: the ecommerce support that is in relish still relies on UA legacy GA if tag manager isnt setup. Im going to create a card and treat as a separate issue since its not working at the moment anyway. This change is purely for traffic tracking.