### PR TITLE
format translations for auto translate script

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1,592 +1,1257 @@
 {
-    "site_owner": { "other": "ABC Cinemas" },
-    "settings_title": { "other": "إعدادات" },
-    "powered_by": { "other": "مشغل بواسطة" },
-    "powered_by_name": { "other": "Shift72" },
-    "powered_by_url": { "other": "https://www.shift72.com" },
-    "in_partnership_with": { "other": "بالشراكة مع/ بالتعاون مع" },
-    "festival_scope": { "other": "Festival Scope" },
-    "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-    "en": { "other": "إنجليزي" },
-    "fr": { "other": "الفرنسية" },
-  
-    "episode_name": {
-      "other": "حلقة"
-    },
-  
-    "season_name": {
-      "other": "موسم"
-    },
-  
-    "seasons":{
-      "one": "مواسم",
-      "other": "{{.Count}} مواسم"
-    },
-    "tvseason": {
-      "other": "مسلسل {{.ShowInfo.Title}} {{.Season.SeasonNumber}}"
-    },
-    "tvseason_html": {
-      "other": "<span>{{.Season.SeasonNumber}}</span> مسلسل {{.ShowInfo.Title}}"
-    },
-    "tvepisode": {
-      "other": "{{.Episode.Title}}"
-    },
-    "tvseason_number": {
-      "other": "مسلسل {{.Season.SeasonNumber}}"
-    },
-    "episode_count": {
-      "one": "حلقة واحدة ",
-      "other": "{{.Count}} حلقات"
-    },
-  
-    "date_day": { "other": "يوم" },
-    "date_month": { "other": "شهر" },
-    "date_year": { "other": "سنة" },
-  
-    "404_page_header": { "other": "هذه الصفحة غير موجودة ...." },
-    "404_page_content": { "other": "<p> المعذرة ، يبدو أن الصفحة التي تبحث عنها غير موجودة. </ p> <p> ربما تم نقلها أو حذفها ، أو ربما أخطأت في الكتابة. </ p> <p> حاول العودة إلى الصفحة الرئيسية للعثور على ما كنت تبحث عنه. </ p> <p> <a href=\"{{.URL}}\"> الرجوع إلى الصفحة الرئيسية </a> </p>>" },
-  
-  
-    "nav_homepage": { "other": "ABC Cinemas" },
-    "nav_signin": { "other": "تسجيل الدخول" },
-    "nav_signup": { "other": "إنشاء حساب" },
-    "nav_signed_in_as": { "other": "تسجيل الدخول بصفة / تسجيل الدخول من حساب / تسجيل الدخول بإسم" },
-    "nav_library": { "other": "المدوّنة" },
-    "nav_devices": { "other": "أجهزتي" },
-    "nav_wishlist": { "other": "قائمتي" },
-    "nav_account": { "other": "حسابي" },
-    "nav_signout": { "other": "تسجيل الخروج" },
-    "play_trailer": { "other": "إعلان ترويجي" },
-    "runtime_hours": { "other": "ساعة" },
-    "runtime_minutes": { "other": "دقيقة" },
-  
-    "datetime_today": { "other": "اليوم {{.Date}}" },
-    "datetime_tomorrow": { "other": "غداً {{.Date}}" },
-    "datetime_yesterday": { "other": "البارحة {{.Date}}" },
-    "datetime_next": { "other": "{{.Date}}" },
-    "datetime_last": { "other": "{{.Date}}" },
-  
-    "search_control_placeholder": { "other": "البحث" },
-    "search_control_submit": { "other": "تأكيد البحث" },
-  
-    "play_button_watch": { "other" : "شاهد الآن"},
-    "play_button_resume": { "other" : "تابع "},
-  
-    "social_media_buttons_title": { "other": "النشر " },
-    "social_media_buttons_facebook": { "other": "انشر في الفيسبوك" },
-    "social_media_buttons_twitter": { "other": "حصة على التغريد" },
-    "social_media_buttons_linkedin": { "other": "انشر على لينكد إن" },
-    "social_media_buttons_email": { "other": "سهم عبر البريد الإلكتروني" },
-    "social_media_buttons_email_subject": { "other": "مشاركة الارتباط" },
-    "social_media_buttons_copied_link": { "other": "تم نسخ الرابط إلى الحافظة!" },
-    "social_media_buttons_copy_link": { "other": "نسخ إلى الحافظة" },
-  
-    "accept_invite_page_header": { "other": "أهلا بك" },
-    "acceptinvite_form_invalid_reset_password_token": { "other": "يبدو أنك طالبت بهذه الدعوة من قبل ، يجب عليك <a href=\"{{.SigninURL}}\"> تسجيل الدخول </a> بدلاً من ذلك. إذا نسيت كلمة المرور ، فيمكنك أيضًا <a href=\"{{.ForgotPasswordURL}}\"> إعادة تعيين كلمة المرور </a>." },
-    "acceptinvite_complete": { "other": "شكراً لك. لقد تم إنشاء حسابك." },
-    "acceptinvite_form_submit": { "other": "قبول الدعوة" },
-    "acceptinvite_agreement": { "other": "بالضغط على ، فإنك توافق على أنك قد قرأت وفهمت <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">بنود & amp؛ و شروط </a> و <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\"> سياسة الخصوصية </a>." },
-  
-    "signup_page_header": { "other": "انشاء حساب جديد" },
-    "signup_form_name": { "other": "الإسم" },
-    "signup_form_email": { "other": "عنوان البريد الإلكتروني" },
-    "signup_form_password": { "other": "كلمة المرور" },
-    "signup_form_password_confirmation": { "other": "تأكيد كلمة المرور" },
-    "signup_form_gender": { "other": "الجنس" },
-    "signup_form_dob": { "other": "تاريخ الولادة" },
-    "signup_form_submit": { "other": "إرسال" },
-  
-    "signin_page_header": { "other": "تسجيل الدخول" },
-    "signin_form_email": { "other": "عنوان البريد الإلكتروني" },
-    "signin_form_password": { "other": "كلمه المرور" },
-    "signin_form_remember": { "other": "تذكرني" },
-    "signin_form_submit": { "other": "إرسال" },
-    "signin_page_forgotpassword": { "other": "هل نسيت كلمة المرور؟" },
-    "signin_page_createnewaccount": { "other": "ليس لديك حساب؟ انشاء حساب جديد" },
-    "signup_page_alreadyhaveanaccount": { "other": "لديك حساب؟ تسجيل الدخول" },
-    "signup_form_error_email_already_in_use": { "other": "تم إستخدام هذا البريد الإلكتروني مسبقاً." },
-    "signin_form_error_incorrect_credentials": { "other": "خطأ في عنوان البريد الإلكتروني أو كلمة المرور." },
-    "signin_form_error_ip_throttled": { "other": "لقد فشلت في تسجيل الدخول عدة مرات. الرجاء معاودة المحاولة في وقت لاحق." },
-    "signin_form_error_account_suspended": { "other": "لقد تم إيقاف حسابك مؤقتا. يرجى الاتصال بمدير الموقع إذا كنت تعتقد(ين) أن هناك خطأ." },
-  
-    "signup_form_error_forbidden": { "other": "حدث خطأ." },
-  
-    "combined_auth_continue": { "other": "إكمال" },
-    "combined_auth_change": { "other": "تغيير" },
-    "combined_auth_signin": { "other": "تسجيل الدخول" },
-    "combined_auth_signup": { "other": "التسجيل" },
-    "combined_auth_signin_password": { "other": "الرجاء إدخال كلمة المرور الخاصة بك لتسجيل الدخول إلى حسابك." },
-    "combined_auth_signin_error_incorrect_credentials": { "other": "كلمة المرور هذه غير صحيحة." },
-    "combined_auth_error_forbidden": { "other": "حدث خطأ." },
-    "combined_auth_error_too_many_requests": { "other": "هنالك طلبات كثيرة، الرجاء المحاولة لاحقا." },
-  
-    "forgotpassword_page_header": { "other": "تغيير كلمة المرور" },
-    "forgotpassword_form_email": { "other": "عنوان البريد الإلكتروني" },
-    "forgotpassword_form_submit": { "other": "تغيير" },
-    "forgotpassword_form_error_email_doesnt_exist": { "other": "لا يوجد حساب بهذا العنوان البريد الإلكتروني." },
-    "forgotpassword_form_error_account_suspended": { "other": "تم تعليق هذا الحساب." },
-    "forgotpassword_complete": { "other": "شكراً لك. سوف يصلك قريباً  بريد إلكتروني لإعادة تعيين كلمة المرور." },
-    "forgotpassword_form_error_forbidden": { "other": "حدث خطأ." },
-    "forgotpassword_form_error_too_many_requests": { "other": "هنالك طلبات كثيرة، الرجاء المحاولة لاحقا." },
-  
-    "resetpassword_page_header": { "other": "تغيير كلمة المرور الخاصة بك" },
-    "resetpassword_form_invalid_reset_password_token": { "other": "يبدو أن طلب إعادة تعيين كلمة المرور هذا غير صالح ، يرجى ملء نموذج <a href=\"{{.URL}}\"> نسيت كلمة المرور </a> مرة أخرى." },
-    "resetpassword_form_password": { "other": "كلمة المرور الجديدة " },
-    "resetpassword_form_password2": { "other": "تأكيد كلمة المرور الجديدة الخاصة بك" },
-    "resetpassword_form_submit": { "other": "تغيير" },
-    "resetpassword_complete": { "other": "شكراً لك. تم تغيير كلمة المرور الخاصة بك وتم تسجيل دخولك." },
-    "resetpassword_form_error_invalid_reset_password_token": { "other": "طلب إعادة تعيين كلمة المرور غير صالح. الرجاء معاودة المحاولة لاحقا." },
-    "resetpassword_form_error_reset_password_token_expired": { "other": "انتهت صلاحية الرمز. الرجاء إعادة الطلب." },
-    "resetpassword_form_error_too_many_requests": { "other": "هنالك طلبات كثيرة، الرجاء المحاولة لاحقا." },
-  
-    "account_page_header": { "other": "حسابي" },
-    "account_form_name": { "other": "الإسم" },
-    "account_form_email": { "other": "العنوان الالكتروني" },
-    "account_form_password": { "other": "كلمة المرور" },
-    "account_form_change_password": { "other": "تغيير" },
-    "account_form_gender": { "other": "الجنس" },
-    "account_form_dob": { "other": "تاريخ الولادة" },
-    "account_form_submit": { "other": "تحديث" },
-    "account_form_submitted": { "other": "تم التحديث" },
-    "account_form_password_changed": { "other": "تم التحديث" },
-    "account_form_error_incorrect_password": { "other": "كلمة المرور هذه غير صحيحة" },
-    "account_form_pin_code": { "other": "الرمز PIN" },
-    "account_form_pin_code_not_set": { "other": "ليس لديك رمز PIN ، وهو مطلوب لشراء بعض الأفلام واستئجارها ومشاهدتها."},
-    "account_form_set_pin": { "other": "ضبط رمز PIN" },
-    "account_form_pin_changed": { "other": "تم التحديث" },
-    "account_form_change_pin": { "other": "تعديل الرمز PIN" },
-  
-    "user_set_pin_header": { "other": "ضبط رمز PIN" },
-    "user_set_pin_button": { "other": "ضبط رمز PIN" },
-    "user_submit_pin_heading": { "other": "أدخل رقم التعريف الشخصي لـ {{.Action}} هذا المحتوى مقيد" },
-    "user_error_wrong_pin_retry": { "other": "رقم التعريف الشخصي غير صحيح" },
-    "user_error_too_many_pin_errors": { "other": "<p> يبدو أنك تواجه مشكلة. </ p> <p> أعد تعيين رقم التعريف الشخصي أو اتصل بنا <a href=\"{{.HelpURL}}\" target=\"_blank\"> للمساعدة </a>" },
-    "user_submit_pin_button": { "other": "أدخل" },
-    "user_reset_pin_button": { "other": "إعادة ضبط رمز PIN" },
-  
-    "signup_form_optin": {"other": "اشترك(ي) في نشرةنا الإلكترونية مجانا"},
-  
-    "passwordconfirmation_modal_header": { "other": "تأكيد كلمة المرور" },
-    "passwordconfirmation_modal_label": { "other": "الرجاء إدخال كلمة المرور لتحديث التغييرات " },
-    "passwordconfirmation_modal_confirm": { "other": "تأكيد" },
-  
-    "changepassword_modal_header": { "other": "تغيير كلمة المرور" },
-    "changepassword_modal_currentpassword": { "other": "كلمة المرور الحالية" },
-    "changepassword_modal_password": { "other": "كلمة المرور الجديدة" },
-    "changepassword_modal_password2": { "other": "تأكيد كلمة المرور" },
-    "changepassword_modal_submit": { "other": "تحديث" },
-    "changepassword_modal_error_incorrect_password": { "other": "كلمة المرور غير صحيحة" },
-  
-    "userlibrary_page_header": { "other": "مكتبتي" },
-    "userlibrary_empty_header":  { "other": "مكتبتك فارغة" },
-    "userlibrary_empty_content": { "other": "تصفح(ي) <a href=\"{{.HomeURL}}\"> مجموعتنا الرائعة </a> واملأها." },
-  
-    "searchresults_page_header": { "other": "نتائج البحث" },
-    "searchresults_load_more": { "other": "تحميل {{.Count}} أكثر" },
-    "searchresults_total": {
-      "one": "تم العثور على {{.Count}} نتائج لـ \"{{.Query}}\".",
-      "other": "تم العثور على {{.Count}} نتائج لـ  \"{{.Query}}\"."
-    },
-    "searchresults_empty_header":  { "other": "لا توجد نتائج بحث عن \"{{.Query}}\"" },
-    "searchresults_empty_content": { "other": "جرّب بحثًا آخر أو <a href=\"{{.HomeURL}}\"> تصفح المحتوى الخاص بنا </a> للعثور على ما تبحث عنه." },
-  
-    "validation_name_required": { "other": "الرجاء إدخال الإسم" },
-    "validation_email_required": { "other": "الرجاء إدخال العنوان الإلكتروني" },
-    "validation_email_email": { "other": "الرجاء إدخال عنوان إلكتروني صالح" },
-    "validation_currentpassword_required": { "other": "الرجاء إدخال كلمة المرور الحالية" },
-    "validation_password_required": { "other": "الرجاء إدخال كلمة مرور" },
-    "validation_password2_required": { "other": "الرجاء تأكيد كلمة المرور" },
-    "validation_password2_match": { "other": "كلمات السر الخاصة بك لا تتطابق." },
-    "validation_password_minlength": { "other": "الرجاء إدخال {{.Count}} أحرف على الأقل." },
-    "validation_promocode_required": { "other": "الرجاء إدخال الرمز الترويجي." },
-    "validation_pincode_required": { "other": "الرجاء إدخال رمز PIN." },
-    "validation_pincode1_required": { "other": "الرجاء إدخال رمز PIN صالح." },
-    "validation_pincode2_required": { "other": "الرجاء إدخال رمز PIN صالح." },
-    "validation_pincode1_pattern": { "other": "الرجاء إدخال رمز PIN صالح." },
-    "validation_pincode2_pattern": { "other": "الرجاء إدخال رمز PIN صالح." },
-    "validation_pincode2_match": { "other": "رمز PIN غير متطابق." },
-    "validation_gender_required": { "other": "الرجاء اختيار الجنس" },
-    "validation_dob_required": { "other": "الرجاء ادخال تاريخ الولادة" },
-    "validation_dob_date": { "other": "الرجاء ادخال تاريخ ولادة صالح" },
-  
-    "shopping_info_subtitle_hd": { "other": "فيديو عالي الدقة HD حسب الطلب" },
-    "shopping_info_subtitle_sd": { "other": "فيديو  SD حسب الطلب" },
-    "shopping_info_subtitle_wallet": { "other": "يمكن استخدام الرصيد في محفظتك لشراء أو استئجار أي محتوى على ScreenPlus." },
-    "shopping_info_subtitle_help": { "other": "انظر هنا لمتطلبات النظام." },
-    "shopping_info_ownership_buy": { "other": "شراء" },
-    "shopping_info_ownership_rent": { "other": "استئجار" },
-  
-    "shopping_info_sd_only": { "other": "يقتصر على تشغيل SD فقط." },
-    "shopping_info_release_date_title": { "other": "الإصدارات  {{.Date}}. " },
-    "shopping_info_release_date_explanation_rent": { "other": "يمكنك الاستئجار الآن ، لكنك لن تتمكن من المشاهدة حتى ذلك الحين." },
-    "shopping_info_release_date_explanation_buy": { "other": "يمكنك الشراء الآن ، لكنك لن تتمكن من المشاهدة حتى ذلك الحين." },
-  
-    "shopping_info_available_until_date_title": { "other": "صالح لغاية {{.Date}}. " },
-    "shopping_info_available_until_date_explanation_rent": { "other": "لن تتمكن من عرض المحتوى بعد ذلك." },
-    "shopping_info_available_until_date_explanation_buy": { "other": "لن تتمكن من عرض المحتوى بعد ذلك." },
-  
-    "duration_hour": { "one": "1 ساعة", "other": "{{.Count}} ساعة" },
-    "duration_day": { "one": "1 يوم", "other": "{{.Count}} يوما" },
-    "shopping_info_rental_period_duration": { "other": "تأجير لمدة {{.ValueUnit}} " },
-    "shopping_info_watch_window_duration": { "other": "تشغيل لمدة {{.Count}} ساعة. " },
-    "shopping_info_watch_window_explanation_film": {
-      "one": "عند الاستئجار، سيكون الفيلم متاحًا في حسابك لمدة {{.ValueUnit}}.",
-      "other": "عند الاستئجار، سيكون الفيلم متاحًا في حسابك لمدة {{.ValueUnit}}."
-    },
-    "shopping_info_watch_window_explanation2_film": {
-      "one": "عند الضغط على تشغيل، يمكنك مشاهدة الفيلم عدة مرات لمدة ساعة واحدة. ",
-      "other": "عند الضغط على تشغيل، يمكنك مشاهدة الفيلم عدة مرات لمدة {{.Count}} ساعات. "
-    },
-    "shopping_info_watch_window_explanation_bundle": {
-      "one": "عند الاستئجار ، ستكون العناصر الموجودة في حزمتك متوفرة في حسابك لمدة يوم واحد. ",
-      "other": "عند الاستئجار ، ستكون العناصر الموجودة في حزمتك متوفرة في حسابك لمدة {{.Count}} أيام. "
-    },
-    "shopping_info_watch_window_explanation2_bundle": {
-      "one": "عند الضغط على تشغيل فيلم معين ، يمكنك مشاهدته عدة مرات لمدة ساعة واحدة",
-      "other": "عند الضغط على تشغيل فيلم معين ، يمكنك مشاهدته عدة مرات لمدة {{.Count}} ساعات"
-    },
-    "shopping_info_watch_window_explanation_season": {
-      "one": "عند الاستئجار ، سيكون الموسم متاحًا في حسابك لمدة يوم واحد. ",
-      "other": "عند الاستئجار ، سيكون الموسم متاحًا في حسابك لمدة {{.Count}} أيام. "
-    },
-    "shopping_info_watch_window_explanation2_season": {
-      "one": "عند الضغط على التشغيل لإحدى الحلقات، تبدأ فترة المشاهدة لمدة {{.Count}} ساعات يمكنك خلالها مشاهدة تلك الحلقة عدة مرات.",
-      "other": "عند الضغط على التشغيل لإحدى الحلقات، تبدأ فترة المشاهدة لمدة {{.Count}} ساعات يمكنك خلالها مشاهدة تلك الحلقة عدة مرات."
-    },
-    "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}٪ مكافأة" },
-  
-    "shopping_enter_card_prompt": { "other": "أدخل تفاصيل بطاقتك الائتمانية أدناه لإكمال {{.Verb}}." },
-  
-    "shopping_terms": { "other": "بإكمال هذه المعاملة ، أوافق على <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\"> البنود والشروط </a>."},
-    "shopping_discount_applied": { "other": "تم تطبيق الخصم {{.DiscountAmount}}." },
-    "shopping_discount_apply": { "other": "تطبيق" },
-    "shopping_discount_code": { "other": "أدخل الرمز الترويجي." },
-    "shopping_discount_have_code": { "other": "لدي رمز ترويجي." },
-  
-    "shopping_price_you_pay": { "other": "دفع" },
-    "shopping_price_nothing": { "other": "لا شيء" },
-    "shopping_price_free": { "other": "مجاني" },
-  
-    "shopping_auth_directions": { "other": "يجب إنشاء حساب حساب أولا. الرجاء إدخال العنوان الإلكتروني." },
-  
-    "shopping_error_in_library": { "other": "{{.Title}} موجود في مكتبتك." },
-  
-    "shopping_error_missing_card": { "other": "الرجاء إدخال تفاصيل بطاقة الائتمان." },
-    "shopping_error_title": { "other": "حدث خطأ" },
-    "shopping_error_incorrect_cvc": { "other": "الرجاء إدخال رمز CVV صالح." },
-    "shopping_error_invalid_cvc": { "other": "الرجاء إدخال رمز CVV صالح." },
-    "shopping_error_incorrect_number": { "other": "الرجاء إدخال رقم بطاقة ائتمان صالحة." },
-    "shopping_error_invalid_number": { "other": "الرجاء إدخال رقم بطاقة ائتمان صالحة." },
-    "shopping_error_card_declined": { "other": "تم رفض بطاقة الائتمان." },
-    "shopping_error_invalid_expiry_month": { "other": "الرجاء إدخال تاريخ انتهاء صالح." },
-    "shopping_error_invalid_expiry_year": { "other": "الرجاء إدخال تاريخ انتهاء صالح." },
-    "shopping_error_expired_card": { "other": "انتهت صلاحية بطاقة الائتمان." },
-    "shopping_error_creditcard_country_mismatch": { "other": "لم تكتمل {{.Ownership}}. يجب التواجد في البلد الذي تم إصدار البطاقة الائتمانية فيه. الرجاء استخدام بطاقة أخرى لإجراء الدفع." },
-    "shopping_error_proxy_detected": { "other": "لم تكتمل {{.Ownership}}. لقد اكتشفنا استخدامكم لخدمة فك تشفير أو خدمة وكيل Proxy. الرجاء إيقاف تشغيل أي من هذه الخدمات وحاول مرة أخرى." },
-  
-    "shopping_error_discount_worn_out": { "other": "لم يعد من الممكن استخدام هذا الرمز الترويجي." },
-    "shopping_error_discount_blank": { "other": "الرجاء إدخال الرمز الترويجي." },
-    "shopping_error_discount_not_applied": { "other": "الرجاء إدخال رمز ترويجي صالح." },
-    "shopping_error_discount_invalid": { "other": "الرجاء إدخال رمز ترويجي صالح." },
-    "shopping_error_discount_disabled": { "other": "الرجاء إدخال رمز ترويجي صالح." },
-    "shopping_error_discount_already_applied": { "other": "سبق وتم استخدام رمز ترويجي لهذه الجلسة." },
-    "shopping_error_discount_already_redeemed": { "other": "تم استخدام هذا الرمز الترويجي سابقا." },
-    "shopping_error_discount_used_previously": { "other": "تم استخدام هذا الرمز الترويجي سابقا." },
-    "shopping_error_discount_max_limit": { "other": "لم يعد من الممكن استخدام هذا الرمز الترويجي." },
-    "shopping_error_discount_expired": { "other": "انتهت صلاحية هذا الرمز الترويجي." },
-    "shopping_error_discount_invalid_ownership_buy": { "other": "لا يمكن استخدام هذا الرمز الترويجي عند الشراء." },
-    "shopping_error_discount_invalid_ownership_rent": { "other": "لا يمكن استخدام هذا الرمز الترويجي عند الاستئجار." },
-    "shopping_error_discount_invalid_item": { "other": "لا يمكن استخدام هذا الرمز الترويجي مع هذا العنصر." },
-    "shopping_error_discount_invalid_pricing_region": { "other": "لا يمكن استخدام هذا الرمز الترويجي في بلدك." },
-    "shopping_error_discounts_not_allowed": { "other": "لا يمكن استخدام هذا الرمز الترويجي." },
-    "shopping_error_discount_disallowed_on_bundles": { "other": "لا يمكن استخدام هذا الرمز الترويجي للباقات." },
-    "shopping_error_payment_intent_authentication_failure": { "other": "تم رفض بطاقة الائتمان. الرجاء المحاولة مرة اخرى." },
-  
-    "shopping_complete_rental": { "other": "نجاح!" },
-    "shopping_complete_rental_period": {
-      "one": "يمكنك الآن مشاهدته بقدر ما تريد(ين) حتى اليوم التالي.",
-      "other": "يمكنك الآن المشاهدة قدر ما تريد(ين) على مدار الأيام الـ {{.Count}} القادمة."
-    },
-    "shopping_complete_purchase": { "other": "شكرًا لشراء {{.Title}}." },
-    "shopping_complete_credit_purchase": { "other": "شكرًا لشراء {{.Title}} ، تمت إضافة {{.CreditTotal}} إلى حسابك." },
-    "shopping_complete_purchase_coming_soon": { "other": "يمكن المشاهدة ابتداء من {{.Date}}." },
-    "shopping_complete_receipt": { "other": "تم إرسال الإيصال عبر البريد الإلكتروني." },
-    "shopping_complete_library_link": { "other": "عرض المكتبة" },
-    "shopping_complete_plan": {
-      "other": "لقد نجحت عملية شرائك لـ {{ .Title }}"
-    },
-    "shopping_complete_rental_watch_window_start": {
-      "one": "يمكن الآن بدء المشاهدة حتى اليوم التالي.",
-      "other": "يمكن الآن بدء المشاهدة في غضون الأيام الـ {{.Count}} القادمة."
-    },
-    "shopping_complete_rental_watch_window_end": {
-      "one": "عند بدء التشغيل ، يمكن المشاهدة قدر ما تريد(ين) لمدة ساعة واحدة.",
-      "other": "عند بدء التشغيل ، يمكن المشاهدة قدر ما تريد(ين) لمدة {{.Count}} ساعات."
-    },
-    "shopping_complete_rental_coming_soon": {
-      "one": "يمكن المشاهدة اعتبارًا من {{.Date}} وسيظل التأجير سار لمدة يوم.",
-      "other": "يمكن المشاهدة اعتبارًا من {{.Date}} وسيظل التأجير سار لمدة {{.Count}} أيام."
-    },
-    "shopping_complete_rental_coming_soon_watch_window_start": {
-      "one": "يمكن المشاهدة اعتبارًا من {{.Date}} وسيظل التأجير سار لمدة يوم.",
-      "other": "يمكن المشاهدة اعتبارًا من {{.Date}} وسيظل التأجير سار لمدة {{.Count}} أيام.."
-    },
-  
-    "shopping_action_rent": { "other": "تأجير" },
-    "shopping_action_buy": { "other": "شراء" },
-  
-    "shopping_payment_method_header": { "other": "طرق الدفع" },
-    "shopping_payment_method_credit_card": { "other": "بطاقة إئتمان" },
-    "shopping_payment_method_giropay": { "other": "جيروباي Giropay" },
-  
-    "shopping_error_stripe_unknown_error": { "other": "حدث خطأ ما فيعملية  الدفع. الرجاء معاودة المحاولة لاحقا." },
-    "shopping_error_payment_complete_failed": { "other": "تم رفض الدفعة. الرجاء إغلاق هذه النافذة والمحاولة مرة أخرى." },
-  
-    "meta_detail_cast_title": { "other": "الممثلين" },
-    "meta_detail_crew_title": { "other": "طاقم العمل" },
-    "meta_detail_languages": { "one": "اللغة", "other": "اللغات" },
-    "meta_detail_studios": { "one": "الاستديو", "other": "الاستوديوهات" },
-    "meta_detail_countries": { "one": "البلد", "other": "البلدان" },
-    "meta_detail_subtitles": { "other": "الترجمة" },
-    "meta_detail_captions": { "other": "الترجمة [CC]" },
-    "meta_detail_episodes_title": { "other": "الحلفات" },
-    "meta_detail_bonus_title": { "other": "محتوى إضافي" },
-    "meta_detail_recommendations_title": { "other": "قد يعجبك أيضا" },
-    "meta_detail_bundle_items_title": { "other": "المحتوى المتضمن في هذه الحزمة" },
-  
-    "bundle_items_all_films": { "other": "{{.Count}} أفلام" },
-    "bundle_items_all_seasons": { "other": "{{.Count}} مواسم" },
-    "bundle_items_mixed": { "other": "{{.Count}} أفلام ومواسم" },
-    "userwishlist_page_header": { "other": "قائمتي" },
-    "userwishlist_slider_header": { "other": "قائمتي" },
-    "userwishlist_empty_header":  { "other": "قائمتك فارغة." },
-    "userwishlist_empty_content": { "other": "تصفح(ي) <a href=\"{{.HomeURL}}\"> مجموعتنا الرائعة </a> واملأها." },
-    "userwishlist_button_add": { "other": "أضف إلى قائمتي" },
-    "userwishlist_button_remove": { "other": "قائمتي" },
-    "userwishlist_button_add_compact": { "other": "قائمتي" },
-    "userwishlist_button_remove_compact": { "other": "قائمتي" },
-  
-    "activatedevice_page_header": { "other": "تنشيط الجهاز" },
-    "activatedevice_page_content": { "other": "اتبع(ي) التعليمات الموجودة على جهازك للحصول على رمز PIN. يجب أن يكون كل من الكمبيوتر والجهاز متصلين بالإنترنت لتنشيطهما." },
-    "activatedevice_form_pin": { "other": "رمز PIN " },
-    "activatedevice_form_submit": { "other": "تفعيل" },
-    "activatedevice_form_error_invalid_code": { "other": "لم يتم العثور على رمز PIN ، الرجاء المحاولة مرة أخرى." },
-    "activatedevice_form_error_pin_not_found": { "other": "لم يتم العثور على رمز PIN ، الرجاء المحاولة مرة أخرى." },
-    "activatedevice_signin_prompt": { "other": "الرجاء تسجيل الدخول قبل تنشيط الجهاز." },
-    "activatedevice_page_activated": { "other": "شكرًا لتنشيط {{.DeviceName}}. يمكن الآن تصفح مكتبتك على التلفزيون أو الجهاز." },
-  
-    "userdevices_page_header": { "other": "الأجهزة" },
-    "userdevices_page_content": {
-      "one": "سيتم إضافة الأجهزة هنا تلقائيًا عند استخدامها. الرجاء التقيد بـ {{.Count}} أجهزة.",
-      "other": "سيتم إضافة الأجهزة هنا تلقائيًا عند استخدامها. الرجاء التقيد بـ {{.Count}} أجهزة."
-    },
-    "userdevices_empty_content": { "other": "لديك حاليا 0 أجهزة مسجلة." },
-    "userdevices_header_type": { "other": "نوع الجهاز" },
-    "userdevices_header_description": { "other": "وصف" },
-    "userdevices_device_added": { "other": "تمت الإضافة {{.Date}}" },
-    "userdevices_device_actions_delete": { "other": "إزالة" },
-    "userdevices_device_actions_cancel": { "other": "إلغاء" },
-    "userdevices_device_actions_confirm": { "other": "نعم ، القيام بإزالة الجهاز" },
-    "userdevices_device_deleted": { "other": "(تمت الإزالة)" },
-    "userdevices_delete_limits": { "other": "يمكن إزالة {{.Limit}} من الأجهزة من هذه القائمة كل {{.Period}} يوم (أيام)."},
-    "userdevices_delete_limit_reached": { "other": "لقد وصلت إلى الحد الأقصى  ولا يمكن إزالة أية أجهزة في الوقت الحالي. يمكنك حذف إحدى الأجهزة بعد {{.Days}} يوم (أيام)." },
-  
-    "playlist_page_header": { "other": "قائمة التشغيل" },
-    "playlist_sign_in_warning": { "other": "الرجاء تسجيل الدخول لمشاهدة البث التلفزيوني المباشر."},
-    "playlist_share_title": { "other": "الرجاء تسجيل الدخول لمشاهدة البث التلفزيوني المباشر." },
-    "playlist_up_next_title": { "other": "التالي" },
-  
-    "pricing_ownership_buy": { "other": "شراء" },
-    "pricing_ownership_rent": { "other": "إيجار" },
-  
-    "classification_intro": { "other": "تقييم: " },
-    "classification_divider": { "other": " - " },
-    "classification_outro": { "other": "" },
-  
-    "cookie_banner_message": { "other": "يستخدم هذا الموقع ملفات تعريف الارتباط لتحسين تجربتك. باستخدام هذا الموقع ، فإنك توافق على <a href=\"{{.CookiePolicyURL}}\"> استخدام ملفات تعريف الارتباط </a>." },
-    "cookie_banner_accept": { "other": "وافق" },
-  
-    "all_rights_reserved": { "other": "كل الحقوق محفوظة. لا يجوز إعادة إنتاج أي جزء من هذا الموقع دون إذن كتابي." },
-  
-    "users_gender_none": { "other": "غير محدد" },
-    "users_gender_female": { "other": "أنثى" },
-    "users_gender_male": { "other": "ذكر" },
-    "users_gender_diverse": { "other": "مختلف" },
-    "users_gender_other": { "other": "غير محدد" },
-  
-  
-    "pricing_quality_hd": { "other": "HD" },
-    "pricing_quality_sd": { "other": "SD" },
-    "pricing_quality_hd_only": { "other": "HD فقط" },
-    "pricing_quality_sd_only": { "other": "SD فقط" },
-  
-    "shopping_card_save_card": { "other": "احفظ(ي) هذه البطاقة لاستخدامها في المستقبل" },
-    "shopping_card_button_change": { "other": "إظهار كل البطاقات المحفوظة" },
-    "shopping_card_existing_description": { "other": "{{.Card.Brand}} بالرقم تنتهي {{.Card.Number}}" },
-    "shopping_card_existing_expiry": { "other": "(تنتهي صلاحيتها {{.Card.Expiry}})" },
-    "shopping_card_existing_expired": { "other": "(منتهية الصلاحية)" },
-    "shopping_card_use_other": { "other": "استخدام بطاقة جديدة" },
-    "shopping_card_use_new_card": { "other": "تغيير البطاقة" },
-    "shopping_card_update_reason_none": { "other": "لا يوجد سبب لتحديث بطاقة التسوق" },
-    "shopping_card_new_subscription": { "other": "سيتم حفظ هذه البطاقة وإعادة تعبئتها بانتظام" },
-    "shopping_card_change": { "other": "بطاقة الائتمان غير صحيحة؟ <a href=\"{{.SubscriptionsURL}}\"> انقر(ي) هنا لتحديث بطاقتك. </a>" },
-  
-    "shopping_info_ownership_plan": { "other": "الاشتراك" },
-  
-    "shopping_info_rental_period_coming_soon": { "other": "من تاريخ ووقت الإصدار." },
-
-    "usersubscriptions_change_payment_method_change": { "other": "تغيير بطاقة الائتمان" },
-    "usersubscriptions_change_payment_method_modal_title": { "other": "تحديث تفاصيل بطاقة الائتمان" },
-    "usersubscriptions_change_payment_method_modal_submit": { "other": "تحديث" },
-  
-    "usersubscriptions_subscription_expiry": { "other": "تنتهي {{.Expiry}}" },
-    "usersubscriptions_subscription_status_cancelled": { "other": "usersubscriptions_subscription_status_cancelled" },
-    "usersubscriptions_subscription_status_errored": { "other": "usersubscriptions_subscription_status_errored" },
-    "usersubscriptions_subscription_status_past_due": { "other": "usersubscriptions_subscription_status_past_due" },
-    "usersubscriptions_subscription_status_trialing": { "other": "فترة النسخة التجريبية" },
-    "usersubscriptions_subscription_unsubscribe": { "other": "إلغاء اشتراكي" },
-    "usersubscriptions_unsubscribe_modal_cancel": { "other": "يلغي" },
-    "usersubscriptions_unsubscribe_modal_confirm": { "other": "نعم ، إلغاء اشتراكي" },
-    "usersubscriptions_unsubscribe_modal_title": { "other": "إلغاء الاشتراك؟" },
-    "usersubscriptions_unsubscribe_modal_body": { "other": "سيؤدي هذا إلى إلغاء الاشتراك في خطة {{.Name}}. ستظل قادرًا على مشاهدة المحتوى في الخطة حتى انتهاء صلاحيتها {{.Expiry}}." },
-  
-  
-    "availability_coming_soon": { "other": "قريبا" },
-    "availability_renting": { "other": "إيجار" },
-    "availability_not_available": { "other": "غير متوفر" },
-    "availability_in_watch_window": { "other": "التوفر في مدة المشاهدة" },
-    "availability_sold_out": { "other": "نفذ" },
-    "availability_available_till": { "other": "متوفر حتى {{.ExpiryDate}}" },
-    "availability_not_available_in_country": { "other": "غير متاح في بلدك" },
-    "availability_available": { "other": "متوفر في {{.ReleaseDate}}" },
-    "availability_expires": { "other": "تنتهي الصلاحية في {{.Expiry}}" },
-    "availability_expired": { "other": "منتهي الصلاحية"},
-  
-    "modal_cancel": { "other": "إلغاء" },
-  
-    "play": { "other": "تشغيل" },
-  
-    "combined_auth_signin_prompt": { "other": "تسجيل الدخول" },
-    "combined_auth_signup_prompt": { "other": "اشتراك" },
-    "combined_auth_terms": { "other": "أوافق على جميع <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\"> البنود & amp؛ الشروط </a>." },
-    "signup_terms": { "other": "أوافق على جميع <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\"> البنود & amp؛ الشروط </a>." },
-    "validation_terms_required": { "other": "يجب الموافقة على الاحكام والشروط." },
-    "shopping_error_item_limit_exceeded": { "other": "للأسف ، لقد نفذ {{.Title}}." },
-  
-    "changepincode_modal_header": { "other": "بتغيير رقم التعريف الشخصي PIN" },
-    "changepincode_modal_currentpassword": { "other": "كلمة السر الحالية " },
-    "changepincode_modal_pincode1": { "other": "رقم التعريف الشخصي PIN الجديد المكون من 4 أرقام" },
-    "changepincode_modal_pincode2": { "other": "تأكيد رقم التعريف الشخصي PIN الجديد المكون من 4 أرقام" },
-    "changepincode_modal_submit": { "other": "تعيين رقم التعريف الشخصي PIN" },
-    "changepincode_modal_error_wrong_password": { "other": "كلمة المرورغير صحيحة." },
-  
-    "user_set_pin_intro": { "other": "أنت بحاجة إلى رقم تعريف شخصي PIN  ل {{.Action}} المحتوى المحظور"},
-    "user_error_wrong_pin_reset": { "other": "انقر(ي) هنا لإعادة تعيين رقم التعريف الشخصي PIN الخاص بك" },
-    "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-    "shopping_error_age_restricted": { "other": "هذا المحتوى مقيد بالفئة العمرية." },
-    "shopping_error_close_button": { "other": "نعم" },
-  
-    "wcag_skip_links_header": { "other": "روابط الوصول" },
-    "wcag_skip_links_content": { "other": "روابط الوصول" },
-  
-    "wcag_homepage_h1": { "other": "الصفحة الرئيسية" },
-    "wcag_carousel_h2": { "other": "المشاركات الدائرية" },
-    "wcag_collections_h2": { "other": "المجموعات" },
-  
-    "wcag_aria_label_footer": { "other": "أسفل الصفحة" },
-    "wcag_aria_label_nav_main": { "other": "الرئيسية" },
-    "wcag_aria_label_nav_sub": { "other": "الفرعية" },
-    "wcag_aria_label_toggle_nav": { "other": "تبديل التنقل" },
-    "wcag_aria_label_bundle_items": { "other": "عناصر الحزمات" },
-    "wcag_aria_label_carousel": { "other": "المشاركات الدائرية" },
-    "wcag_aria_label_page_collection": { "other": "صفحة المجموعات" },
-    "wcag_aria_label_collection_list": { "other": "لائحة المجموعات" },
-    "wcag_aria_label_collection_slider": { "other": "شريط تمرير المجموعات" },
-    "wcag_aria_label_wishlist": { "other": "قائمة الرغبات" },
-    "wcag_aria_label_facebook": { "other": "انشر على الفيسبوك" },
-    "wcag_aria_label_twitter": { "other": "انشر على تويتر" },
-    "wcag_aria_label_linkedin": { "other": "انشر على لينكد ان" },
-
-    "shopping_price_title_plan": {
-        "other": "سعر"
-    },
-    "shopping_price_plan_note": {
-        "zero": "اتهم كل {{ .Interval }} .",
-        "one": "يتم تحصيل الرسوم كل {{ .Interval }} بعد انتهاء الفترة التجريبية المجانية لمدة 24 ساعة.",
-        "other": "يتم تحصيل الرسوم كل {{ .Interval }} بعد انتهاء {{ .Count }} التجريبية المجانية .Count يوم."
-    },
-    "shopping_price_plan_note_interval": {
-        "one": "{{ .Interval }}",
-        "other": "{{ .Count }} {{ .Interval }}"
-    },
-    "shopping_enter_card_prompt_plan": {
-        "other": "أدخل تفاصيل بطاقة الائتمان الخاصة بك أدناه لبدء اشتراكك."
-    },
-    "shopping_action_plan": {
-        "other": "مكتمل"
-    },
-    "shopping_action_credit": { "other": "فوق حتى" },
-    "shopping_complete_subscription": {
-        "other": "تم شراء اشتراكك بنجاح. أنت الآن مشترك في {{ .Title }} ."
-    },
-    "shopping_complete_subscription_browse": {
-        "other": "لا تتردد في <a href=\"/\">تصفح</a> الموقع ، أو <a href=\"/search.html\">البحث</a> عن شيء محدد."
-    },
-    "shopping_info_plan_offer": {
-        "one": "يجدد تلقائيا كل. {{ .Interval }}",
-        "other": "يجدد تلقائيا كل {{ .Count }} {{ .Interval }}"
-    },
-    "shopping_info_trial_period_offer": {
-        "one": "جرب الإصدار التجريبي المجاني لمدة 24 ساعة الآن!",
-        "other": "{{ .Count }} التجريبي المجاني من {{ .Count }} day!"
-    },
-    "plans_page_header": {
-        "other": "الخطط المتاحة"
-    },
-    "plan_label_owned": {
-        "other": "أنت تملك هذه الخطة"
-    },
-    "plan_expiry_date": {
-        "other": "إغلاق المبيعات:"
-    },
-    "plan_read_more": {
-        "other": "اكتشف المزيد"
-    },
-    "plan_page_read_more": {
-        "other": "اقرأ أكثر"
-    },
-    "plan_page_header_text": {
-        "other": "استمتع {{ .Name }}"
-    },
-    "page_plan_explore_intro": {
-        "other": "أو"
-    },
-    "page_plan_explore_link": {
-        "other": "استكشف ممرات أخرى"
-    },
-    "plan_showcase_page_ownership_button_buy": {
-        "other": "اشتري الآن"
-    },
-    "plan_free_link_text": {
-      "other": "سجل مجانا"
-    },
-
-    "awards_in_competition": {
-      "other": "في المنافسة"
-    },
-    "donate_button_text": {
-      "other": "يتبرع"
-    },
-    "shopping_error_plan_already_owned": { "other": "لديك بالفعل هذه الخطة" },
-    "shopping_error_plan_expired": { "other": "هذه الخطة لم تعد متوفرة" },
-
-    "wcag_aria_label_letterboxd": { "other": "عرض على Letterboxd" },
-
-    "header_banner": { "other": "سينما ABC - مهرجان الفيلم الحادي والعشرون ، 1-6 يونيو 2021" },
-    "app_badge_title": { "other": "قم بتنزيل التطبيق لعرض المحتوى الذي اشتريته!" },
-    "app_badge_ios": { "other": "قم بالتحميل من متجر البرامج" },
-    "app_badge_android": { "other": "احصل عليه من متجر جوجل للتطبيقات" },
-
-    "awards_winner": { "other": "الفائز" }
-
-  } 
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "إعدادات"
+  },
+  "powered_by": {
+    "other": "مشغل بواسطة"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "بالشراكة مع/ بالتعاون مع"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "إنجليزي"
+  },
+  "fr": {
+    "other": "الفرنسية"
+  },
+  "episode_name": {
+    "other": "حلقة"
+  },
+  "season_name": {
+    "other": "موسم"
+  },
+  "seasons": {
+    "one": "مواسم",
+    "other": "{{.Count}} مواسم"
+  },
+  "tvseason": {
+    "other": "مسلسل {{.ShowInfo.Title}} {{.Season.SeasonNumber}}"
+  },
+  "tvseason_html": {
+    "other": "<span>{{.Season.SeasonNumber}}</span> مسلسل {{.ShowInfo.Title}}"
+  },
+  "tvepisode": {
+    "other": "{{.Episode.Title}}"
+  },
+  "tvseason_number": {
+    "other": "مسلسل {{.Season.SeasonNumber}}"
+  },
+  "episode_count": {
+    "one": "حلقة واحدة ",
+    "other": "{{.Count}} حلقات"
+  },
+  "date_day": {
+    "other": "يوم"
+  },
+  "date_month": {
+    "other": "شهر"
+  },
+  "date_year": {
+    "other": "سنة"
+  },
+  "404_page_header": {
+    "other": "هذه الصفحة غير موجودة ...."
+  },
+  "404_page_content": {
+    "other": "<p> المعذرة ، يبدو أن الصفحة التي تبحث عنها غير موجودة. </ p> <p> ربما تم نقلها أو حذفها ، أو ربما أخطأت في الكتابة. </ p> <p> حاول العودة إلى الصفحة الرئيسية للعثور على ما كنت تبحث عنه. </ p> <p> <a href=\"{{.URL}}\"> الرجوع إلى الصفحة الرئيسية </a> </p>>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "تسجيل الدخول"
+  },
+  "nav_signup": {
+    "other": "إنشاء حساب"
+  },
+  "nav_signed_in_as": {
+    "other": "تسجيل الدخول بصفة / تسجيل الدخول من حساب / تسجيل الدخول بإسم"
+  },
+  "nav_library": {
+    "other": "المدوّنة"
+  },
+  "nav_devices": {
+    "other": "أجهزتي"
+  },
+  "nav_wishlist": {
+    "other": "قائمتي"
+  },
+  "nav_account": {
+    "other": "حسابي"
+  },
+  "nav_signout": {
+    "other": "تسجيل الخروج"
+  },
+  "play_trailer": {
+    "other": "إعلان ترويجي"
+  },
+  "runtime_hours": {
+    "other": "ساعة"
+  },
+  "runtime_minutes": {
+    "other": "دقيقة"
+  },
+  "datetime_today": {
+    "other": "اليوم {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "غداً {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "البارحة {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "{{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "البحث"
+  },
+  "search_control_submit": {
+    "other": "تأكيد البحث"
+  },
+  "play_button_watch": {
+    "other": "شاهد الآن"
+  },
+  "play_button_resume": {
+    "other": "تابع "
+  },
+  "social_media_buttons_title": {
+    "other": "النشر "
+  },
+  "social_media_buttons_facebook": {
+    "other": "انشر في الفيسبوك"
+  },
+  "social_media_buttons_twitter": {
+    "other": "حصة على التغريد"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "انشر على لينكد إن"
+  },
+  "social_media_buttons_email": {
+    "other": "سهم عبر البريد الإلكتروني"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "مشاركة الارتباط"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "تم نسخ الرابط إلى الحافظة!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "نسخ إلى الحافظة"
+  },
+  "accept_invite_page_header": {
+    "other": "أهلا بك"
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "يبدو أنك طالبت بهذه الدعوة من قبل ، يجب عليك <a href=\"{{.SigninURL}}\"> تسجيل الدخول </a> بدلاً من ذلك. إذا نسيت كلمة المرور ، فيمكنك أيضًا <a href=\"{{.ForgotPasswordURL}}\"> إعادة تعيين كلمة المرور </a>."
+  },
+  "acceptinvite_complete": {
+    "other": "شكراً لك. لقد تم إنشاء حسابك."
+  },
+  "acceptinvite_form_submit": {
+    "other": "قبول الدعوة"
+  },
+  "acceptinvite_agreement": {
+    "other": "بالضغط على ، فإنك توافق على أنك قد قرأت وفهمت <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">بنود & amp؛ و شروط </a> و <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\"> سياسة الخصوصية </a>."
+  },
+  "signup_page_header": {
+    "other": "انشاء حساب جديد"
+  },
+  "signup_form_name": {
+    "other": "الإسم"
+  },
+  "signup_form_email": {
+    "other": "عنوان البريد الإلكتروني"
+  },
+  "signup_form_password": {
+    "other": "كلمة المرور"
+  },
+  "signup_form_password_confirmation": {
+    "other": "تأكيد كلمة المرور"
+  },
+  "signup_form_gender": {
+    "other": "الجنس"
+  },
+  "signup_form_dob": {
+    "other": "تاريخ الولادة"
+  },
+  "signup_form_submit": {
+    "other": "إرسال"
+  },
+  "signin_page_header": {
+    "other": "تسجيل الدخول"
+  },
+  "signin_form_email": {
+    "other": "عنوان البريد الإلكتروني"
+  },
+  "signin_form_password": {
+    "other": "كلمه المرور"
+  },
+  "signin_form_remember": {
+    "other": "تذكرني"
+  },
+  "signin_form_submit": {
+    "other": "إرسال"
+  },
+  "signin_page_forgotpassword": {
+    "other": "هل نسيت كلمة المرور؟"
+  },
+  "signin_page_createnewaccount": {
+    "other": "ليس لديك حساب؟ انشاء حساب جديد"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "لديك حساب؟ تسجيل الدخول"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "تم إستخدام هذا البريد الإلكتروني مسبقاً."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "خطأ في عنوان البريد الإلكتروني أو كلمة المرور."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "لقد فشلت في تسجيل الدخول عدة مرات. الرجاء معاودة المحاولة في وقت لاحق."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "لقد تم إيقاف حسابك مؤقتا. يرجى الاتصال بمدير الموقع إذا كنت تعتقد(ين) أن هناك خطأ."
+  },
+  "signup_form_error_forbidden": {
+    "other": "حدث خطأ."
+  },
+  "combined_auth_continue": {
+    "other": "إكمال"
+  },
+  "combined_auth_change": {
+    "other": "تغيير"
+  },
+  "combined_auth_signin": {
+    "other": "تسجيل الدخول"
+  },
+  "combined_auth_signup": {
+    "other": "التسجيل"
+  },
+  "combined_auth_signin_password": {
+    "other": "الرجاء إدخال كلمة المرور الخاصة بك لتسجيل الدخول إلى حسابك."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "كلمة المرور هذه غير صحيحة."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "حدث خطأ."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "هنالك طلبات كثيرة، الرجاء المحاولة لاحقا."
+  },
+  "forgotpassword_page_header": {
+    "other": "تغيير كلمة المرور"
+  },
+  "forgotpassword_form_email": {
+    "other": "عنوان البريد الإلكتروني"
+  },
+  "forgotpassword_form_submit": {
+    "other": "تغيير"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "لا يوجد حساب بهذا العنوان البريد الإلكتروني."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "تم تعليق هذا الحساب."
+  },
+  "forgotpassword_complete": {
+    "other": "شكراً لك. سوف يصلك قريباً  بريد إلكتروني لإعادة تعيين كلمة المرور."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "حدث خطأ."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "هنالك طلبات كثيرة، الرجاء المحاولة لاحقا."
+  },
+  "resetpassword_page_header": {
+    "other": "تغيير كلمة المرور الخاصة بك"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "يبدو أن طلب إعادة تعيين كلمة المرور هذا غير صالح ، يرجى ملء نموذج <a href=\"{{.URL}}\"> نسيت كلمة المرور </a> مرة أخرى."
+  },
+  "resetpassword_form_password": {
+    "other": "كلمة المرور الجديدة "
+  },
+  "resetpassword_form_password2": {
+    "other": "تأكيد كلمة المرور الجديدة الخاصة بك"
+  },
+  "resetpassword_form_submit": {
+    "other": "تغيير"
+  },
+  "resetpassword_complete": {
+    "other": "شكراً لك. تم تغيير كلمة المرور الخاصة بك وتم تسجيل دخولك."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "طلب إعادة تعيين كلمة المرور غير صالح. الرجاء معاودة المحاولة لاحقا."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "انتهت صلاحية الرمز. الرجاء إعادة الطلب."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "هنالك طلبات كثيرة، الرجاء المحاولة لاحقا."
+  },
+  "account_page_header": {
+    "other": "حسابي"
+  },
+  "account_form_name": {
+    "other": "الإسم"
+  },
+  "account_form_email": {
+    "other": "العنوان الالكتروني"
+  },
+  "account_form_password": {
+    "other": "كلمة المرور"
+  },
+  "account_form_change_password": {
+    "other": "تغيير"
+  },
+  "account_form_gender": {
+    "other": "الجنس"
+  },
+  "account_form_dob": {
+    "other": "تاريخ الولادة"
+  },
+  "account_form_submit": {
+    "other": "تحديث"
+  },
+  "account_form_submitted": {
+    "other": "تم التحديث"
+  },
+  "account_form_password_changed": {
+    "other": "تم التحديث"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "كلمة المرور هذه غير صحيحة"
+  },
+  "account_form_pin_code": {
+    "other": "الرمز PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "ليس لديك رمز PIN ، وهو مطلوب لشراء بعض الأفلام واستئجارها ومشاهدتها."
+  },
+  "account_form_set_pin": {
+    "other": "ضبط رمز PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "تم التحديث"
+  },
+  "account_form_change_pin": {
+    "other": "تعديل الرمز PIN"
+  },
+  "user_set_pin_header": {
+    "other": "ضبط رمز PIN"
+  },
+  "user_set_pin_button": {
+    "other": "ضبط رمز PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "أدخل رقم التعريف الشخصي لـ {{.Action}} هذا المحتوى مقيد"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "رقم التعريف الشخصي غير صحيح"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p> يبدو أنك تواجه مشكلة. </ p> <p> أعد تعيين رقم التعريف الشخصي أو اتصل بنا <a href=\"{{.HelpURL}}\" target=\"_blank\"> للمساعدة </a>"
+  },
+  "user_submit_pin_button": {
+    "other": "أدخل"
+  },
+  "user_reset_pin_button": {
+    "other": "إعادة ضبط رمز PIN"
+  },
+  "signup_form_optin": {
+    "other": "اشترك(ي) في نشرةنا الإلكترونية مجانا"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "تأكيد كلمة المرور"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "الرجاء إدخال كلمة المرور لتحديث التغييرات "
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "تأكيد"
+  },
+  "changepassword_modal_header": {
+    "other": "تغيير كلمة المرور"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "كلمة المرور الحالية"
+  },
+  "changepassword_modal_password": {
+    "other": "كلمة المرور الجديدة"
+  },
+  "changepassword_modal_password2": {
+    "other": "تأكيد كلمة المرور"
+  },
+  "changepassword_modal_submit": {
+    "other": "تحديث"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "كلمة المرور غير صحيحة"
+  },
+  "userlibrary_page_header": {
+    "other": "مكتبتي"
+  },
+  "userlibrary_empty_header": {
+    "other": "مكتبتك فارغة"
+  },
+  "userlibrary_empty_content": {
+    "other": "تصفح(ي) <a href=\"{{.HomeURL}}\"> مجموعتنا الرائعة </a> واملأها."
+  },
+  "searchresults_page_header": {
+    "other": "نتائج البحث"
+  },
+  "searchresults_load_more": {
+    "other": "تحميل {{.Count}} أكثر"
+  },
+  "searchresults_total": {
+    "one": "تم العثور على {{.Count}} نتائج لـ \"{{.Query}}\".",
+    "other": "تم العثور على {{.Count}} نتائج لـ  \"{{.Query}}\"."
+  },
+  "searchresults_empty_header": {
+    "other": "لا توجد نتائج بحث عن \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "جرّب بحثًا آخر أو <a href=\"{{.HomeURL}}\"> تصفح المحتوى الخاص بنا </a> للعثور على ما تبحث عنه."
+  },
+  "validation_name_required": {
+    "other": "الرجاء إدخال الإسم"
+  },
+  "validation_email_required": {
+    "other": "الرجاء إدخال العنوان الإلكتروني"
+  },
+  "validation_email_email": {
+    "other": "الرجاء إدخال عنوان إلكتروني صالح"
+  },
+  "validation_currentpassword_required": {
+    "other": "الرجاء إدخال كلمة المرور الحالية"
+  },
+  "validation_password_required": {
+    "other": "الرجاء إدخال كلمة مرور"
+  },
+  "validation_password2_required": {
+    "other": "الرجاء تأكيد كلمة المرور"
+  },
+  "validation_password2_match": {
+    "other": "كلمات السر الخاصة بك لا تتطابق."
+  },
+  "validation_password_minlength": {
+    "other": "الرجاء إدخال {{.Count}} أحرف على الأقل."
+  },
+  "validation_promocode_required": {
+    "other": "الرجاء إدخال الرمز الترويجي."
+  },
+  "validation_pincode_required": {
+    "other": "الرجاء إدخال رمز PIN."
+  },
+  "validation_pincode1_required": {
+    "other": "الرجاء إدخال رمز PIN صالح."
+  },
+  "validation_pincode2_required": {
+    "other": "الرجاء إدخال رمز PIN صالح."
+  },
+  "validation_pincode1_pattern": {
+    "other": "الرجاء إدخال رمز PIN صالح."
+  },
+  "validation_pincode2_pattern": {
+    "other": "الرجاء إدخال رمز PIN صالح."
+  },
+  "validation_pincode2_match": {
+    "other": "رمز PIN غير متطابق."
+  },
+  "validation_gender_required": {
+    "other": "الرجاء اختيار الجنس"
+  },
+  "validation_dob_required": {
+    "other": "الرجاء ادخال تاريخ الولادة"
+  },
+  "validation_dob_date": {
+    "other": "الرجاء ادخال تاريخ ولادة صالح"
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "فيديو عالي الدقة HD حسب الطلب"
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "فيديو  SD حسب الطلب"
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "يمكن استخدام الرصيد في محفظتك لشراء أو استئجار أي محتوى على ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "انظر هنا لمتطلبات النظام."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "شراء"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "استئجار"
+  },
+  "shopping_info_sd_only": {
+    "other": "يقتصر على تشغيل SD فقط."
+  },
+  "shopping_info_release_date_title": {
+    "other": "الإصدارات  {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "يمكنك الاستئجار الآن ، لكنك لن تتمكن من المشاهدة حتى ذلك الحين."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "يمكنك الشراء الآن ، لكنك لن تتمكن من المشاهدة حتى ذلك الحين."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "صالح لغاية {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "لن تتمكن من عرض المحتوى بعد ذلك."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "لن تتمكن من عرض المحتوى بعد ذلك."
+  },
+  "duration_hour": {
+    "one": "1 ساعة",
+    "other": "{{.Count}} ساعة"
+  },
+  "duration_day": {
+    "one": "1 يوم",
+    "other": "{{.Count}} يوما"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "تأجير لمدة {{.ValueUnit}} "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "تشغيل لمدة {{.Count}} ساعة. "
+  },
+  "shopping_info_watch_window_explanation_film": {
+    "one": "عند الاستئجار، سيكون الفيلم متاحًا في حسابك لمدة {{.ValueUnit}}.",
+    "other": "عند الاستئجار، سيكون الفيلم متاحًا في حسابك لمدة {{.ValueUnit}}."
+  },
+  "shopping_info_watch_window_explanation2_film": {
+    "one": "عند الضغط على تشغيل، يمكنك مشاهدة الفيلم عدة مرات لمدة ساعة واحدة. ",
+    "other": "عند الضغط على تشغيل، يمكنك مشاهدة الفيلم عدة مرات لمدة {{.Count}} ساعات. "
+  },
+  "shopping_info_watch_window_explanation_bundle": {
+    "one": "عند الاستئجار ، ستكون العناصر الموجودة في حزمتك متوفرة في حسابك لمدة يوم واحد. ",
+    "other": "عند الاستئجار ، ستكون العناصر الموجودة في حزمتك متوفرة في حسابك لمدة {{.Count}} أيام. "
+  },
+  "shopping_info_watch_window_explanation2_bundle": {
+    "one": "عند الضغط على تشغيل فيلم معين ، يمكنك مشاهدته عدة مرات لمدة ساعة واحدة",
+    "other": "عند الضغط على تشغيل فيلم معين ، يمكنك مشاهدته عدة مرات لمدة {{.Count}} ساعات"
+  },
+  "shopping_info_watch_window_explanation_season": {
+    "one": "عند الاستئجار ، سيكون الموسم متاحًا في حسابك لمدة يوم واحد. ",
+    "other": "عند الاستئجار ، سيكون الموسم متاحًا في حسابك لمدة {{.Count}} أيام. "
+  },
+  "shopping_info_watch_window_explanation2_season": {
+    "one": "عند الضغط على التشغيل لإحدى الحلقات، تبدأ فترة المشاهدة لمدة {{.Count}} ساعات يمكنك خلالها مشاهدة تلك الحلقة عدة مرات.",
+    "other": "عند الضغط على التشغيل لإحدى الحلقات، تبدأ فترة المشاهدة لمدة {{.Count}} ساعات يمكنك خلالها مشاهدة تلك الحلقة عدة مرات."
+  },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}٪ مكافأة"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "أدخل تفاصيل بطاقتك الائتمانية أدناه لإكمال {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "بإكمال هذه المعاملة ، أوافق على <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\"> البنود والشروط </a>."
+  },
+  "shopping_discount_applied": {
+    "other": "تم تطبيق الخصم {{.DiscountAmount}}."
+  },
+  "shopping_discount_apply": {
+    "other": "تطبيق"
+  },
+  "shopping_discount_code": {
+    "other": "أدخل الرمز الترويجي."
+  },
+  "shopping_discount_have_code": {
+    "other": "لدي رمز ترويجي."
+  },
+  "shopping_price_you_pay": {
+    "other": "دفع"
+  },
+  "shopping_price_nothing": {
+    "other": "لا شيء"
+  },
+  "shopping_price_free": {
+    "other": "مجاني"
+  },
+  "shopping_auth_directions": {
+    "other": "يجب إنشاء حساب حساب أولا. الرجاء إدخال العنوان الإلكتروني."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} موجود في مكتبتك."
+  },
+  "shopping_error_missing_card": {
+    "other": "الرجاء إدخال تفاصيل بطاقة الائتمان."
+  },
+  "shopping_error_title": {
+    "other": "حدث خطأ"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "الرجاء إدخال رمز CVV صالح."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "الرجاء إدخال رمز CVV صالح."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "الرجاء إدخال رقم بطاقة ائتمان صالحة."
+  },
+  "shopping_error_invalid_number": {
+    "other": "الرجاء إدخال رقم بطاقة ائتمان صالحة."
+  },
+  "shopping_error_card_declined": {
+    "other": "تم رفض بطاقة الائتمان."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "الرجاء إدخال تاريخ انتهاء صالح."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "الرجاء إدخال تاريخ انتهاء صالح."
+  },
+  "shopping_error_expired_card": {
+    "other": "انتهت صلاحية بطاقة الائتمان."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "لم تكتمل {{.Ownership}}. يجب التواجد في البلد الذي تم إصدار البطاقة الائتمانية فيه. الرجاء استخدام بطاقة أخرى لإجراء الدفع."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "لم تكتمل {{.Ownership}}. لقد اكتشفنا استخدامكم لخدمة فك تشفير أو خدمة وكيل Proxy. الرجاء إيقاف تشغيل أي من هذه الخدمات وحاول مرة أخرى."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "لم يعد من الممكن استخدام هذا الرمز الترويجي."
+  },
+  "shopping_error_discount_blank": {
+    "other": "الرجاء إدخال الرمز الترويجي."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "الرجاء إدخال رمز ترويجي صالح."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "الرجاء إدخال رمز ترويجي صالح."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "الرجاء إدخال رمز ترويجي صالح."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "سبق وتم استخدام رمز ترويجي لهذه الجلسة."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "تم استخدام هذا الرمز الترويجي سابقا."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "تم استخدام هذا الرمز الترويجي سابقا."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "لم يعد من الممكن استخدام هذا الرمز الترويجي."
+  },
+  "shopping_error_discount_expired": {
+    "other": "انتهت صلاحية هذا الرمز الترويجي."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "لا يمكن استخدام هذا الرمز الترويجي عند الشراء."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "لا يمكن استخدام هذا الرمز الترويجي عند الاستئجار."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "لا يمكن استخدام هذا الرمز الترويجي مع هذا العنصر."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "لا يمكن استخدام هذا الرمز الترويجي في بلدك."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "لا يمكن استخدام هذا الرمز الترويجي."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "لا يمكن استخدام هذا الرمز الترويجي للباقات."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "تم رفض بطاقة الائتمان. الرجاء المحاولة مرة اخرى."
+  },
+  "shopping_complete_rental": {
+    "other": "نجاح!"
+  },
+  "shopping_complete_rental_period": {
+    "one": "يمكنك الآن مشاهدته بقدر ما تريد(ين) حتى اليوم التالي.",
+    "other": "يمكنك الآن المشاهدة قدر ما تريد(ين) على مدار الأيام الـ {{.Count}} القادمة."
+  },
+  "shopping_complete_purchase": {
+    "other": "شكرًا لشراء {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "شكرًا لشراء {{.Title}} ، تمت إضافة {{.CreditTotal}} إلى حسابك."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "يمكن المشاهدة ابتداء من {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "تم إرسال الإيصال عبر البريد الإلكتروني."
+  },
+  "shopping_complete_library_link": {
+    "other": "عرض المكتبة"
+  },
+  "shopping_complete_plan": {
+    "other": "لقد نجحت عملية شرائك لـ {{ .Title }}"
+  },
+  "shopping_complete_rental_watch_window_start": {
+    "one": "يمكن الآن بدء المشاهدة حتى اليوم التالي.",
+    "other": "يمكن الآن بدء المشاهدة في غضون الأيام الـ {{.Count}} القادمة."
+  },
+  "shopping_complete_rental_watch_window_end": {
+    "one": "عند بدء التشغيل ، يمكن المشاهدة قدر ما تريد(ين) لمدة ساعة واحدة.",
+    "other": "عند بدء التشغيل ، يمكن المشاهدة قدر ما تريد(ين) لمدة {{.Count}} ساعات."
+  },
+  "shopping_complete_rental_coming_soon": {
+    "one": "يمكن المشاهدة اعتبارًا من {{.Date}} وسيظل التأجير سار لمدة يوم.",
+    "other": "يمكن المشاهدة اعتبارًا من {{.Date}} وسيظل التأجير سار لمدة {{.Count}} أيام."
+  },
+  "shopping_complete_rental_coming_soon_watch_window_start": {
+    "one": "يمكن المشاهدة اعتبارًا من {{.Date}} وسيظل التأجير سار لمدة يوم.",
+    "other": "يمكن المشاهدة اعتبارًا من {{.Date}} وسيظل التأجير سار لمدة {{.Count}} أيام.."
+  },
+  "shopping_action_rent": {
+    "other": "تأجير"
+  },
+  "shopping_action_buy": {
+    "other": "شراء"
+  },
+  "shopping_payment_method_header": {
+    "other": "طرق الدفع"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "بطاقة إئتمان"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "جيروباي Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "حدث خطأ ما فيعملية  الدفع. الرجاء معاودة المحاولة لاحقا."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "تم رفض الدفعة. الرجاء إغلاق هذه النافذة والمحاولة مرة أخرى."
+  },
+  "meta_detail_cast_title": {
+    "other": "الممثلين"
+  },
+  "meta_detail_crew_title": {
+    "other": "طاقم العمل"
+  },
+  "meta_detail_languages": {
+    "one": "اللغة",
+    "other": "اللغات"
+  },
+  "meta_detail_studios": {
+    "one": "الاستديو",
+    "other": "الاستوديوهات"
+  },
+  "meta_detail_countries": {
+    "one": "البلد",
+    "other": "البلدان"
+  },
+  "meta_detail_subtitles": {
+    "other": "الترجمة"
+  },
+  "meta_detail_captions": {
+    "other": "الترجمة [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "الحلفات"
+  },
+  "meta_detail_bonus_title": {
+    "other": "محتوى إضافي"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "قد يعجبك أيضا"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "المحتوى المتضمن في هذه الحزمة"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} أفلام"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} مواسم"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} أفلام ومواسم"
+  },
+  "userwishlist_page_header": {
+    "other": "قائمتي"
+  },
+  "userwishlist_slider_header": {
+    "other": "قائمتي"
+  },
+  "userwishlist_empty_header": {
+    "other": "قائمتك فارغة."
+  },
+  "userwishlist_empty_content": {
+    "other": "تصفح(ي) <a href=\"{{.HomeURL}}\"> مجموعتنا الرائعة </a> واملأها."
+  },
+  "userwishlist_button_add": {
+    "other": "أضف إلى قائمتي"
+  },
+  "userwishlist_button_remove": {
+    "other": "قائمتي"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "قائمتي"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "قائمتي"
+  },
+  "activatedevice_page_header": {
+    "other": "تنشيط الجهاز"
+  },
+  "activatedevice_page_content": {
+    "other": "اتبع(ي) التعليمات الموجودة على جهازك للحصول على رمز PIN. يجب أن يكون كل من الكمبيوتر والجهاز متصلين بالإنترنت لتنشيطهما."
+  },
+  "activatedevice_form_pin": {
+    "other": "رمز PIN "
+  },
+  "activatedevice_form_submit": {
+    "other": "تفعيل"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "لم يتم العثور على رمز PIN ، الرجاء المحاولة مرة أخرى."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "لم يتم العثور على رمز PIN ، الرجاء المحاولة مرة أخرى."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "الرجاء تسجيل الدخول قبل تنشيط الجهاز."
+  },
+  "activatedevice_page_activated": {
+    "other": "شكرًا لتنشيط {{.DeviceName}}. يمكن الآن تصفح مكتبتك على التلفزيون أو الجهاز."
+  },
+  "userdevices_page_header": {
+    "other": "الأجهزة"
+  },
+  "userdevices_page_content": {
+    "one": "سيتم إضافة الأجهزة هنا تلقائيًا عند استخدامها. الرجاء التقيد بـ {{.Count}} أجهزة.",
+    "other": "سيتم إضافة الأجهزة هنا تلقائيًا عند استخدامها. الرجاء التقيد بـ {{.Count}} أجهزة."
+  },
+  "userdevices_empty_content": {
+    "other": "لديك حاليا 0 أجهزة مسجلة."
+  },
+  "userdevices_header_type": {
+    "other": "نوع الجهاز"
+  },
+  "userdevices_header_description": {
+    "other": "وصف"
+  },
+  "userdevices_device_added": {
+    "other": "تمت الإضافة {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "إزالة"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "إلغاء"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "نعم ، القيام بإزالة الجهاز"
+  },
+  "userdevices_device_deleted": {
+    "other": "(تمت الإزالة)"
+  },
+  "userdevices_delete_limits": {
+    "other": "يمكن إزالة {{.Limit}} من الأجهزة من هذه القائمة كل {{.Period}} يوم (أيام)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "لقد وصلت إلى الحد الأقصى  ولا يمكن إزالة أية أجهزة في الوقت الحالي. يمكنك حذف إحدى الأجهزة بعد {{.Days}} يوم (أيام)."
+  },
+  "playlist_page_header": {
+    "other": "قائمة التشغيل"
+  },
+  "playlist_sign_in_warning": {
+    "other": "الرجاء تسجيل الدخول لمشاهدة البث التلفزيوني المباشر."
+  },
+  "playlist_share_title": {
+    "other": "الرجاء تسجيل الدخول لمشاهدة البث التلفزيوني المباشر."
+  },
+  "playlist_up_next_title": {
+    "other": "التالي"
+  },
+  "pricing_ownership_buy": {
+    "other": "شراء"
+  },
+  "pricing_ownership_rent": {
+    "other": "إيجار"
+  },
+  "classification_intro": {
+    "other": "تقييم: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "يستخدم هذا الموقع ملفات تعريف الارتباط لتحسين تجربتك. باستخدام هذا الموقع ، فإنك توافق على <a href=\"{{.CookiePolicyURL}}\"> استخدام ملفات تعريف الارتباط </a>."
+  },
+  "cookie_banner_accept": {
+    "other": "وافق"
+  },
+  "all_rights_reserved": {
+    "other": "كل الحقوق محفوظة. لا يجوز إعادة إنتاج أي جزء من هذا الموقع دون إذن كتابي."
+  },
+  "users_gender_none": {
+    "other": "غير محدد"
+  },
+  "users_gender_female": {
+    "other": "أنثى"
+  },
+  "users_gender_male": {
+    "other": "ذكر"
+  },
+  "users_gender_diverse": {
+    "other": "مختلف"
+  },
+  "users_gender_other": {
+    "other": "غير محدد"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD فقط"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD فقط"
+  },
+  "shopping_card_save_card": {
+    "other": "احفظ(ي) هذه البطاقة لاستخدامها في المستقبل"
+  },
+  "shopping_card_button_change": {
+    "other": "إظهار كل البطاقات المحفوظة"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} بالرقم تنتهي {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(تنتهي صلاحيتها {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(منتهية الصلاحية)"
+  },
+  "shopping_card_use_other": {
+    "other": "استخدام بطاقة جديدة"
+  },
+  "shopping_card_use_new_card": {
+    "other": "تغيير البطاقة"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "لا يوجد سبب لتحديث بطاقة التسوق"
+  },
+  "shopping_card_new_subscription": {
+    "other": "سيتم حفظ هذه البطاقة وإعادة تعبئتها بانتظام"
+  },
+  "shopping_card_change": {
+    "other": "بطاقة الائتمان غير صحيحة؟ <a href=\"{{.SubscriptionsURL}}\"> انقر(ي) هنا لتحديث بطاقتك. </a>"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "الاشتراك"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "من تاريخ ووقت الإصدار."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "تغيير بطاقة الائتمان"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "تحديث تفاصيل بطاقة الائتمان"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "تحديث"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "تنتهي {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "usersubscriptions_subscription_status_cancelled"
+  },
+  "usersubscriptions_subscription_status_errored": {
+    "other": "usersubscriptions_subscription_status_errored"
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "usersubscriptions_subscription_status_past_due"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "فترة النسخة التجريبية"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "إلغاء اشتراكي"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "يلغي"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "نعم ، إلغاء اشتراكي"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "إلغاء الاشتراك؟"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "سيؤدي هذا إلى إلغاء الاشتراك في خطة {{.Name}}. ستظل قادرًا على مشاهدة المحتوى في الخطة حتى انتهاء صلاحيتها {{.Expiry}}."
+  },
+  "availability_coming_soon": {
+    "other": "قريبا"
+  },
+  "availability_renting": {
+    "other": "إيجار"
+  },
+  "availability_not_available": {
+    "other": "غير متوفر"
+  },
+  "availability_in_watch_window": {
+    "other": "التوفر في مدة المشاهدة"
+  },
+  "availability_sold_out": {
+    "other": "نفذ"
+  },
+  "availability_available_till": {
+    "other": "متوفر حتى {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "غير متاح في بلدك"
+  },
+  "availability_available": {
+    "other": "متوفر في {{.ReleaseDate}}"
+  },
+  "availability_expires": {
+    "other": "تنتهي الصلاحية في {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "منتهي الصلاحية"
+  },
+  "modal_cancel": {
+    "other": "إلغاء"
+  },
+  "play": {
+    "other": "تشغيل"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "تسجيل الدخول"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "اشتراك"
+  },
+  "combined_auth_terms": {
+    "other": "أوافق على جميع <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\"> البنود & amp؛ الشروط </a>."
+  },
+  "signup_terms": {
+    "other": "أوافق على جميع <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\"> البنود & amp؛ الشروط </a>."
+  },
+  "validation_terms_required": {
+    "other": "يجب الموافقة على الاحكام والشروط."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "للأسف ، لقد نفذ {{.Title}}."
+  },
+  "changepincode_modal_header": {
+    "other": "بتغيير رقم التعريف الشخصي PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "كلمة السر الحالية "
+  },
+  "changepincode_modal_pincode1": {
+    "other": "رقم التعريف الشخصي PIN الجديد المكون من 4 أرقام"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "تأكيد رقم التعريف الشخصي PIN الجديد المكون من 4 أرقام"
+  },
+  "changepincode_modal_submit": {
+    "other": "تعيين رقم التعريف الشخصي PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "كلمة المرورغير صحيحة."
+  },
+  "user_set_pin_intro": {
+    "other": "أنت بحاجة إلى رقم تعريف شخصي PIN  ل {{.Action}} المحتوى المحظور"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "انقر(ي) هنا لإعادة تعيين رقم التعريف الشخصي PIN الخاص بك"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "هذا المحتوى مقيد بالفئة العمرية."
+  },
+  "shopping_error_close_button": {
+    "other": "نعم"
+  },
+  "wcag_skip_links_header": {
+    "other": "روابط الوصول"
+  },
+  "wcag_skip_links_content": {
+    "other": "روابط الوصول"
+  },
+  "wcag_homepage_h1": {
+    "other": "الصفحة الرئيسية"
+  },
+  "wcag_carousel_h2": {
+    "other": "المشاركات الدائرية"
+  },
+  "wcag_collections_h2": {
+    "other": "المجموعات"
+  },
+  "wcag_aria_label_footer": {
+    "other": "أسفل الصفحة"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "الرئيسية"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "الفرعية"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "تبديل التنقل"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "عناصر الحزمات"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "المشاركات الدائرية"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "صفحة المجموعات"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "لائحة المجموعات"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "شريط تمرير المجموعات"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "قائمة الرغبات"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "انشر على الفيسبوك"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "انشر على تويتر"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "انشر على لينكد ان"
+  },
+  "shopping_price_title_plan": {
+    "other": "سعر"
+  },
+  "shopping_price_plan_note": {
+    "zero": "اتهم كل {{ .Interval }} .",
+    "one": "يتم تحصيل الرسوم كل {{ .Interval }} بعد انتهاء الفترة التجريبية المجانية لمدة 24 ساعة.",
+    "other": "يتم تحصيل الرسوم كل {{ .Interval }} بعد انتهاء {{ .Count }} التجريبية المجانية .Count يوم."
+  },
+  "shopping_price_plan_note_interval": {
+    "one": "{{ .Interval }}",
+    "other": "{{ .Count }} {{ .Interval }}"
+  },
+  "shopping_enter_card_prompt_plan": {
+    "other": "أدخل تفاصيل بطاقة الائتمان الخاصة بك أدناه لبدء اشتراكك."
+  },
+  "shopping_action_plan": {
+    "other": "مكتمل"
+  },
+  "shopping_action_credit": {
+    "other": "فوق حتى"
+  },
+  "shopping_complete_subscription": {
+    "other": "تم شراء اشتراكك بنجاح. أنت الآن مشترك في {{ .Title }} ."
+  },
+  "shopping_complete_subscription_browse": {
+    "other": "لا تتردد في <a href=\"/\">تصفح</a> الموقع ، أو <a href=\"/search.html\">البحث</a> عن شيء محدد."
+  },
+  "shopping_info_plan_offer": {
+    "one": "يجدد تلقائيا كل. {{ .Interval }}",
+    "other": "يجدد تلقائيا كل {{ .Count }} {{ .Interval }}"
+  },
+  "shopping_info_trial_period_offer": {
+    "one": "جرب الإصدار التجريبي المجاني لمدة 24 ساعة الآن!",
+    "other": "{{ .Count }} التجريبي المجاني من {{ .Count }} day!"
+  },
+  "plans_page_header": {
+    "other": "الخطط المتاحة"
+  },
+  "plan_label_owned": {
+    "other": "أنت تملك هذه الخطة"
+  },
+  "plan_expiry_date": {
+    "other": "إغلاق المبيعات:"
+  },
+  "plan_read_more": {
+    "other": "اكتشف المزيد"
+  },
+  "plan_page_read_more": {
+    "other": "اقرأ أكثر"
+  },
+  "plan_page_header_text": {
+    "other": "استمتع {{ .Name }}"
+  },
+  "page_plan_explore_intro": {
+    "other": "أو"
+  },
+  "page_plan_explore_link": {
+    "other": "استكشف ممرات أخرى"
+  },
+  "plan_showcase_page_ownership_button_buy": {
+    "other": "اشتري الآن"
+  },
+  "plan_free_link_text": {
+    "other": "سجل مجانا"
+  },
+  "awards_in_competition": {
+    "other": "في المنافسة"
+  },
+  "donate_button_text": {
+    "other": "يتبرع"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "لديك بالفعل هذه الخطة"
+  },
+  "shopping_error_plan_expired": {
+    "other": "هذه الخطة لم تعد متوفرة"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "عرض على Letterboxd"
+  },
+  "header_banner": {
+    "other": "سينما ABC - مهرجان الفيلم الحادي والعشرون ، 1-6 يونيو 2021"
+  },
+  "app_badge_title": {
+    "other": "قم بتنزيل التطبيق لعرض المحتوى الذي اشتريته!"
+  },
+  "app_badge_ios": {
+    "other": "قم بالتحميل من متجر البرامج"
+  },
+  "app_badge_android": {
+    "other": "احصل عليه من متجر جوجل للتطبيقات"
+  },
+  "awards_winner": {
+    "other": "الفائز"
+  }
+}

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1,1164 +1,1179 @@
 {
   "site_owner": {
-   "other": "ABC Cinemas"
+    "other": "ABC Cinemas"
   },
   "settings_title": {
-   "other": "Configuració"
+    "other": "Configuració"
   },
   "powered_by": {
-   "other": "Ofert per"
+    "other": "Ofert per"
   },
   "powered_by_name": {
-   "other": "Shift72"
+    "other": "Shift72"
   },
   "powered_by_url": {
-   "other": "https://www.screenplus.com"
+    "other": "https://www.screenplus.com"
   },
   "in_partnership_with": {
-   "other": "En col·laboració amb"
+    "other": "En col·laboració amb"
   },
   "festival_scope": {
-   "other": "Festival Scope"
+    "other": "Festival Scope"
   },
   "festival_scope_url": {
-   "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
   },
   "en": {
-   "other": "Anglès"
+    "other": "Anglès"
   },
   "fr": {
-   "other": "Francès"
+    "other": "Francès"
   },
   "episode_name": {
-   "other": "Episodi"
+    "other": "Episodi"
   },
   "season_name": {
-   "other": "Temporada"
+    "other": "Temporada"
   },
   "seasons": {
-   "one": "una temporada",
-   "other": "{{.Count}} temporades"
+    "one": "una temporada",
+    "other": "{{.Count}} temporades"
   },
   "tvseason": {
-   "other": "{{.ShowInfo.Title}} Sèries {{.Season.SeasonNumber}}"
+    "other": "{{.ShowInfo.Title}} Sèries {{.Season.SeasonNumber}}"
   },
   "tvseason_html": {
-   "other": "{{.ShowInfo.Title}} <span>Sèries {{.Season.SeasonNumber}}</span>"
+    "other": "{{.ShowInfo.Title}} <span>Sèries {{.Season.SeasonNumber}}</span>"
   },
   "tvepisode": {
-   "other": "{{.Episode.Title}}"
+    "other": "{{.Episode.Title}}"
   },
   "tvseason_number": {
-   "other": "Sèries {{.Season.SeasonNumber}}"
+    "other": "Sèries {{.Season.SeasonNumber}}"
   },
   "episode_count": {
-   "one": "1 episodi",
-   "other": "{{.Count}} Episodis"
+    "one": "1 episodi",
+    "other": "{{.Count}} Episodis"
   },
   "date_day": {
-   "other": "Dia"
+    "other": "Dia"
   },
   "date_month": {
-   "other": "Mes"
+    "other": "Mes"
   },
   "date_year": {
-   "other": "Curs"
+    "other": "Curs"
   },
   "404_page_header": {
-   "other": "Aquesta pàgina no existeix ..."
+    "other": "Aquesta pàgina no existeix ..."
   },
   "404_page_content": {
-   "other": "<p>Ho sento, sembla que la pàgina que busqueu no existeix.</p><p>Podria haver estat traslladada o suprimida, o potser heu escrit malament alguna cosa.</p><p>Proveu a tornar a la pàgina d'inici per trobar el que buscaves.</p><p><a href=\"{{.URL}}\">Tornar a la pàgina principal</a></p>"
+    "other": "<p>Ho sento, sembla que la pàgina que busqueu no existeix.</p><p>Podria haver estat traslladada o suprimida, o potser heu escrit malament alguna cosa.</p><p>Proveu a tornar a la pàgina d'inici per trobar el que buscaves.</p><p><a href=\"{{.URL}}\">Tornar a la pàgina principal</a></p>"
   },
   "nav_homepage": {
-   "other": "ABC Cinemas"
+    "other": "ABC Cinemas"
   },
   "nav_signin": {
-   "other": "Inicieu la sessió"
+    "other": "Inicieu la sessió"
   },
   "nav_signup": {
-   "other": "Crear compte"
+    "other": "Crear compte"
   },
   "nav_signed_in_as": {
-   "other": "Signat com"
+    "other": "Signat com"
   },
   "nav_library": {
-   "other": "La meva llibreria"
+    "other": "La meva llibreria"
   },
   "nav_devices": {
-   "other": "Els meus dispositius"
+    "other": "Els meus dispositius"
   },
   "nav_wishlist": {
-   "other": "La meva llista"
+    "other": "La meva llista"
   },
   "nav_account": {
-   "other": "El meu compte"
+    "other": "El meu compte"
   },
   "nav_signout": {
-   "other": "Tanca sessió"
+    "other": "Tanca sessió"
   },
   "header_banner": {
-   "other": "ABC Cinemas - 21è Festival de Cinema, de l'1 al 6 de juny de 2021"
+    "other": "ABC Cinemas - 21è Festival de Cinema, de l'1 al 6 de juny de 2021"
   },
   "play_trailer": {
-   "other": "Tràiler"
+    "other": "Tràiler"
   },
   "runtime_hours": {
-   "other": "h"
+    "other": "h"
   },
   "runtime_minutes": {
-   "other": "m"
+    "other": "m"
   },
   "datetime_today": {
-   "other": "avui {{.Date}}"
+    "other": "avui {{.Date}}"
   },
   "datetime_tomorrow": {
-   "other": "demà {{.Date}}"
+    "other": "demà {{.Date}}"
   },
   "datetime_yesterday": {
-   "other": "ahir {{.Date}}"
+    "other": "ahir {{.Date}}"
   },
   "datetime_next": {
-   "other": "{{.Date}}"
+    "other": "{{.Date}}"
   },
   "datetime_last": {
-   "other": "Últim {{.Date}}"
+    "other": "Últim {{.Date}}"
   },
   "search_control_placeholder": {
-   "other": "Cerca"
+    "other": "Cerca"
   },
   "search_control_submit": {
-   "other": "Envia la cerca"
+    "other": "Envia la cerca"
   },
   "play_button_watch": {
-   "other": "Visualitza ara"
+    "other": "Visualitza ara"
   },
   "play_button_resume": {
-   "other": "Continuar"
+    "other": "Continuar"
   },
   "social_media_buttons_title": {
-   "other": "Compartir"
+    "other": "Compartir"
   },
-  "social_media_buttons_facebook": { "other": "Comparteix a Facebook" },
-  "social_media_buttons_twitter": { "other": "Comparteix a Twitter" },
-  "social_media_buttons_linkedin": { "other": "Comparteix a Linkedin" },
-  "social_media_buttons_email": { "other": "Comparteix per correu electrònic" },
-  "social_media_buttons_email_subject": { "other": "Compartir enllaç" },
-  "social_media_buttons_copied_link": { "other": "S'ha copiat l'enllaç al porta-retalls!" },
-  "social_media_buttons_copy_link": { "other": "Copiar al portapapers" },
+  "social_media_buttons_facebook": {
+    "other": "Comparteix a Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Comparteix a Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Comparteix a Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Comparteix per correu electrònic"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Compartir enllaç"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "S'ha copiat l'enllaç al porta-retalls!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Copiar al portapapers"
+  },
   "accept_invite_page_header": {
-   "other": "Benvingut "
+    "other": "Benvingut "
   },
   "acceptinvite_form_invalid_reset_password_token": {
-   "other": "Sembla que ja heu reclamat aquesta invitació, haureu de fer <a href=\"{{.SigninURL}}\">inicia la sessió</a> en canvi. Si heu oblidat la vostra contrasenya, també podeu <a href=\"{{.ForgotPasswordURL}}\">restablir la contrasenya</a>."
+    "other": "Sembla que ja heu reclamat aquesta invitació, haureu de fer <a href=\"{{.SigninURL}}\">inicia la sessió</a> en canvi. Si heu oblidat la vostra contrasenya, també podeu <a href=\"{{.ForgotPasswordURL}}\">restablir la contrasenya</a>."
   },
   "acceptinvite_complete": {
-   "other": "Gràcies. El teu compte ha estat creat."
+    "other": "Gràcies. El teu compte ha estat creat."
   },
   "acceptinvite_form_submit": {
-   "other": "Accepta invitació"
+    "other": "Accepta invitació"
   },
   "acceptinvite_agreement": {
-   "other": "En fer clic a \"Acceptar invitació\", accepteu que heu llegit i entès el nostres <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Condicions generals; Condicions </a> i <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">Política de privadesa</a>."
+    "other": "En fer clic a \"Acceptar invitació\", accepteu que heu llegit i entès el nostres <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Condicions generals; Condicions </a> i <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">Política de privadesa</a>."
   },
   "signup_page_header": {
-   "other": "Crear un nou compte"
+    "other": "Crear un nou compte"
   },
   "signup_form_name": {
-   "other": "Nom"
+    "other": "Nom"
   },
   "signup_form_email": {
-   "other": "Correu electrònic"
+    "other": "Correu electrònic"
   },
   "signup_form_password": {
-   "other": "Contrasenya"
+    "other": "Contrasenya"
   },
   "signup_form_password_confirmation": {
-   "other": "Confirmar la contrasenya"
+    "other": "Confirmar la contrasenya"
   },
   "signup_form_gender": {
-   "other": "Génere"
+    "other": "Génere"
   },
   "signup_form_dob": {
-   "other": "Data de naixement"
+    "other": "Data de naixement"
   },
   "signup_form_submit": {
-   "other": "Presentar"
+    "other": "Presentar"
   },
   "signin_page_header": {
-   "other": "Inicieu la sessió"
+    "other": "Inicieu la sessió"
   },
   "signin_form_email": {
-   "other": "Correu electrònic"
+    "other": "Correu electrònic"
   },
   "signin_form_password": {
-   "other": "Contrasenya"
+    "other": "Contrasenya"
   },
   "signin_form_remember": {
-   "other": "Recorda'm"
+    "other": "Recorda'm"
   },
   "signin_form_submit": {
-   "other": "Presentar"
+    "other": "Presentar"
   },
   "signin_page_forgotpassword": {
-   "other": "Has oblidat la teva contrassenya?"
+    "other": "Has oblidat la teva contrassenya?"
   },
   "signin_page_createnewaccount": {
-   "other": "No teniu un compte? Crear un nou compte"
+    "other": "No teniu un compte? Crear un nou compte"
   },
   "signup_page_alreadyhaveanaccount": {
-   "other": "Ja tens un compte? Inicieu la sessió"
+    "other": "Ja tens un compte? Inicieu la sessió"
   },
   "signup_form_error_email_already_in_use": {
-   "other": "Aquesta adreça de correu electrònic ja està en ús."
+    "other": "Aquesta adreça de correu electrònic ja està en ús."
   },
   "signin_form_error_incorrect_credentials": {
-   "other": "El nom d'usuari o la contrasenya és incorrecte."
+    "other": "El nom d'usuari o la contrasenya és incorrecte."
   },
   "signin_form_error_ip_throttled": {
-   "other": "No heu pogut iniciar la sessió massa vegades. Si us plau, intenta-ho més tard."
+    "other": "No heu pogut iniciar la sessió massa vegades. Si us plau, intenta-ho més tard."
   },
   "signin_form_error_account_suspended": {
-   "other": "El teu compte ha estat suspès temporalment. Poseu-vos en contacte amb un administrador si creieu que això és un error."
+    "other": "El teu compte ha estat suspès temporalment. Poseu-vos en contacte amb un administrador si creieu que això és un error."
   },
   "signup_form_error_forbidden": {
-   "other": "S'ha produït un error."
+    "other": "S'ha produït un error."
   },
   "combined_auth_continue": {
-   "other": "Continuar"
+    "other": "Continuar"
   },
   "combined_auth_change": {
-   "other": "canvi"
+    "other": "canvi"
   },
   "combined_auth_signin": {
-   "other": "Inicieu la sessió"
+    "other": "Inicieu la sessió"
   },
   "combined_auth_signup": {
-   "other": "Crear compte"
+    "other": "Crear compte"
   },
   "combined_auth_signin_password": {
-   "other": "Introduïu la vostra contrasenya per iniciar la sessió al vostre compte."
+    "other": "Introduïu la vostra contrasenya per iniciar la sessió al vostre compte."
   },
   "combined_auth_signin_error_incorrect_credentials": {
-   "other": "Aquesta contrasenya és incorrecta."
+    "other": "Aquesta contrasenya és incorrecta."
   },
   "combined_auth_error_forbidden": {
-   "other": "S'ha produït un error."
+    "other": "S'ha produït un error."
   },
   "combined_auth_error_too_many_requests": {
     "other": "Hi ha massa sol·licituds, torneu-ho a provar més tard."
   },
   "forgotpassword_page_header": {
-   "other": "Restablir la contrasenya"
+    "other": "Restablir la contrasenya"
   },
   "forgotpassword_form_email": {
-   "other": "Correu electrònic"
+    "other": "Correu electrònic"
   },
   "forgotpassword_form_submit": {
-   "other": "Reiniciar"
+    "other": "Reiniciar"
   },
   "forgotpassword_form_error_email_doesnt_exist": {
-   "other": "No hi ha cap compte que coincideixi amb aquesta adreça de correu electrònic."
+    "other": "No hi ha cap compte que coincideixi amb aquesta adreça de correu electrònic."
   },
   "forgotpassword_form_error_account_suspended": {
-   "other": "Aquest compte està suspès."
+    "other": "Aquest compte està suspès."
   },
   "forgotpassword_complete": {
-   "other": "Gràcies. Un correu electrònic de restabliment de la contrasenya hauria d'aparèixer a la vostra safata d'entrada en breu."
+    "other": "Gràcies. Un correu electrònic de restabliment de la contrasenya hauria d'aparèixer a la vostra safata d'entrada en breu."
   },
   "forgotpassword_form_error_forbidden": {
-   "other": "S'ha produït un error."
+    "other": "S'ha produït un error."
   },
   "forgotpassword_form_error_too_many_requests": {
     "other": "Hi ha massa sol·licituds, torneu-ho a provar més tard."
   },
   "resetpassword_page_header": {
-   "other": "Canvia la teva contrasenya"
+    "other": "Canvia la teva contrasenya"
   },
   "resetpassword_form_invalid_reset_password_token": {
-   "other": "Sembla com si aquesta sol·licitud de contrasenya de restabliment no és vàlida, empleneu la contrasenya <a href=\"{{.URL}}\">Heu oblidat la contrasenya</a> de nou."
+    "other": "Sembla com si aquesta sol·licitud de contrasenya de restabliment no és vàlida, empleneu la contrasenya <a href=\"{{.URL}}\">Heu oblidat la contrasenya</a> de nou."
   },
   "resetpassword_form_password": {
-   "other": "Nova contrasenya"
+    "other": "Nova contrasenya"
   },
   "resetpassword_form_password2": {
-   "other": "Confirmeu la vostra nova contrasenya"
+    "other": "Confirmeu la vostra nova contrasenya"
   },
   "resetpassword_form_submit": {
-   "other": "Canvi"
+    "other": "Canvi"
   },
   "resetpassword_complete": {
-   "other": "Gràcies. S'ha canviat la vostra contrasenya i heu estat iniciat la sessió."
+    "other": "Gràcies. S'ha canviat la vostra contrasenya i heu estat iniciat la sessió."
   },
   "resetpassword_form_error_invalid_reset_password_token": {
-   "other": "La sol·licitud de restabliment de la contrasenya no és vàlida. Siusplau, intenta-ho més tard."
+    "other": "La sol·licitud de restabliment de la contrasenya no és vàlida. Siusplau, intenta-ho més tard."
   },
   "resetpassword_form_error_reset_password_token_expired": {
-   "other": "El token de restabliment ha caducat. Si us plau, sol·liciteu-ne un de nou."
+    "other": "El token de restabliment ha caducat. Si us plau, sol·liciteu-ne un de nou."
   },
   "resetpassword_form_error_too_many_requests": {
     "other": "Hi ha massa sol·licituds, torneu-ho a provar més tard."
   },
   "account_page_header": {
-   "other": "El meu compte"
+    "other": "El meu compte"
   },
   "account_form_name": {
-   "other": "Nom"
+    "other": "Nom"
   },
   "account_form_email": {
-   "other": "Correu electrònic"
+    "other": "Correu electrònic"
   },
   "account_form_password": {
-   "other": "Contrasenya"
+    "other": "Contrasenya"
   },
   "account_form_change_password": {
-   "other": "Canvi"
+    "other": "Canvi"
   },
   "account_form_gender": {
-   "other": "Génere"
+    "other": "Génere"
   },
   "account_form_dob": {
-   "other": "Data de naixement"
+    "other": "Data de naixement"
   },
   "account_form_submit": {
-   "other": "Actualitzar"
+    "other": "Actualitzar"
   },
   "account_form_submitted": {
-   "other": "Actualitzat"
+    "other": "Actualitzat"
   },
   "account_form_password_changed": {
-   "other": "Actualitzat"
+    "other": "Actualitzat"
   },
   "account_form_error_incorrect_password": {
-   "other": "Aquesta contrasenya és incorrecta."
+    "other": "Aquesta contrasenya és incorrecta."
   },
   "account_form_pin_code": {
-   "other": "PIN"
+    "other": "PIN"
   },
   "account_form_pin_code_not_set": {
-   "other": "No teniu un conjunt de PIN, que es requereix per comprar, llogar i veure alguns títols."
+    "other": "No teniu un conjunt de PIN, que es requereix per comprar, llogar i veure alguns títols."
   },
   "account_form_set_pin": {
-   "other": "Estableix el PIN"
+    "other": "Estableix el PIN"
   },
   "account_form_pin_changed": {
-   "other": "Actualitzat"
+    "other": "Actualitzat"
   },
   "account_form_change_pin": {
-   "other": "Canvia el PIN"
+    "other": "Canvia el PIN"
   },
   "user_set_pin_header": {
-   "other": "Configureu el PIN"
+    "other": "Configureu el PIN"
   },
   "user_set_pin_button": {
-   "other": "Estableix el PIN"
+    "other": "Estableix el PIN"
   },
   "user_submit_pin_heading": {
-   "other": "Introduïu el vostre PIN a {{.Action}} aquest contingut restringit"
+    "other": "Introduïu el vostre PIN a {{.Action}} aquest contingut restringit"
   },
   "user_error_wrong_pin_retry": {
-   "other": "Oops, heu introduït un PIN incorrecte"
+    "other": "Oops, heu introduït un PIN incorrecte"
   },
   "user_error_too_many_pin_errors": {
-   "other": "<p>Sembla que teniu problemes.</p><p>Restableix el vostre PIN o poseu-vos en contacte amb nosaltres <a href=\"{{.HelpURL}}\" target=\"_blank\">Ajuda</a>"
+    "other": "<p>Sembla que teniu problemes.</p><p>Restableix el vostre PIN o poseu-vos en contacte amb nosaltres <a href=\"{{.HelpURL}}\" target=\"_blank\">Ajuda</a>"
   },
   "user_submit_pin_button": {
-   "other": "Entrar"
+    "other": "Entrar"
   },
   "user_reset_pin_button": {
-   "other": "Restablir el PIN"
+    "other": "Restablir el PIN"
   },
   "signup_form_optin": {
-   "other": "Inscriviu-vos al nostre butlletí gratuït"
+    "other": "Inscriviu-vos al nostre butlletí gratuït"
   },
   "passwordconfirmation_modal_header": {
-   "other": "Confirmar la contrasenya"
+    "other": "Confirmar la contrasenya"
   },
   "passwordconfirmation_modal_label": {
-   "other": "Introduïu la vostra contrasenya per actualitzar els canvis"
+    "other": "Introduïu la vostra contrasenya per actualitzar els canvis"
   },
   "passwordconfirmation_modal_confirm": {
-   "other": "Confirmar"
+    "other": "Confirmar"
   },
   "changepassword_modal_header": {
-   "other": "Canvia la teva contrasenya"
+    "other": "Canvia la teva contrasenya"
   },
   "changepassword_modal_currentpassword": {
-   "other": "La vostra contrasenya actual"
+    "other": "La vostra contrasenya actual"
   },
   "changepassword_modal_password": {
-   "other": "La vostra nova contrasenya"
+    "other": "La vostra nova contrasenya"
   },
   "changepassword_modal_password2": {
-   "other": "Confirmeu la vostra nova contrasenya"
+    "other": "Confirmeu la vostra nova contrasenya"
   },
   "changepassword_modal_submit": {
-   "other": "Actualitzar"
+    "other": "Actualitzar"
   },
   "changepassword_modal_error_incorrect_password": {
-   "other": "Aquesta contrasenya és incorrecta."
+    "other": "Aquesta contrasenya és incorrecta."
   },
   "userlibrary_page_header": {
-   "other": "La meva biblioteca"
+    "other": "La meva biblioteca"
   },
   "userlibrary_empty_header": {
-   "other": "La vostra biblioteca està buida."
+    "other": "La vostra biblioteca està buida."
   },
   "userlibrary_empty_content": {
-   "other": "Empleneu-lo de <a href=\"{{.HomeURL}}\">navegació</a>la nostra gran selecció."
+    "other": "Empleneu-lo de <a href=\"{{.HomeURL}}\">navegació</a>la nostra gran selecció."
   },
   "searchresults_page_header": {
-   "other": "Resultats de la cerca"
+    "other": "Resultats de la cerca"
   },
   "searchresults_load_more": {
-   "other": "Carregueu {{.Count}} més"
+    "other": "Carregueu {{.Count}} més"
   },
   "searchresults_total": {
-   "one": "Trobat 1 resultat per a \"{{.Query}}\".",
-   "other": "Trobat {{.Count}} Resultats per a \"{{.Query}}\"."
+    "one": "Trobat 1 resultat per a \"{{.Query}}\".",
+    "other": "Trobat {{.Count}} Resultats per a \"{{.Query}}\"."
   },
   "searchresults_empty_header": {
-   "other": "No hi va ha resultats de cerca per a \"{{.Query}}\""
+    "other": "No hi va ha resultats de cerca per a \"{{.Query}}\""
   },
   "searchresults_empty_content": {
-   "other": "Proveu una altra cerca o <a href=\"{{.HomeURL}}\">Navegueu en el nostre contingut</a>per trobar el que busqueu."
+    "other": "Proveu una altra cerca o <a href=\"{{.HomeURL}}\">Navegueu en el nostre contingut</a>per trobar el que busqueu."
   },
   "validation_name_required": {
-   "other": "Introduïu el vostre nom."
+    "other": "Introduïu el vostre nom."
   },
   "validation_email_required": {
-   "other": "Si us plau, ingressi el seu correu electrònic."
+    "other": "Si us plau, ingressi el seu correu electrònic."
   },
   "validation_email_email": {
-   "other": "Si us plau, introdueixi una adreça de correu electrònic vàlida."
+    "other": "Si us plau, introdueixi una adreça de correu electrònic vàlida."
   },
   "validation_currentpassword_required": {
-   "other": "Introduïu la vostra contrasenya actual."
+    "other": "Introduïu la vostra contrasenya actual."
   },
   "validation_password_required": {
-   "other": "Introduïu una contrasenya."
+    "other": "Introduïu una contrasenya."
   },
   "validation_password2_required": {
-   "other": "Confirmeu la vostra contrasenya."
+    "other": "Confirmeu la vostra contrasenya."
   },
   "validation_password2_match": {
-   "other": "Les vostres contrasenyes no coincideixen."
+    "other": "Les vostres contrasenyes no coincideixen."
   },
   "validation_password_minlength": {
-   "other": "Introduïu els caràcters com a mínim {{.Count}}."
+    "other": "Introduïu els caràcters com a mínim {{.Count}}."
   },
   "validation_promocode_required": {
-   "other": "Introduïu un codi de promoció."
+    "other": "Introduïu un codi de promoció."
   },
   "validation_pincode_required": {
-   "other": "Introduïu un codi PIN."
+    "other": "Introduïu un codi PIN."
   },
   "validation_pincode1_required": {
-   "other": "Introduïu un codi PIN vàlid."
+    "other": "Introduïu un codi PIN vàlid."
   },
   "validation_pincode2_required": {
-   "other": "Introduïu un codi PIN vàlid."
+    "other": "Introduïu un codi PIN vàlid."
   },
   "validation_pincode1_pattern": {
-   "other": "Introduïu un codi PIN vàlid."
+    "other": "Introduïu un codi PIN vàlid."
   },
   "validation_pincode2_pattern": {
-   "other": "Introduïu un codi PIN vàlid."
+    "other": "Introduïu un codi PIN vàlid."
   },
   "validation_pincode2_match": {
-   "other": "El codi PIN no coincideix."
+    "other": "El codi PIN no coincideix."
   },
   "validation_gender_required": {
-   "other": "Seleccioneu el gènere més proper amb el qual us identifiqueu."
+    "other": "Seleccioneu el gènere més proper amb el qual us identifiqueu."
   },
   "validation_dob_required": {
-   "other": "Si us plau introduïu la vostra data de neixement."
+    "other": "Si us plau introduïu la vostra data de neixement."
   },
   "validation_dob_date": {
-   "other": "Introduïu una data de naixement vàlida."
+    "other": "Introduïu una data de naixement vàlida."
   },
   "shopping_info_subtitle_hd": {
-   "other": "Vídeo HD sota demanda."
+    "other": "Vídeo HD sota demanda."
   },
   "shopping_info_subtitle_sd": {
-   "other": "Vídeo SD sota demanda."
+    "other": "Vídeo SD sota demanda."
   },
   "shopping_info_subtitle_wallet": {
-   "other": "Els fons de la cartera es poden utilitzar per a la compra o lloguer de qualsevol contingut de ScreenPlus."
+    "other": "Els fons de la cartera es poden utilitzar per a la compra o lloguer de qualsevol contingut de ScreenPlus."
   },
   "shopping_info_subtitle_help": {
-   "other": "Consulteu aquí els requisits del sistema."
+    "other": "Consulteu aquí els requisits del sistema."
   },
   "shopping_info_ownership_buy": {
-   "other": "comprar"
+    "other": "comprar"
   },
   "shopping_info_ownership_rent": {
-   "other": "lloguer"
+    "other": "lloguer"
   },
   "shopping_info_sd_only": {
-   "other": "Limitat només a la reproducció SD."
+    "other": "Limitat només a la reproducció SD."
   },
   "shopping_info_release_date_title": {
-   "other": "Llançaments {{.Date}}. "
+    "other": "Llançaments {{.Date}}. "
   },
   "shopping_info_release_date_explanation_rent": {
-   "other": "Podeu llogar-lo ara, però no podreu veure-ho fins llavors."
+    "other": "Podeu llogar-lo ara, però no podreu veure-ho fins llavors."
   },
   "shopping_info_release_date_explanation_buy": {
-   "other": "Podeu comprar-lo ara, però no podreu veure-ho fins llavors."
+    "other": "Podeu comprar-lo ara, però no podreu veure-ho fins llavors."
   },
   "shopping_info_available_until_date_title": {
-   "other": "Disponible fins a {{.Date}}. "
+    "other": "Disponible fins a {{.Date}}. "
   },
   "shopping_info_available_until_date_explanation_rent": {
-   "other": "No podreu veure el contingut després d'això."
+    "other": "No podreu veure el contingut després d'això."
   },
   "shopping_info_available_until_date_explanation_buy": {
-   "other": "No podreu veure el contingut després d'això."
+    "other": "No podreu veure el contingut després d'això."
   },
   "duration_hour": {
-   "one": "1 hora",
-   "other": "{{.Count}} hores"
+    "one": "1 hora",
+    "other": "{{.Count}} hores"
   },
   "duration_day": {
-   "one": "1 dia",
-   "other": "{{.Count}} dies"
+    "one": "1 dia",
+    "other": "{{.Count}} dies"
   },
   "shopping_info_rental_period_duration": {
-   "other": "{{.ValueUnit}} de lloguer "
+    "other": "{{.ValueUnit}} de lloguer "
   },
   "shopping_info_watch_window_duration": {
-   "other": "{{.Count}} Finestra de reproducció d'hora. "
+    "other": "{{.Count}} Finestra de reproducció d'hora. "
   },
   "shopping_info_watch_window_explanation_film": {
-   "one": "Un cop llogat, la pel·lícula estarà disponible al vostre compte durant {{.ValueUnit}}. ",
-   "other": "Un cop llogat, la vostra pel·lícula estarà disponible al vostre compte per a {{.ValueUnit}}. "
+    "one": "Un cop llogat, la pel·lícula estarà disponible al vostre compte durant {{.ValueUnit}}. ",
+    "other": "Un cop llogat, la vostra pel·lícula estarà disponible al vostre compte per a {{.ValueUnit}}. "
   },
   "shopping_info_watch_window_explanation2_film": {
-   "one": "Un cop activada la reproducció, comença la finestra de reproducció i teniu una hora per veure la pel·lícula tantes vegades com vulgueu.",
-   "other": "Un cop activada la reproducció, comença la finestra de reproducció i teniu {{.Count}} hores per veure la pel·lícula tantes vegades com vulgueu."
+    "one": "Un cop activada la reproducció, comença la finestra de reproducció i teniu una hora per veure la pel·lícula tantes vegades com vulgueu.",
+    "other": "Un cop activada la reproducció, comença la finestra de reproducció i teniu {{.Count}} hores per veure la pel·lícula tantes vegades com vulgueu."
   },
   "shopping_info_watch_window_explanation_bundle": {
-   "one": "Un cop llogats, els articles del vostre paquet estaran disponibles al vostre compte durant un dia. ",
-   "other": "Un cop llogats, els articles del vostre paquet estaran disponibles al vostre compte per {{.Count}} dies. "
+    "one": "Un cop llogats, els articles del vostre paquet estaran disponibles al vostre compte durant un dia. ",
+    "other": "Un cop llogats, els articles del vostre paquet estaran disponibles al vostre compte per {{.Count}} dies. "
   },
   "shopping_info_watch_window_explanation2_bundle": {
-   "one": "Una vegada que premeu PLAY en una pel·lícula específica, comença la finestra de visionat i teniu una hora per veure aquesta pel·lícula tantes vegades com vulgueu.",
-   "other": "Quan premeu PLAY en una pel·lícula específica, comença la finestra de visionat i teniu {{.Count}} hores per veure aquesta pel·lícula tantes vegades com vulgueu."
+    "one": "Una vegada que premeu PLAY en una pel·lícula específica, comença la finestra de visionat i teniu una hora per veure aquesta pel·lícula tantes vegades com vulgueu.",
+    "other": "Quan premeu PLAY en una pel·lícula específica, comença la finestra de visionat i teniu {{.Count}} hores per veure aquesta pel·lícula tantes vegades com vulgueu."
   },
   "shopping_info_watch_window_explanation_season": {
-   "one": "Un cop llogada, la vostra temporada estarà disponible al vostre compte durant un dia. ",
-   "other": "Un cop llogada, la vostra temporada estarà disponible al vostre compte per a {{.Count}} dies. "
+    "one": "Un cop llogada, la vostra temporada estarà disponible al vostre compte durant un dia. ",
+    "other": "Un cop llogada, la vostra temporada estarà disponible al vostre compte per a {{.Count}} dies. "
   },
   "shopping_info_watch_window_explanation2_season": {
-   "one": "Una vegada que premeu Play en un episodi, comença la finestra de visionat i teniu una hora per veure aquest episodi tantes vegades com vulgueu.",
-   "other": "Un cop premuda la reproducció d'un episodi, comença la finestra de visionat i teniu {{.Count}} hores per veure aquest episodi tantes vegades com vulgueu."
+    "one": "Una vegada que premeu Play en un episodi, comença la finestra de visionat i teniu una hora per veure aquest episodi tantes vegades com vulgueu.",
+    "other": "Un cop premuda la reproducció d'un episodi, comença la finestra de visionat i teniu {{.Count}} hores per veure aquest episodi tantes vegades com vulgueu."
   },
   "shopping_info_credit_bonus_title": {
-   "other": "{{.BonusPercentage}}% Bonificació"
+    "other": "{{.BonusPercentage}}% Bonificació"
   },
   "shopping_enter_card_prompt": {
-   "other": "Introduïu les dades de la vostra targeta de crèdit a continuació per completar el vostre {{.Verb}}."
+    "other": "Introduïu les dades de la vostra targeta de crèdit a continuació per completar el vostre {{.Verb}}."
   },
   "shopping_terms": {
-   "other": "En completar aquesta transacció, accepto les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">Condicions generals</a>."
+    "other": "En completar aquesta transacció, accepto les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">Condicions generals</a>."
   },
   "shopping_discount_applied": {
-   "other": "{{.DiscountAmount}} Descompte aplicat."
+    "other": "{{.DiscountAmount}} Descompte aplicat."
   },
   "shopping_discount_apply": {
-   "other": "Dedicar-se"
+    "other": "Dedicar-se"
   },
   "shopping_discount_code": {
-   "other": "Introduïu un codi de promoció."
+    "other": "Introduïu un codi de promoció."
   },
   "shopping_discount_have_code": {
-   "other": "Tinc un codi de promoció."
+    "other": "Tinc un codi de promoció."
   },
   "shopping_price_you_pay": {
-   "other": "Tu pagues"
+    "other": "Tu pagues"
   },
   "shopping_price_nothing": {
-   "other": "Res"
+    "other": "Res"
   },
   "shopping_price_free": {
-   "other": "Lliure"
+    "other": "Lliure"
   },
   "shopping_auth_directions": {
-   "other": "Primer es necessita un compte. Si us plau, ingressi el seu correu electrònic."
+    "other": "Primer es necessita un compte. Si us plau, ingressi el seu correu electrònic."
   },
   "shopping_error_in_library": {
-   "other": "{{.Title}} ja es troba a la vostra llibreria."
+    "other": "{{.Title}} ja es troba a la vostra llibreria."
   },
   "shopping_error_missing_card": {
-   "other": "Introduïu les dades de la vostra targeta de crèdit."
+    "other": "Introduïu les dades de la vostra targeta de crèdit."
   },
   "shopping_error_title": {
-   "other": "Va ocórrer un error"
+    "other": "Va ocórrer un error"
   },
   "shopping_error_incorrect_cvc": {
-   "other": "Introduïu un CVV vàlid."
+    "other": "Introduïu un CVV vàlid."
   },
   "shopping_error_invalid_cvc": {
-   "other": "Introduïu un CVV vàlid."
+    "other": "Introduïu un CVV vàlid."
   },
   "shopping_error_incorrect_number": {
-   "other": "Si us plau, introduïu un número de targeta de crèdit vàlid."
+    "other": "Si us plau, introduïu un número de targeta de crèdit vàlid."
   },
   "shopping_error_invalid_number": {
-   "other": "Si us plau, introduïu un número de targeta de crèdit vàlid."
+    "other": "Si us plau, introduïu un número de targeta de crèdit vàlid."
   },
   "shopping_error_card_declined": {
-   "other": "S'ha rebutjat la targeta de crèdit."
+    "other": "S'ha rebutjat la targeta de crèdit."
   },
   "shopping_error_invalid_expiry_month": {
-   "other": "Introduïu una caducitat vàlida."
+    "other": "Introduïu una caducitat vàlida."
   },
   "shopping_error_invalid_expiry_year": {
-   "other": "Introduïu una caducitat vàlida."
+    "other": "Introduïu una caducitat vàlida."
   },
   "shopping_error_expired_card": {
-   "other": "La targeta de crèdit ha caducat."
+    "other": "La targeta de crèdit ha caducat."
   },
   "shopping_error_creditcard_country_mismatch": {
-   "other": "No s'ha completat el vostre {{.Ownership}}. Heu d'estar al país on es va emetre la targeta de crèdit. Utilitzeu una altra targeta per fer el pagament."
+    "other": "No s'ha completat el vostre {{.Ownership}}. Heu d'estar al país on es va emetre la targeta de crèdit. Utilitzeu una altra targeta per fer el pagament."
   },
   "shopping_error_proxy_detected": {
-   "other": "No s'ha completat el vostre {{.Ownership}}. Hem detectat que esteu utilitzant un servei de desbloqueig o proxy. Si us plau, apagueu qualsevol d'aquests serveis i torneu-ho a provar."
+    "other": "No s'ha completat el vostre {{.Ownership}}. Hem detectat que esteu utilitzant un servei de desbloqueig o proxy. Si us plau, apagueu qualsevol d'aquests serveis i torneu-ho a provar."
   },
   "shopping_error_discount_worn_out": {
-   "other": "Que el codi de promoció ja no es pot utilitzar."
+    "other": "Que el codi de promoció ja no es pot utilitzar."
   },
   "shopping_error_discount_blank": {
-   "other": "Introduïu un codi de promoció."
+    "other": "Introduïu un codi de promoció."
   },
   "shopping_error_discount_not_applied": {
-   "other": "Introduïu un codi de promoció vàlid."
+    "other": "Introduïu un codi de promoció vàlid."
   },
   "shopping_error_discount_invalid": {
-   "other": "Introduïu un codi de promoció vàlid."
+    "other": "Introduïu un codi de promoció vàlid."
   },
   "shopping_error_discount_disabled": {
-   "other": "Introduïu un codi de promoció vàlid."
+    "other": "Introduïu un codi de promoció vàlid."
   },
   "shopping_error_discount_already_applied": {
-   "other": "Ja s'ha utilitzat un codi de promoció per a aquesta sessió."
+    "other": "Ja s'ha utilitzat un codi de promoció per a aquesta sessió."
   },
   "shopping_error_discount_already_redeemed": {
-   "other": "Aquest codi de promoció ja s'ha utilitzat."
+    "other": "Aquest codi de promoció ja s'ha utilitzat."
   },
   "shopping_error_discount_used_previously": {
-   "other": "Aquest codi de promoció ja s'ha utilitzat."
+    "other": "Aquest codi de promoció ja s'ha utilitzat."
   },
   "shopping_error_discount_max_limit": {
-   "other": "Que el codi de promoció ja no es pot utilitzar."
+    "other": "Que el codi de promoció ja no es pot utilitzar."
   },
   "shopping_error_discount_expired": {
-   "other": "Aquest codi de promoció ha caducat."
+    "other": "Aquest codi de promoció ha caducat."
   },
   "shopping_error_discount_invalid_ownership_buy": {
-   "other": "Aquest codi de promoció no es pot utilitzar quan es compra."
+    "other": "Aquest codi de promoció no es pot utilitzar quan es compra."
   },
   "shopping_error_discount_invalid_ownership_rent": {
-   "other": "Aquest codi de promoció no es pot utilitzar quan es lloga."
+    "other": "Aquest codi de promoció no es pot utilitzar quan es lloga."
   },
   "shopping_error_discount_invalid_item": {
-   "other": "Aquest codi de promoció no es pot utilitzar amb aquest element."
+    "other": "Aquest codi de promoció no es pot utilitzar amb aquest element."
   },
   "shopping_error_discount_invalid_pricing_region": {
-   "other": "Aquest codi de promoció no es pot utilitzar al vostre país."
+    "other": "Aquest codi de promoció no es pot utilitzar al vostre país."
   },
   "shopping_error_discounts_not_allowed": {
-   "other": "Que el codi de promoció no es pot utilitzar."
+    "other": "Que el codi de promoció no es pot utilitzar."
   },
   "shopping_error_discount_disallowed_on_bundles": {
-   "other": "Aquest codi de promoció no es pot utilitzar en paquets."
+    "other": "Aquest codi de promoció no es pot utilitzar en paquets."
   },
   "shopping_error_payment_intent_authentication_failure": {
-   "other": "S'ha rebutjat la targeta de crèdit. Siusplau torna-ho a provar."
+    "other": "S'ha rebutjat la targeta de crèdit. Siusplau torna-ho a provar."
   },
   "shopping_complete_rental": {
-   "other": "Èxit!"
+    "other": "Èxit!"
   },
   "shopping_complete_rental_period": {
-   "one": "Ara podeu veure-ho tan sovint com vulgueu durant l'endemà.",
-   "other": "Ara podeu veure-ho tantes vegades com vulgueu durant els propers dies {{.Count}}."
+    "one": "Ara podeu veure-ho tan sovint com vulgueu durant l'endemà.",
+    "other": "Ara podeu veure-ho tantes vegades com vulgueu durant els propers dies {{.Count}}."
   },
   "shopping_complete_purchase": {
-   "other": "Gràcies per comprar {{.Title}}."
+    "other": "Gràcies per comprar {{.Title}}."
   },
   "shopping_complete_credit_purchase": {
-   "other": "Gràcies per comprar {{.Title}}, {{.CreditTotal}} s'ha afegit al vostre compte."
+    "other": "Gràcies per comprar {{.Title}}, {{.CreditTotal}} s'ha afegit al vostre compte."
   },
   "shopping_complete_purchase_coming_soon": {
-   "other": "Podreu veure-ho des de {{.Date}}."
+    "other": "Podreu veure-ho des de {{.Date}}."
   },
   "shopping_complete_plan": {
     "other": "La teva compra de {{ .Title }} estat correcta."
-  },  
+  },
   "shopping_complete_receipt": {
-   "other": "S'ha enviat un rebut per correu electrònic."
+    "other": "S'ha enviat un rebut per correu electrònic."
   },
   "shopping_complete_library_link": {
-   "other": "Consulteu la vostra llibreria"
+    "other": "Consulteu la vostra llibreria"
   },
   "shopping_complete_rental_watch_window_start": {
-   "one": "Ara podeu començar a veure-ho durant l'endemà.",
-   "other": "Ara podeu començar a veure-ho dins dels propers dies {{.Count}}."
+    "one": "Ara podeu començar a veure-ho durant l'endemà.",
+    "other": "Ara podeu començar a veure-ho dins dels propers dies {{.Count}}."
   },
   "shopping_complete_rental_watch_window_end": {
-   "one": "Quan es comença la reproducció, tindreu una hora per veure l'article tantes vegades com vulgueu.",
-   "other": "Quan es comença la reproducció, tindreu {{.Count}} hores per veure l'article tantes vegades com vulgueu."
+    "one": "Quan es comença la reproducció, tindreu una hora per veure l'article tantes vegades com vulgueu.",
+    "other": "Quan es comença la reproducció, tindreu {{.Count}} hores per veure l'article tantes vegades com vulgueu."
   },
   "shopping_complete_rental_coming_soon": {
-   "one": "Podreu veure-ho des de {{.Date}} i el vostre lloguer es mantindrà actiu durant un dia.",
-   "other": "Podreu veure-ho des de {{.Date}} i el vostre lloguer es mantindrà actiu per als dies {{.Count}}."
+    "one": "Podreu veure-ho des de {{.Date}} i el vostre lloguer es mantindrà actiu durant un dia.",
+    "other": "Podreu veure-ho des de {{.Date}} i el vostre lloguer es mantindrà actiu per als dies {{.Count}}."
   },
   "shopping_complete_rental_coming_soon_watch_window_start": {
-   "one": "Podreu veure-ho des de {{.Date}} i el vostre lloguer es mantindrà actiu durant un dia.",
-   "other": "Podreu veure-ho des de {{.Date}} i el vostre lloguer es mantindrà actiu per als dies {{.Count}}."
+    "one": "Podreu veure-ho des de {{.Date}} i el vostre lloguer es mantindrà actiu durant un dia.",
+    "other": "Podreu veure-ho des de {{.Date}} i el vostre lloguer es mantindrà actiu per als dies {{.Count}}."
   },
   "shopping_action_rent": {
-   "other": "Llogar"
+    "other": "Llogar"
   },
   "shopping_action_buy": {
-   "other": "Comprar"
+    "other": "Comprar"
   },
   "shopping_payment_method_header": {
-   "other": "Mètodes de Pagament"
+    "other": "Mètodes de Pagament"
   },
   "shopping_payment_method_credit_card": {
-   "other": "Targeta de crèdit"
+    "other": "Targeta de crèdit"
   },
   "shopping_payment_method_giropay": {
-   "other": "Giropay"
+    "other": "Giropay"
   },
   "shopping_error_stripe_unknown_error": {
-   "other": "Alguna cosa va sortir malament amb aquest pagament. Si us plau, intenta-ho més tard."
+    "other": "Alguna cosa va sortir malament amb aquest pagament. Si us plau, intenta-ho més tard."
   },
   "shopping_error_payment_complete_failed": {
-   "other": "El pagament es va denegar. Tanqueu aquesta finestra i torneu-ho a provar."
+    "other": "El pagament es va denegar. Tanqueu aquesta finestra i torneu-ho a provar."
   },
   "meta_detail_cast_title": {
-   "other": "Equip artistic"
+    "other": "Equip artistic"
   },
   "meta_detail_crew_title": {
-   "other": "Equip técnic"
+    "other": "Equip técnic"
   },
   "meta_detail_languages": {
-   "one": "Llenguatge",
-   "other": "Llengües"
+    "one": "Llenguatge",
+    "other": "Llengües"
   },
   "meta_detail_studios": {
-   "one": "Estudi",
-   "other": "Estudis"
+    "one": "Estudi",
+    "other": "Estudis"
   },
   "meta_detail_countries": {
-   "one": "Pais",
-   "other": "Països"
+    "one": "Pais",
+    "other": "Països"
   },
   "meta_detail_subtitles": {
-   "other": "Subtítols"
+    "other": "Subtítols"
   },
-  "meta_detail_captions": { "other": "Subtítols [CC]" },
+  "meta_detail_captions": {
+    "other": "Subtítols [CC]"
+  },
   "meta_detail_episodes_title": {
-   "other": "Episodis"
+    "other": "Episodis"
   },
   "meta_detail_bonus_title": {
-   "other": "Contingut extra"
+    "other": "Contingut extra"
   },
   "meta_detail_recommendations_title": {
-   "other": "també et pot agradar"
+    "other": "també et pot agradar"
   },
   "meta_detail_bundle_items_title": {
-   "other": "Contingut inclòs en aquest paquet"
+    "other": "Contingut inclòs en aquest paquet"
   },
   "bundle_items_all_films": {
-   "other": "{{.Count}} Films"
+    "other": "{{.Count}} Films"
   },
   "bundle_items_all_seasons": {
-   "other": "{{.Count}} Temporades"
+    "other": "{{.Count}} Temporades"
   },
   "bundle_items_mixed": {
-   "other": "{{.Count}} Films i temporades"
+    "other": "{{.Count}} Films i temporades"
   },
   "userwishlist_page_header": {
-   "other": "La meva llista"
+    "other": "La meva llista"
   },
   "userwishlist_slider_header": {
-   "other": "La meva llista"
+    "other": "La meva llista"
   },
   "userwishlist_empty_header": {
-   "other": "La vostra llista està buida."
+    "other": "La vostra llista està buida."
   },
   "userwishlist_empty_content": {
-   "other": "Empleneu-lo de <a href=\"{{.HomeURL}}\">navegació</a> la nostra gran selecció."
+    "other": "Empleneu-lo de <a href=\"{{.HomeURL}}\">navegació</a> la nostra gran selecció."
   },
   "userwishlist_button_add": {
-   "other": "Afegeix a la meva llista"
+    "other": "Afegeix a la meva llista"
   },
   "userwishlist_button_remove": {
-   "other": "La meva llista"
+    "other": "La meva llista"
   },
   "userwishlist_button_add_compact": {
-   "other": "La meva llista"
+    "other": "La meva llista"
   },
   "userwishlist_button_remove_compact": {
-   "other": "La meva llista"
+    "other": "La meva llista"
   },
   "activatedevice_page_header": {
-   "other": "Activeu el dispositiu"
+    "other": "Activeu el dispositiu"
   },
   "activatedevice_page_content": {
-   "other": "Seguiu les instruccions del dispositiu per obtenir un codi PIN. El vostre ordinador i dispositiu han de connectar-se a Internet per activar-lo."
+    "other": "Seguiu les instruccions del dispositiu per obtenir un codi PIN. El vostre ordinador i dispositiu han de connectar-se a Internet per activar-lo."
   },
   "activatedevice_form_pin": {
-   "other": "Codi PIN"
+    "other": "Codi PIN"
   },
   "activatedevice_form_submit": {
-   "other": "Activar"
+    "other": "Activar"
   },
   "activatedevice_form_error_invalid_code": {
-   "other": "El codi PIN no s'ha trobat, torneu-ho a provar."
+    "other": "El codi PIN no s'ha trobat, torneu-ho a provar."
   },
   "activatedevice_form_error_pin_not_found": {
-   "other": "El codi PIN no s'ha trobat, torneu-ho a provar."
+    "other": "El codi PIN no s'ha trobat, torneu-ho a provar."
   },
   "activatedevice_signin_prompt": {
-   "other": "Inicieu la sessió abans d'activar el dispositiu."
+    "other": "Inicieu la sessió abans d'activar el dispositiu."
   },
   "activatedevice_page_activated": {
-   "other": "Gràcies per activar {{.DeviceName}}. Ara haureu de poder navegar per la vostra biblioteca a la vostra televisió o dispositiu."
+    "other": "Gràcies per activar {{.DeviceName}}. Ara haureu de poder navegar per la vostra biblioteca a la vostra televisió o dispositiu."
   },
   "userdevices_page_header": {
-   "other": "Dispositius"
+    "other": "Dispositius"
   },
   "userdevices_page_content": {
-   "one": "Els dispositius s'afegiran automàticament aquí quan els utilitzeu. Està limitat a només un dispositiu.",
-   "other": "Els dispositius s'afegiran automàticament aquí quan els utilitzeu. Està limitat als dispositius {{.Count}}."
+    "one": "Els dispositius s'afegiran automàticament aquí quan els utilitzeu. Està limitat a només un dispositiu.",
+    "other": "Els dispositius s'afegiran automàticament aquí quan els utilitzeu. Està limitat als dispositius {{.Count}}."
   },
   "userdevices_empty_content": {
-   "other": "Actualment teniu 0 dispositius registrats."
+    "other": "Actualment teniu 0 dispositius registrats."
   },
   "userdevices_header_type": {
-   "other": "Tipus de dispositiu"
+    "other": "Tipus de dispositiu"
   },
   "userdevices_header_description": {
-   "other": "Descripció"
+    "other": "Descripció"
   },
   "userdevices_device_added": {
-   "other": "Afegit {{.Date}}"
+    "other": "Afegit {{.Date}}"
   },
   "userdevices_device_actions_delete": {
-   "other": "Treure"
+    "other": "Treure"
   },
   "userdevices_device_actions_cancel": {
-   "other": "Cancel · lar"
+    "other": "Cancel · lar"
   },
   "userdevices_device_actions_confirm": {
-   "other": "Sí, elimina el dispositiu"
+    "other": "Sí, elimina el dispositiu"
   },
   "userdevices_device_deleted": {
-   "other": "(Eliminat)"
+    "other": "(Eliminat)"
   },
   "userdevices_delete_limits": {
-   "other": "Podeu eliminar els vostres dispositius {{.Limit}} d'aquesta llista tots els dies {{.Period}}."
+    "other": "Podeu eliminar els vostres dispositius {{.Limit}} d'aquesta llista tots els dies {{.Period}}."
   },
   "userdevices_delete_limit_reached": {
-   "other": "Heu arribat a aquest límit i no podeu eliminar cap dispositiu ara mateix. Podeu suprimir un dispositiu a {{.Days}} dia (s)."
+    "other": "Heu arribat a aquest límit i no podeu eliminar cap dispositiu ara mateix. Podeu suprimir un dispositiu a {{.Days}} dia (s)."
   },
   "playlist_page_header": {
-   "other": "Llista de reproducció"
+    "other": "Llista de reproducció"
   },
   "playlist_sign_in_warning": {
-   "other": "Inicieu la sessió per veure la televisió en directe."
+    "other": "Inicieu la sessió per veure la televisió en directe."
   },
   "playlist_share_title": {
-   "other": "Llista de reproducció"
+    "other": "Llista de reproducció"
   },
   "playlist_up_next_title": {
-   "other": "Fins a la propera"
+    "other": "Fins a la propera"
   },
   "pricing_ownership_buy": {
-   "other": "Comprar"
+    "other": "Comprar"
   },
   "pricing_ownership_rent": {
-   "other": "Llogar"
+    "other": "Llogar"
   },
   "classification_intro": {
-   "other": "Valoració: "
+    "other": "Valoració: "
   },
   "classification_divider": {
-   "other": " - "
+    "other": " - "
   },
   "classification_outro": {
-   "other": ""
+    "other": ""
   },
   "cookie_banner_message": {
-   "other": "Aquest lloc utilitza galetes per millorar la vostra experiència. Mitjançant l'ús d'aquest lloc, accepteu el nostre Ús <a href=\"{{.CookiePolicyURL}}\">cookie</a>."
+    "other": "Aquest lloc utilitza galetes per millorar la vostra experiència. Mitjançant l'ús d'aquest lloc, accepteu el nostre Ús <a href=\"{{.CookiePolicyURL}}\">cookie</a>."
   },
   "cookie_banner_accept": {
-   "other": "Accepto"
+    "other": "Accepto"
   },
   "all_rights_reserved": {
-   "other": "Tots els drets reservats. No es pot reproduir cap part d'aquest lloc sense el nostre permís per escrit."
+    "other": "Tots els drets reservats. No es pot reproduir cap part d'aquest lloc sense el nostre permís per escrit."
   },
   "users_gender_none": {
-   "other": "Sense especificar"
+    "other": "Sense especificar"
   },
   "users_gender_female": {
-   "other": "Dona"
+    "other": "Dona"
   },
   "users_gender_male": {
-   "other": "Home"
+    "other": "Home"
   },
   "users_gender_diverse": {
-   "other": "Divers"
+    "other": "Divers"
   },
   "users_gender_other": {
-   "other": "Altre"
+    "other": "Altre"
   },
   "pricing_quality_hd": {
-   "other": "HD"
+    "other": "HD"
   },
   "pricing_quality_sd": {
-   "other": "SD"
+    "other": "SD"
   },
   "pricing_quality_hd_only": {
-   "other": "Només HD"
+    "other": "Només HD"
   },
   "pricing_quality_sd_only": {
-   "other": "Només SD"
+    "other": "Només SD"
   },
   "shopping_card_save_card": {
-   "other": "Deseu aquesta targeta per a un ús futur"
+    "other": "Deseu aquesta targeta per a un ús futur"
   },
   "shopping_card_button_change": {
-   "other": "Mostra totes les targetes desades"
+    "other": "Mostra totes les targetes desades"
   },
   "shopping_card_existing_description": {
-   "other": "{{.Card.Brand}} Finalitza a {{.Card.Number}}"
+    "other": "{{.Card.Brand}} Finalitza a {{.Card.Number}}"
   },
   "shopping_card_existing_expiry": {
-   "other": "(caduca {{.Card.Expiry}})"
+    "other": "(caduca {{.Card.Expiry}})"
   },
   "shopping_card_existing_expired": {
-   "other": "(caducat)"
+    "other": "(caducat)"
   },
   "shopping_card_use_other": {
-   "other": "Utilitzeu una targeta nova"
+    "other": "Utilitzeu una targeta nova"
   },
   "shopping_card_use_new_card": {
-   "other": "Canvia la targeta"
+    "other": "Canvia la targeta"
   },
   "shopping_card_update_reason_none": {
-   "other": "tarja-decompra_actualitzada_cap_motiu"
+    "other": "tarja-decompra_actualitzada_cap_motiu"
   },
   "shopping_card_new_subscription": {
-   "other": "Aquesta targeta es desarà i es cobrarà regularment"
+    "other": "Aquesta targeta es desarà i es cobrarà regularment"
   },
   "shopping_card_change": {
-   "other": "La targeta de crèdit no és correcta? <a href=\"{{.SubscriptionsURL}}\">Feu clic aquí per actualitzar la vostra targeta.</a>"
+    "other": "La targeta de crèdit no és correcta? <a href=\"{{.SubscriptionsURL}}\">Feu clic aquí per actualitzar la vostra targeta.</a>"
   },
   "shopping_info_ownership_plan": {
-   "other": "Subscripció"
+    "other": "Subscripció"
   },
   "shopping_action_credit": {
-   "other": "Omplir"
+    "other": "Omplir"
   },
   "shopping_info_rental_period_coming_soon": {
-   "other": "des de la data i l'hora de l'alliberament."
+    "other": "des de la data i l'hora de l'alliberament."
   },
   "usersubscriptions_change_payment_method_change": {
-   "other": "Canviar targeta de crèdit"
+    "other": "Canviar targeta de crèdit"
   },
   "usersubscriptions_change_payment_method_modal_title": {
-   "other": "Actualitza els detalls de la targeta de crèdit"
+    "other": "Actualitza els detalls de la targeta de crèdit"
   },
   "usersubscriptions_change_payment_method_modal_submit": {
-   "other": "Actualització"
+    "other": "Actualització"
   },
   "usersubscriptions_subscription_expiry": {
-   "other": "Caduca {{.Expiry}}"
+    "other": "Caduca {{.Expiry}}"
   },
   "usersubscriptions_subscription_status_cancelled": {
-   "other": "usersubscriptions_subscription_status_cancelled"
+    "other": "usersubscriptions_subscription_status_cancelled"
   },
   "usersubscriptions_subscription_status_errored": {
-   "other": "usersubscriptions_subscription_status_errored"
+    "other": "usersubscriptions_subscription_status_errored"
   },
   "usersubscriptions_subscription_status_past_due": {
-   "other": "usersubscriptions_subscription_status_past_due"
+    "other": "usersubscriptions_subscription_status_past_due"
   },
   "usersubscriptions_subscription_status_trialing": {
-   "other": "Període de prova"
+    "other": "Període de prova"
   },
   "usersubscriptions_subscription_unsubscribe": {
-   "other": "Cancel·la la meva subscripció"
+    "other": "Cancel·la la meva subscripció"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-   "other": "Cancel · lar"
+    "other": "Cancel · lar"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-   "other": "Sí, cancel·lar la meva subscripció"
+    "other": "Sí, cancel·lar la meva subscripció"
   },
   "usersubscriptions_unsubscribe_modal_title": {
-   "other": "Cancel·lar la subscripció?"
+    "other": "Cancel·lar la subscripció?"
   },
   "usersubscriptions_unsubscribe_modal_body": {
-   "other": "Això cancel·larà la subscripció al pla {{.Name}}. Encara podreu veure el contingut del pla fins que caduqui {{.Expiry}}."
+    "other": "Això cancel·larà la subscripció al pla {{.Name}}. Encara podreu veure el contingut del pla fins que caduqui {{.Expiry}}."
   },
   "availability_coming_soon": {
-   "other": "Pròximament"
+    "other": "Pròximament"
   },
   "availability_renting": {
-   "other": "Lloguer"
+    "other": "Lloguer"
   },
   "availability_not_available": {
-   "other": "No disponible"
+    "other": "No disponible"
   },
   "availability_in_watch_window": {
-   "other": "disponibilitat_a_visualització_finestra"
+    "other": "disponibilitat_a_visualització_finestra"
   },
   "availability_sold_out": {
-   "other": "Venut"
+    "other": "Venut"
   },
   "availability_available_till": {
-   "other": "Disponible fins a {{.ExpiryDate}}"
+    "other": "Disponible fins a {{.ExpiryDate}}"
   },
   "availability_not_available_in_country": {
-   "other": "No disponible al vostre país"
+    "other": "No disponible al vostre país"
   },
   "availability_available": {
-   "other": "Disponible {{.ReleaseDate}}"
+    "other": "Disponible {{.ReleaseDate}}"
   },
   "availability_expires": {
-   "other": "Caduca {{.Expiry}}"
+    "other": "Caduca {{.Expiry}}"
   },
   "availability_expired": {
-   "other": "Expirat"
+    "other": "Expirat"
   },
   "modal_cancel": {
-   "other": "Cancel·lar"
+    "other": "Cancel·lar"
   },
   "play": {
-   "other": "Reproduir"
+    "other": "Reproduir"
   },
   "combined_auth_signin_prompt": {
-   "other": "Inicieu la sessió"
+    "other": "Inicieu la sessió"
   },
   "combined_auth_signup_prompt": {
-   "other": "Registra't"
+    "other": "Registra't"
   },
   "combined_auth_terms": {
-   "other": "Accepto tots els <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Termes de targetes; Condicions</a>."
+    "other": "Accepto tots els <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Termes de targetes; Condicions</a>."
   },
   "signup_terms": {
-   "other": "Accepto tots els <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Termes de targetes; Condicions</a>."
+    "other": "Accepto tots els <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Termes de targetes; Condicions</a>."
   },
   "validation_terms_required": {
-   "other": "Heu d'acceptar els termes i condicions."
+    "other": "Heu d'acceptar els termes i condicions."
   },
   "shopping_error_item_limit_exceeded": {
-   "other": "Malauradament, {{.Title}} s'ha esgotat."
+    "other": "Malauradament, {{.Title}} s'ha esgotat."
   },
   "changepincode_modal_header": {
-   "other": "Canvieu el vostre PIN"
+    "other": "Canvieu el vostre PIN"
   },
   "changepincode_modal_currentpassword": {
-   "other": "La vostra contrasenya actual"
+    "other": "La vostra contrasenya actual"
   },
   "changepincode_modal_pincode1": {
-   "other": "El vostre nou PIN de 4 dígits"
+    "other": "El vostre nou PIN de 4 dígits"
   },
   "changepincode_modal_pincode2": {
-   "other": "Confirmeu el vostre nou PIN de 4 dígits"
+    "other": "Confirmeu el vostre nou PIN de 4 dígits"
   },
   "changepincode_modal_submit": {
-   "other": "Estableix el PIN"
+    "other": "Estableix el PIN"
   },
   "changepincode_modal_error_wrong_password": {
-   "other": "Aquesta contrasenya és incorrecta."
+    "other": "Aquesta contrasenya és incorrecta."
   },
   "user_set_pin_intro": {
-   "other": "Necessiteu un PIN a {{.Action}} contingut restringit"
+    "other": "Necessiteu un PIN a {{.Action}} contingut restringit"
   },
   "user_error_wrong_pin_reset": {
-   "other": "Feu clic aquí per restablir el vostre PIN"
+    "other": "Feu clic aquí per restablir el vostre PIN"
   },
   "user_error_too_many_pin_errors_help_page_link": {
-   "other": ""
+    "other": ""
   },
   "shopping_error_age_restricted": {
-   "other": "Aquest contingut és restringit per edat."
+    "other": "Aquest contingut és restringit per edat."
   },
   "shopping_error_close_button": {
-   "other": "D'acord"
+    "other": "D'acord"
   },
   "wcag_skip_links_header": {
-   "other": "Enllaços d'accessibilitat"
+    "other": "Enllaços d'accessibilitat"
   },
   "wcag_skip_links_content": {
-   "other": "Saltar al contingut"
+    "other": "Saltar al contingut"
   },
   "wcag_homepage_h1": {
-   "other": "Pàgina principal"
+    "other": "Pàgina principal"
   },
   "wcag_carousel_h2": {
-   "other": "Carrusel"
+    "other": "Carrusel"
   },
   "wcag_collections_h2": {
-   "other": "Col·leccions"
+    "other": "Col·leccions"
   },
   "wcag_aria_label_footer": {
-   "other": "Peu"
+    "other": "Peu"
   },
   "wcag_aria_label_nav_main": {
-   "other": "Principal"
+    "other": "Principal"
   },
   "wcag_aria_label_nav_sub": {
-   "other": "Sub"
+    "other": "Sub"
   },
   "wcag_aria_label_toggle_nav": {
-   "other": "Commuta la navegació"
+    "other": "Commuta la navegació"
   },
   "wcag_aria_label_bundle_items": {
-   "other": "Articles de paquets"
+    "other": "Articles de paquets"
   },
   "wcag_aria_label_carousel": {
-   "other": "Carrusel"
+    "other": "Carrusel"
   },
   "wcag_aria_label_page_collection": {
-   "other": "Col·lecció de pàgines"
+    "other": "Col·lecció de pàgines"
   },
   "wcag_aria_label_collection_list": {
-   "other": "Llista de col·leccions"
+    "other": "Llista de col·leccions"
   },
   "wcag_aria_label_collection_slider": {
-   "other": "Control lliscant de col·lecció"
+    "other": "Control lliscant de col·lecció"
   },
   "wcag_aria_label_wishlist": {
-   "other": "Cessió"
+    "other": "Cessió"
   },
   "wcag_aria_label_facebook": {
-   "other": "Comparteix a Facebook"
+    "other": "Comparteix a Facebook"
   },
   "wcag_aria_label_twitter": {
-   "other": "Comparteix a Twitter"
+    "other": "Comparteix a Twitter"
   },
   "wcag_aria_label_linkedin": {
-   "other": "Comparteix a LinkedIn"
+    "other": "Comparteix a LinkedIn"
   },
   "app_badge_title": {
-   "other": "Descarrega l'aplicació per veure el contingut comprat!"
+    "other": "Descarrega l'aplicació per veure el contingut comprat!"
   },
   "app_badge_ios": {
-   "other": "Descarrega a l'App Store"
+    "other": "Descarrega a l'App Store"
   },
   "app_badge_android": {
-   "other": "Aconsegueix-ho a Google Play"
+    "other": "Aconsegueix-ho a Google Play"
   },
-
   "shopping_price_title_plan": {
     "other": "Preu"
   },
@@ -1230,8 +1245,13 @@
   "donate_button_text": {
     "other": "Donar"
   },
-  "shopping_error_plan_already_owned": { "other": "Ja tens aquest pla." },
-  "shopping_error_plan_expired": { "other": "Aquest pla ja no està disponible." },
-
-  "wcag_aria_label_letterboxd": { "other": "Veure a Letterboxd" }
+  "shopping_error_plan_already_owned": {
+    "other": "Ja tens aquest pla."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Aquest pla ja no està disponible."
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Veure a Letterboxd"
+  }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -5,12 +5,24 @@
   "settings_title": {
     "other": "Indstillinger"
   },
-  "powered_by": { "other": "Drevet af" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "i samarbejde med" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
+  "powered_by": {
+    "other": "Drevet af"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "i samarbejde med"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
   "en": {
     "other": "Engelsk"
   },
@@ -124,13 +136,27 @@
   "social_media_buttons_title": {
     "other": "Del"
   },
-  "social_media_buttons_facebook": { "other": "Del på facebook" },
-  "social_media_buttons_twitter": { "other": "Del på Twitter" },
-  "social_media_buttons_linkedin": { "other": "Del på Linkedin" },
-  "social_media_buttons_email": { "other": "Del via e-mail" },
-  "social_media_buttons_email_subject": { "other": "Linkdeling" },
-  "social_media_buttons_copied_link": { "other": "Link kopieret til udklipsholder!" },
-  "social_media_buttons_copy_link": { "other": "Kopier til udklipsholder" },
+  "social_media_buttons_facebook": {
+    "other": "Del på facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Del på Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Del på Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Del via e-mail"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Linkdeling"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link kopieret til udklipsholder!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Kopier til udklipsholder"
+  },
   "accept_invite_page_header": {
     "other": "Velkommen "
   },
@@ -233,7 +259,6 @@
   "combined_auth_error_too_many_requests": {
     "other": "For mange anmodninger, prøv venligst igen senere."
   },
-
   "forgotpassword_page_header": {
     "other": "Nulstil dit kodeord"
   },
@@ -502,8 +527,14 @@
   "shopping_info_available_until_date_explanation_buy": {
     "other": "Du vil ikke kunne se indholdet efter dette."
   },
-  "duration_hour": { "one": "1 time", "other": "{{.Count}} timer" },
-  "duration_day": { "one": "1 dag", "other": "{{.Count}} dage" },
+  "duration_hour": {
+    "one": "1 time",
+    "other": "{{.Count}} timer"
+  },
+  "duration_day": {
+    "one": "1 dag",
+    "other": "{{.Count}} dage"
+  },
   "shopping_info_rental_period_duration": {
     "other": "{{.ValueUnit}} leje "
   },
@@ -678,7 +709,7 @@
   },
   "shopping_complete_plan": {
     "other": "Dit køb af {{ .Title }} blev gennemført."
-  },  
+  },
   "shopping_complete_library_link": {
     "other": "Se dit bibliotek"
   },
@@ -725,7 +756,9 @@
   "meta_detail_subtitles": {
     "other": "Undertekster"
   },
-  "meta_detail_captions": { "other": "Undertekster [CC]" },
+  "meta_detail_captions": {
+    "other": "Undertekster [CC]"
+  },
   "meta_detail_episodes_title": {
     "other": "Episoder"
   },
@@ -1060,73 +1093,77 @@
   "shopping_error_close_button": {
     "other": "Okay"
   },
-  "app_badge_title": { "other": "Download appen for at se dit købte indhold!" },
-  "app_badge_ios": { "other": "Download på App Store" },
-  "app_badge_android": { "other": "Få det på Google Play" },
-
+  "app_badge_title": {
+    "other": "Download appen for at se dit købte indhold!"
+  },
+  "app_badge_ios": {
+    "other": "Download på App Store"
+  },
+  "app_badge_android": {
+    "other": "Få det på Google Play"
+  },
   "shopping_price_title_plan": {
-      "other": "Pris"
+    "other": "Pris"
   },
   "shopping_price_plan_note": {
-      "zero": "Opkræves hvert {{ .Interval }} .",
-      "one": "Opkræves hvert {{ .Interval }} efter din 24 timers gratis prøveperiode slutter.",
-      "other": "Opkræves hvert {{ .Interval }} efter din {{ .Count }} dages gratis prøveperiode slutter."
+    "zero": "Opkræves hvert {{ .Interval }} .",
+    "one": "Opkræves hvert {{ .Interval }} efter din 24 timers gratis prøveperiode slutter.",
+    "other": "Opkræves hvert {{ .Interval }} efter din {{ .Count }} dages gratis prøveperiode slutter."
   },
   "shopping_price_plan_note_interval": {
-      "one": "{{ .Interval }}",
-      "other": "{{ .Count }} {{ .Interval }}"
+    "one": "{{ .Interval }}",
+    "other": "{{ .Count }} {{ .Interval }}"
   },
   "shopping_enter_card_prompt_plan": {
-      "other": "Indtast dine kreditkortoplysninger nedenfor for at starte dit abonnement."
+    "other": "Indtast dine kreditkortoplysninger nedenfor for at starte dit abonnement."
   },
   "shopping_action_plan": {
-      "other": "Komplet"
+    "other": "Komplet"
   },
   "shopping_complete_subscription": {
-      "other": "Dit abonnementskøb blev gennemført. Du abonnerer nu på {{ .Title }} ."
+    "other": "Dit abonnementskøb blev gennemført. Du abonnerer nu på {{ .Title }} ."
   },
   "shopping_complete_subscription_browse": {
-      "other": "Du er velkommen til at <a href=\"/\">browse rundt</a> på siden, eller <a href=\"/search.html\">søg</a> efter noget specifikt."
+    "other": "Du er velkommen til at <a href=\"/\">browse rundt</a> på siden, eller <a href=\"/search.html\">søg</a> efter noget specifikt."
   },
   "shopping_info_plan_offer": {
-      "one": "{{ .Interval }} automatisk hvert .Interval",
-      "other": "{{ .Count }} automatisk hver {{ .Interval }}"
+    "one": "{{ .Interval }} automatisk hvert .Interval",
+    "other": "{{ .Count }} automatisk hver {{ .Interval }}"
   },
   "shopping_info_trial_period_offer": {
-      "one": "Prøv din gratis 24 timers prøveperiode nu!",
-      "other": "Prøv din gratis {{ .Count }} day prøveperiode!"
+    "one": "Prøv din gratis 24 timers prøveperiode nu!",
+    "other": "Prøv din gratis {{ .Count }} day prøveperiode!"
   },
   "plans_page_header": {
-      "other": "Tilgængelige planer"
+    "other": "Tilgængelige planer"
   },
   "plan_label_owned": {
-      "other": "Du ejer denne plan"
+    "other": "Du ejer denne plan"
   },
   "plan_expiry_date": {
-      "other": "Salg lukker:"
+    "other": "Salg lukker:"
   },
   "plan_read_more": {
-      "other": "Find ud af mere"
+    "other": "Find ud af mere"
   },
   "plan_page_read_more": {
-      "other": "Læs mere"
+    "other": "Læs mere"
   },
   "plan_page_header_text": {
-      "other": "Nyd {{ .Name }}"
+    "other": "Nyd {{ .Name }}"
   },
   "page_plan_explore_intro": {
-      "other": "ELLER"
+    "other": "ELLER"
   },
   "page_plan_explore_link": {
-      "other": "Udforsk andre pas"
+    "other": "Udforsk andre pas"
   },
   "plan_showcase_page_ownership_button_buy": {
-      "other": "Køb nu"
+    "other": "Køb nu"
   },
   "plan_free_link_text": {
     "other": "Gratis tilmelding"
   },
-
   "awards_in_competition": {
     "other": "I Konkurrence"
   },
@@ -1136,36 +1173,85 @@
   "donate_button_text": {
     "other": "Doner"
   },
-
-  "shopping_error_plan_already_owned": { "other": "Du har allerede denne plan." },
-  "shopping_error_plan_expired": { "other": "Denne plan er ikke længere tilgængelig." },
-  "shopping_payment_method_header": { "other": "Betalingsmetoder" },
-  "shopping_payment_method_credit_card": { "other": "Kreditkort" },
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  "shopping_error_stripe_unknown_error": { "other": "Der gik noget galt med denne betaling. Prøv igen senere." },
-  "shopping_error_payment_complete_failed": { "other": "Betalingen blev afvist. Luk dette vindue og prøv igen." },
-
-  "wcag_skip_links_header": { "other": "Accessibility Links" },
-  "wcag_skip_links_content": { "other": "Skip to Content" },
-
-  "wcag_homepage_h1": { "other": "Hjemmeside" },
-  "wcag_carousel_h2": { "other": "Karrusel" },
-  "wcag_collections_h2": { "other": "Samlinger" },
-
-  "wcag_aria_label_footer": { "other": "Sidefod" },
-  "wcag_aria_label_nav_main": { "other": "Hoved" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Slå navigation til/fra" },
-  "wcag_aria_label_bundle_items": { "other": "Pak varer" },
-  "wcag_aria_label_carousel": { "other": "Karrusel" },
-  "wcag_aria_label_page_collection": { "other": "Sidesamling" },
-  "wcag_aria_label_collection_list": { "other": "Samlingsliste" },
-  "wcag_aria_label_collection_slider": { "other": "Indsamlingsskyder" },
-  "wcag_aria_label_wishlist": { "other": "Ønskeliste" },
-  "wcag_aria_label_facebook": { "other": "Del på Facebook" },
-  "wcag_aria_label_twitter": { "other": "Del på Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Del på LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Se på Letterboxd" },
-
-  "header_banner": { "other": "ABC Cinemas – 21. filmfestival, 1. – 6. juni 2021" }
+  "shopping_error_plan_already_owned": {
+    "other": "Du har allerede denne plan."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Denne plan er ikke længere tilgængelig."
+  },
+  "shopping_payment_method_header": {
+    "other": "Betalingsmetoder"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Kreditkort"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Der gik noget galt med denne betaling. Prøv igen senere."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Betalingen blev afvist. Luk dette vindue og prøv igen."
+  },
+  "wcag_skip_links_header": {
+    "other": "Accessibility Links"
+  },
+  "wcag_skip_links_content": {
+    "other": "Skip to Content"
+  },
+  "wcag_homepage_h1": {
+    "other": "Hjemmeside"
+  },
+  "wcag_carousel_h2": {
+    "other": "Karrusel"
+  },
+  "wcag_collections_h2": {
+    "other": "Samlinger"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Sidefod"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Hoved"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Slå navigation til/fra"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Pak varer"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Karrusel"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Sidesamling"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Samlingsliste"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Indsamlingsskyder"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Ønskeliste"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Del på Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Del på Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Del på LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Se på Letterboxd"
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21. filmfestival, 1. – 6. juni 2021"
+  }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Einstelllungen" },
-  "powered_by": { "other": "Bereitgestellt von" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "in einer Beziehung mit" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "Englisch" },
-  "fr": { "other": "Französisch" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Einstelllungen"
+  },
+  "powered_by": {
+    "other": "Bereitgestellt von"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "in einer Beziehung mit"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "Englisch"
+  },
+  "fr": {
+    "other": "Französisch"
+  },
   "episode_name": {
     "other": "Folge"
   },
-
   "season_name": {
     "other": "Staffel"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "1 Staffel",
     "other": "{{.Count}} Staffeln"
   },
@@ -38,171 +55,423 @@
     "one": "1 Folge",
     "other": "{{.Count}} Folgen"
   },
-
-  "date_day": { "other": "Tag" },
-  "date_month": { "other": "Monat" },
-  "date_year": { "other": "Jahr" },
-
-  "404_page_header": { "other": "Diese Seite existiert nicht…" },
-  "404_page_content": { "other": "<p>Diese Seite existiert leider nicht.</p><p><a href=\"{{.URL}}\">Zurück zur Startseite</a></p>" },
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Anmelden" },
-  "nav_signup": { "other": "Konto anlegen" },
-  "nav_signed_in_as": { "other": "Eingeloggt als" },
-  "nav_library": { "other": "Meine Bibliothek" },
-  "nav_devices": { "other": "Meine Geräte" },
-  "nav_wishlist": { "other": "Meine Liste" },
-  "nav_account": { "other": "Mein Konto" },
-  "nav_signout": { "other": "Ausloggen" },
-  "play_trailer": { "other": "Vorschau" },
-  "runtime_hours": { "other": "h" },
-  "runtime_minutes": { "other": "m" },
-
-  "search_control_placeholder": { "other": "Suche" },
-  "search_control_submit": { "other": "Suche einreichen" },
-
-  "play_button_watch": { "other" : "Jetzt abspielen"},
-  "play_button_resume": { "other" : "Fortsetzen"},
-
-  "social_media_buttons_title": { "other": "Teilen" },
-  "social_media_buttons_facebook": { "other": "Auf Facebook teilen" },
-  "social_media_buttons_twitter": { "other": "Auf Twitter teilen" },
-  "social_media_buttons_linkedin": { "other": "Auf Linkedin teilen" },
-  "social_media_buttons_email": { "other": "Per E-Mail teilen" },
-  "social_media_buttons_email_subject": { "other": "Link teilen" },
-  "social_media_buttons_copied_link": { "other": "Link in die Zwischenablage kopiert!" },
-  "social_media_buttons_copy_link": { "other": "In die Zwischenablage kopieren" },
-
-  "accept_invite_page_header": { "other": "Willkommen " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Sie haben diese Einladung bereits angenommen. <a href=\"{{.SigninURL}}\">Loggen Sie sich hier ein</a>. Falls Sie Ihr Passwort vergessen haben, können Sie es <a href=\"{{.ForgotPasswordURL}}\">hier zurücksetzen</a>." },
-  "acceptinvite_complete": { "other": "Vielen Dank. Ihr Konto wurde erstellt." },
-  "acceptinvite_form_submit": { "other": "Einladung annehmen" },
-  "acceptinvite_agreement": { "other": "Durch Klicken auf den Button stimme ich den <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Allgemeinen Geschäftsbedingungen</a> und der <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">Datenschutzerklärung zu</a>." },
-
-  "signup_page_header": { "other": "Neues Konto erstellen" },
-  "signup_form_name": { "other": "Name" },
-  "signup_form_email": { "other": "E-Mail-Adresse" },
-  "signup_form_password": { "other": "Passwort" },
-  "signup_form_password_confirmation": { "other": "Bitte bestätigen Sie Ihr Passwort" },
-  "signup_form_gender": { "other": "Geschlecht" },
-  "signup_form_dob": { "other": "Geburtsdatum" },
-  "signup_form_submit": { "other": "Absenden" },
-  "signup_terms": { "other": "Wenn Sie die Schaltfläche unten anklicken, bestätigen Sie, dass Sie die <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Allgemeinen Geschäftsbedingungen</a> gelesen und akzeptiert haben." },
-
-  "signin_page_header": { "other": "Anmelden" },
-  "signin_form_email": { "other": "E-Mail-Adresse" },
-  "signin_form_password": { "other": "Passwort" },
-  "signin_form_remember": { "other": "Angemeldet bleiben" },
-  "signin_form_submit": { "other": "Absenden" },
-  "signin_page_forgotpassword": { "other": "Passwort vergessen?" },
-  "signin_page_createnewaccount": { "other": "Sie haben noch kein Konto? Hier registrieren" },
-  "signup_page_alreadyhaveanaccount": { "other": "Sie haben bereits ein Konto? Hier anmelden" },
-  "signup_form_error_email_already_in_use": { "other": "Diese E-Mail-Adresse ist bereits registriert." },
-  "signin_form_error_incorrect_credentials": { "other": "Der Benutzername oder das Passwort ist falsch." },
-  "signup_form_error_forbidden": { "other": "Ein Fehler ist aufgetreten." },
-
-  "combined_auth_continue": { "other": "Fortsetzen" },
-  "combined_auth_change": { "other": "Veränderung" },
-  "combined_auth_signin": { "other": "Anmelden" },
-  "combined_auth_signup": { "other": "Konto anlegen" },
-  "combined_auth_signin_password": { "other": "Bitte geben Sie Ihr Password ein um zu Ihrem Konto zu gelangen." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Falsches Password." },
-  "combined_auth_error_forbidden": { "other": "Ein Fehler ist aufgetreten." },
-  "combined_auth_error_too_many_requests": { "other": "Zu viele Anfragen. Bitte versuchen Sie es später noch einmal." },
-
-  "forgotpassword_page_header": { "other": "Passwort zurücksetzen" },
-  "forgotpassword_form_email": { "other": "E-Mail-Adresse" },
-  "forgotpassword_form_submit": { "other": "Zurücksetzen" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Es existiert kein Konto mit dieser E-Mail-Adresse." },
-  "forgotpassword_form_error_account_suspended": { "other": "Dieses Konto wurde gesperrt." },
-  "forgotpassword_complete": { "other": "Vielen Dank! In Kürze erhalten Sie eine E-Mail mit einem Link zum Zurücksetzen Ihres Passwortes." },
-  "forgotpassword_form_error_forbidden": { "other": "Ein Fehler ist aufgetreten." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Zu viele Anfragen. Bitte versuchen Sie es später noch einmal." },
-
-  "resetpassword_page_header": { "other": "Ändern Sie Ihr Passwort" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Ihre Anfrage ist ungültig. Bitte füllen Sie das Formular <a href=\"{{.URL}}\">Passwort vergessen</a> nochmals aus." },
-  "resetpassword_form_password": { "other": "Neues Passwort" },
-  "resetpassword_form_password2": { "other": "Bestätigen Sie Ihr Passwort" },
-  "resetpassword_form_submit": { "other": "Veränderung" },
-  "resetpassword_complete": { "other": "Vielen Dank. Ihr Passwort wurde geändert und Sie wurden eingeloggt." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Ihre Anfrage ist ungültig. Bitte versuchen Sie es später nochmals." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Ihre Anfrage ist abgelaufen. Bitte füllen Sie das Formular <a href=\"{{.URL}}\">Passwort vergessen</a> nochmals aus." },
-  "resetpassword_form_error_too_many_requests": { "other": "Zu viele Anfragen. Bitte versuchen Sie es später noch einmal." },
-
-  "account_page_header": { "other": "Mein Konto" },
-  "account_form_name": { "other": "Name" },
-  "account_form_email": { "other": "E-Mail-Adresse" },
-  "account_form_password": { "other": "Passwort" },
-  "account_form_change_password": { "other": "Ändern" },
-  "account_form_gender": { "other": "Geschlecht" },
-  "account_form_dob": { "other": "Geburtsdatum" },
-  "account_form_submit": { "other": "Aktualisieren" },
-  "account_form_submitted": { "other": "Aktualisiert" },
-  "account_form_password_changed": { "other": "Aktualisiert" },
-  "account_form_error_incorrect_password": { "other": "Falsches Password." },
-
-  "signup_form_optin": {"other": "Newsletter abonnieren"},
-
-  "passwordconfirmation_modal_header": { "other": "Bestätigen Sie Ihr Passwort" },
-  "passwordconfirmation_modal_label": { "other": "Bitte geben Sie Ihr Passwort, um Ihre Änderungen zu aktualisieren" },
-  "passwordconfirmation_modal_confirm": { "other": "Bestätigen" },
-
-  "changepassword_modal_header": { "other": "Ändern Sie Ihr Passwort" },
-  "changepassword_modal_currentpassword": { "other": "Ihr aktuelles Passwort" },
-  "changepassword_modal_password": { "other": "Ihr neues Passwort" },
-  "changepassword_modal_password2": { "other": "Bestätigen Sie Ihr Passwort" },
-  "changepassword_modal_submit": { "other": "Aktualisieren" },
-  "changepassword_modal_error_incorrect_password": { "other": "Falsches Password." },
-
-  "userlibrary_page_header": { "other": "Meine Bibliothek" },
-  "userlibrary_empty_header":  { "other": "Ihre Bibliothek ist leer." },
-  "userlibrary_empty_content": { "other": "Durchsuchen Sie unsere <a href=\"{{.HomeURL}}\">Filmauswahl</a>, um Ihre Filmliste zu füllen." },
-
-  "searchresults_page_header": { "other": "Suchergebnisse" },
-  "searchresults_load_more": { "other": "{{.Count}} weitere Ergebnisse laden" },
+  "date_day": {
+    "other": "Tag"
+  },
+  "date_month": {
+    "other": "Monat"
+  },
+  "date_year": {
+    "other": "Jahr"
+  },
+  "404_page_header": {
+    "other": "Diese Seite existiert nicht…"
+  },
+  "404_page_content": {
+    "other": "<p>Diese Seite existiert leider nicht.</p><p><a href=\"{{.URL}}\">Zurück zur Startseite</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Anmelden"
+  },
+  "nav_signup": {
+    "other": "Konto anlegen"
+  },
+  "nav_signed_in_as": {
+    "other": "Eingeloggt als"
+  },
+  "nav_library": {
+    "other": "Meine Bibliothek"
+  },
+  "nav_devices": {
+    "other": "Meine Geräte"
+  },
+  "nav_wishlist": {
+    "other": "Meine Liste"
+  },
+  "nav_account": {
+    "other": "Mein Konto"
+  },
+  "nav_signout": {
+    "other": "Ausloggen"
+  },
+  "play_trailer": {
+    "other": "Vorschau"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "m"
+  },
+  "search_control_placeholder": {
+    "other": "Suche"
+  },
+  "search_control_submit": {
+    "other": "Suche einreichen"
+  },
+  "play_button_watch": {
+    "other": "Jetzt abspielen"
+  },
+  "play_button_resume": {
+    "other": "Fortsetzen"
+  },
+  "social_media_buttons_title": {
+    "other": "Teilen"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Auf Facebook teilen"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Auf Twitter teilen"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Auf Linkedin teilen"
+  },
+  "social_media_buttons_email": {
+    "other": "Per E-Mail teilen"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Link teilen"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link in die Zwischenablage kopiert!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "In die Zwischenablage kopieren"
+  },
+  "accept_invite_page_header": {
+    "other": "Willkommen "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Sie haben diese Einladung bereits angenommen. <a href=\"{{.SigninURL}}\">Loggen Sie sich hier ein</a>. Falls Sie Ihr Passwort vergessen haben, können Sie es <a href=\"{{.ForgotPasswordURL}}\">hier zurücksetzen</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Vielen Dank. Ihr Konto wurde erstellt."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Einladung annehmen"
+  },
+  "acceptinvite_agreement": {
+    "other": "Durch Klicken auf den Button stimme ich den <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Allgemeinen Geschäftsbedingungen</a> und der <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">Datenschutzerklärung zu</a>."
+  },
+  "signup_page_header": {
+    "other": "Neues Konto erstellen"
+  },
+  "signup_form_name": {
+    "other": "Name"
+  },
+  "signup_form_email": {
+    "other": "E-Mail-Adresse"
+  },
+  "signup_form_password": {
+    "other": "Passwort"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Bitte bestätigen Sie Ihr Passwort"
+  },
+  "signup_form_gender": {
+    "other": "Geschlecht"
+  },
+  "signup_form_dob": {
+    "other": "Geburtsdatum"
+  },
+  "signup_form_submit": {
+    "other": "Absenden"
+  },
+  "signup_terms": {
+    "other": "Wenn Sie die Schaltfläche unten anklicken, bestätigen Sie, dass Sie die <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Allgemeinen Geschäftsbedingungen</a> gelesen und akzeptiert haben."
+  },
+  "signin_page_header": {
+    "other": "Anmelden"
+  },
+  "signin_form_email": {
+    "other": "E-Mail-Adresse"
+  },
+  "signin_form_password": {
+    "other": "Passwort"
+  },
+  "signin_form_remember": {
+    "other": "Angemeldet bleiben"
+  },
+  "signin_form_submit": {
+    "other": "Absenden"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Passwort vergessen?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Sie haben noch kein Konto? Hier registrieren"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Sie haben bereits ein Konto? Hier anmelden"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Diese E-Mail-Adresse ist bereits registriert."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Der Benutzername oder das Passwort ist falsch."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Ein Fehler ist aufgetreten."
+  },
+  "combined_auth_continue": {
+    "other": "Fortsetzen"
+  },
+  "combined_auth_change": {
+    "other": "Veränderung"
+  },
+  "combined_auth_signin": {
+    "other": "Anmelden"
+  },
+  "combined_auth_signup": {
+    "other": "Konto anlegen"
+  },
+  "combined_auth_signin_password": {
+    "other": "Bitte geben Sie Ihr Password ein um zu Ihrem Konto zu gelangen."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Falsches Password."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Ein Fehler ist aufgetreten."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Zu viele Anfragen. Bitte versuchen Sie es später noch einmal."
+  },
+  "forgotpassword_page_header": {
+    "other": "Passwort zurücksetzen"
+  },
+  "forgotpassword_form_email": {
+    "other": "E-Mail-Adresse"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Zurücksetzen"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Es existiert kein Konto mit dieser E-Mail-Adresse."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Dieses Konto wurde gesperrt."
+  },
+  "forgotpassword_complete": {
+    "other": "Vielen Dank! In Kürze erhalten Sie eine E-Mail mit einem Link zum Zurücksetzen Ihres Passwortes."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Ein Fehler ist aufgetreten."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Zu viele Anfragen. Bitte versuchen Sie es später noch einmal."
+  },
+  "resetpassword_page_header": {
+    "other": "Ändern Sie Ihr Passwort"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Ihre Anfrage ist ungültig. Bitte füllen Sie das Formular <a href=\"{{.URL}}\">Passwort vergessen</a> nochmals aus."
+  },
+  "resetpassword_form_password": {
+    "other": "Neues Passwort"
+  },
+  "resetpassword_form_password2": {
+    "other": "Bestätigen Sie Ihr Passwort"
+  },
+  "resetpassword_form_submit": {
+    "other": "Veränderung"
+  },
+  "resetpassword_complete": {
+    "other": "Vielen Dank. Ihr Passwort wurde geändert und Sie wurden eingeloggt."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Ihre Anfrage ist ungültig. Bitte versuchen Sie es später nochmals."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Ihre Anfrage ist abgelaufen. Bitte füllen Sie das Formular <a href=\"{{.URL}}\">Passwort vergessen</a> nochmals aus."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Zu viele Anfragen. Bitte versuchen Sie es später noch einmal."
+  },
+  "account_page_header": {
+    "other": "Mein Konto"
+  },
+  "account_form_name": {
+    "other": "Name"
+  },
+  "account_form_email": {
+    "other": "E-Mail-Adresse"
+  },
+  "account_form_password": {
+    "other": "Passwort"
+  },
+  "account_form_change_password": {
+    "other": "Ändern"
+  },
+  "account_form_gender": {
+    "other": "Geschlecht"
+  },
+  "account_form_dob": {
+    "other": "Geburtsdatum"
+  },
+  "account_form_submit": {
+    "other": "Aktualisieren"
+  },
+  "account_form_submitted": {
+    "other": "Aktualisiert"
+  },
+  "account_form_password_changed": {
+    "other": "Aktualisiert"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Falsches Password."
+  },
+  "signup_form_optin": {
+    "other": "Newsletter abonnieren"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Bestätigen Sie Ihr Passwort"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Bitte geben Sie Ihr Passwort, um Ihre Änderungen zu aktualisieren"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Bestätigen"
+  },
+  "changepassword_modal_header": {
+    "other": "Ändern Sie Ihr Passwort"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Ihr aktuelles Passwort"
+  },
+  "changepassword_modal_password": {
+    "other": "Ihr neues Passwort"
+  },
+  "changepassword_modal_password2": {
+    "other": "Bestätigen Sie Ihr Passwort"
+  },
+  "changepassword_modal_submit": {
+    "other": "Aktualisieren"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Falsches Password."
+  },
+  "userlibrary_page_header": {
+    "other": "Meine Bibliothek"
+  },
+  "userlibrary_empty_header": {
+    "other": "Ihre Bibliothek ist leer."
+  },
+  "userlibrary_empty_content": {
+    "other": "Durchsuchen Sie unsere <a href=\"{{.HomeURL}}\">Filmauswahl</a>, um Ihre Filmliste zu füllen."
+  },
+  "searchresults_page_header": {
+    "other": "Suchergebnisse"
+  },
+  "searchresults_load_more": {
+    "other": "{{.Count}} weitere Ergebnisse laden"
+  },
   "searchresults_total": {
     "one": "1 Ergebnis gefunden: \"{{.Query}}\".",
     "other": "{{.Count}} Ergebnisse gefunden: \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "Keine Ergebnisse gefunden für {{.Query}}" },
-  "searchresults_empty_content": { "other": "Probieren Sie eine andere Suche aus oder <a href=\"{{.HomeURL}}\">durchsuchen Sie unsere Inhalte</a>, um zu finden, wonach Sie suchen." },
-
-  "validation_name_required": { "other": "Bitte geben Sie Ihren Namen ein." },
-  "validation_email_required": { "other": "Bitte geben Sie eine gültige Emailadresse ein." },
-  "validation_email_email": { "other": "Bitte geben Sie eine gültige Emailadresse ein." },
-  "validation_currentpassword_required": { "other": "Geben Sie Ihr aktuelles Passwort ein." },
-  "validation_password_required": { "other": "Bitte geben Sie ein Password ein." },
-  "validation_password2_required": { "other": "Bitte bestätigen Sie Ihr Password." },
-  "validation_password2_match": { "other": "Ihre Passwörter stimmen nicht überein." },
-  "validation_password_minlength": { "other": "Bitte geben Sie mindestens {{.Count}} Zeichen ein." },
-  "validation_promocode_required": { "other": "Bitte geben Sie einen Promo-Code ein." },
-  "validation_pincode_required": { "other": "Bitte geben Sie einen Pin-Code ein." },
-  "validation_gender_required": { "other": "Bitte geben Sie Ihr Geschlecht ein." },
-  "validation_dob_required": { "other": "Bitte geben Sie Ihr Geburtsdatum ein." },
-  "validation_dob_date": { "other": "Bitte geben Sie ein gültiges Geburtsdatum ein." },
-
-  "shopping_info_subtitle_hd": { "other": "Film in HD leihen." },
-  "shopping_info_subtitle_sd": { "other": "SD-Video-on-Demand." },
-  "shopping_info_subtitle_wallet": { "other": "Ihr Guthaben kann für den Kauf oder die Leihe genutzt werden." },
-  "shopping_info_subtitle_help": { "other": "Technische Voraussetzungen." },
-  "shopping_info_ownership_buy": { "other": "kaufen" },
-  "shopping_info_ownership_rent": { "other": "ausleihen" },
-
-  "shopping_info_sd_only": { "other": "Nur in SD verfügbar" },
-  "shopping_info_release_date_title": { "other": "Verfügbar ab {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Sie können den Film jetzt leihen, aber erst ab diesem Datum ansehen." },
-  "shopping_info_release_date_explanation_buy": { "other": "Sie können diesen Film jetzt kaufen, aber erst ab diesem Datum ansehen." },
-
-  "shopping_info_available_until_date_title": { "other": "Verfügbar bis {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Danach können Sie den Film nicht mehr ansehen." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Danach können Sie den Film nicht mehr ansehen." },
-
-  "duration_hour": { "one": "1 Stunde", "other": "{{.Count}} Stunden" },
-  "duration_day": { "one": "1 Tag", "other": "{{.Count}} Tage" },
-  "shopping_info_rental_period_duration": { "other": "Verfügbar für {{.ValueUnit}} " },
-  "shopping_info_watch_window_duration": { "other": "Abspielbar für {{.Count}} Stunden. " },
+  "searchresults_empty_header": {
+    "other": "Keine Ergebnisse gefunden für {{.Query}}"
+  },
+  "searchresults_empty_content": {
+    "other": "Probieren Sie eine andere Suche aus oder <a href=\"{{.HomeURL}}\">durchsuchen Sie unsere Inhalte</a>, um zu finden, wonach Sie suchen."
+  },
+  "validation_name_required": {
+    "other": "Bitte geben Sie Ihren Namen ein."
+  },
+  "validation_email_required": {
+    "other": "Bitte geben Sie eine gültige Emailadresse ein."
+  },
+  "validation_email_email": {
+    "other": "Bitte geben Sie eine gültige Emailadresse ein."
+  },
+  "validation_currentpassword_required": {
+    "other": "Geben Sie Ihr aktuelles Passwort ein."
+  },
+  "validation_password_required": {
+    "other": "Bitte geben Sie ein Password ein."
+  },
+  "validation_password2_required": {
+    "other": "Bitte bestätigen Sie Ihr Password."
+  },
+  "validation_password2_match": {
+    "other": "Ihre Passwörter stimmen nicht überein."
+  },
+  "validation_password_minlength": {
+    "other": "Bitte geben Sie mindestens {{.Count}} Zeichen ein."
+  },
+  "validation_promocode_required": {
+    "other": "Bitte geben Sie einen Promo-Code ein."
+  },
+  "validation_pincode_required": {
+    "other": "Bitte geben Sie einen Pin-Code ein."
+  },
+  "validation_gender_required": {
+    "other": "Bitte geben Sie Ihr Geschlecht ein."
+  },
+  "validation_dob_required": {
+    "other": "Bitte geben Sie Ihr Geburtsdatum ein."
+  },
+  "validation_dob_date": {
+    "other": "Bitte geben Sie ein gültiges Geburtsdatum ein."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "Film in HD leihen."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD-Video-on-Demand."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Ihr Guthaben kann für den Kauf oder die Leihe genutzt werden."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Technische Voraussetzungen."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "kaufen"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "ausleihen"
+  },
+  "shopping_info_sd_only": {
+    "other": "Nur in SD verfügbar"
+  },
+  "shopping_info_release_date_title": {
+    "other": "Verfügbar ab {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Sie können den Film jetzt leihen, aber erst ab diesem Datum ansehen."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Sie können diesen Film jetzt kaufen, aber erst ab diesem Datum ansehen."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Verfügbar bis {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Danach können Sie den Film nicht mehr ansehen."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Danach können Sie den Film nicht mehr ansehen."
+  },
+  "duration_hour": {
+    "one": "1 Stunde",
+    "other": "{{.Count}} Stunden"
+  },
+  "duration_day": {
+    "one": "1 Tag",
+    "other": "{{.Count}} Tage"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "Verfügbar für {{.ValueUnit}} "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "Abspielbar für {{.Count}} Stunden. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Sobald Sie den Film leihen, ist dieser für {{.ValueUnit}} in Ihrem Konto verfügbar. ",
     "other": "Sobald Sie den Film leihen ist dieser für {{.ValueUnit}} in Ihrem Konto verfügbar. "
@@ -227,70 +496,157 @@
     "one": "Sobald Sie eine Episode in dieser Staffel zum ersten Mal abspielen, können die Episoden dieser Staffel während 1 Stunde so oft wiedergegeben werden, wie Sie möchten. ",
     "other": "Sobald Sie eine Episode in dieser Staffel zum ersten Mal abspielen, können die Episoden dieser Staffel während {{.Count}} Stunden so oft wiedergegeben werden, wie Sie möchten."
   },
-  "shopping_info_rental_period_coming_soon": { "other": "ab dem Zeitpunk der Premiere." },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Bonus" },
-
-  "shopping_enter_card_prompt": { "other": "Bitte geben Sie Ihre Kreditkartendetails ein um den Film auszuleihen." },
-
-  "shopping_terms": { "other": "Durch den Abschluss dieser Transaktion stimme ich den <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">Allgemeinen Geschäftsbedingungen</a> zu."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} Rabatt gewährt" },
-  "shopping_discount_apply": { "other": "Anwenden" },
-  "shopping_discount_code": { "other": "Gutscheincode eingeben." },
-  "shopping_discount_have_code": { "other": "Gutschein einlösen." },
-
-  "shopping_price_you_pay": { "other": "Sie zahlen" },
-  "shopping_price_nothing": { "other": "nichts" },
-  "shopping_price_free": { "other": "Kostenlos" },
-
-  "shopping_auth_directions": { "other": "Sie benötigen ein Nutzerkonto. Bitte geben Sie hierfür Ihre Emailadresse ein." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} haben Sie bereits in Ihren Filmen." },
-
-  "shopping_error_missing_card": { "other": "Bitte geben Sie Ihre Kreditkartendetails ein." },
-  "shopping_error_title": { "other": "Es ist ein Fehler aufgetreten." },
-  "shopping_error_incorrect_cvc": { "other": "Bitte geben Sie eine gültige CVV-Nummer ein." },
-  "shopping_error_invalid_cvc": { "other": "Bitte geben Sie eine CVV-Nummer ein." },
-  "shopping_error_incorrect_number": { "other": "Bitte geben Sie eine gültige Kreditkarten-Nummer ein." },
-  "shopping_error_invalid_number": { "other": "Bitte geben Sie eine Kreditkarten-Nummer ein." },
-  "shopping_error_card_declined": { "other": "Die Kreditkarte wurde abgelehnt." },
-  "shopping_error_invalid_expiry_month": { "other": "Bitte geben Sie ein gültiges Datum ein." },
-  "shopping_error_invalid_expiry_year": { "other": "Bitte geben Sie ein gültiges Datum ein." },
-  "shopping_error_expired_card": { "other": "Ihre Kreditkarte ist abgelaufen." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Ihr {{.Ownership}} konnte nicht abgeschlossen werden, weil Ihre Kreditkarte nicht in dem Land ausgestellt wurde, in welchem Sie sich befinden. Bitte benutzen Sie eine andere Karte." },
-  "shopping_error_proxy_detected": { "other": "Ihr {{.Ownership}} konnte nicht abgeschlossen werden. Sie scheinen einen Proxy-Service zu benutzen. Bitte deaktivieren Sie alle Dienste und versuchen Sie es erneut." },
-
-  "shopping_error_discount_worn_out": { "other": "Dieser Promo-Code kann nicht länger genutzt werden." },
-  "shopping_error_discount_blank": { "other": "Bitte geben Sie einen Promo-Code ein." },
-  "shopping_error_discount_not_applied": { "other": "Bitte geben Sie einen gültigen Promo-Code ein." },
-  "shopping_error_discount_invalid": { "other": "Bitte geben Sie einen gültigen Promo-Code ein." },
-  "shopping_error_discount_disabled": { "other": "Bitte geben Sie einen gültigen Promo-Code ein." },
-  "shopping_error_discount_already_applied": { "other": "Es wurde bereits ein Promo-Code eingelöst." },
-  "shopping_error_discount_already_redeemed": { "other": "Dieser Promo-Code wurde bereits eingelöst." },
-  "shopping_error_discount_used_previously": { "other": "Dieser Promo-Code wurde bereits eingelöst." },
-  "shopping_error_discount_max_limit": { "other": "Dieser Promo-Code kann nicht länger genutzt werden." },
-  "shopping_error_discount_expired": { "other": "Dieser Promo-Code ist abgelaufen." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Dieser Promo-Code ist für Käufe ungültig." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Dieser Promo-Code ist für Leihen ungültig." },
-  "shopping_error_discount_invalid_item": { "other": "Dieser Promo-Code ist für diesen Film ungültig." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Dieser Promo-Code ist in Ihrem Land ungültig." },
-  "shopping_error_discounts_not_allowed": { "other": "Dieser Promo-Code ist ungültig." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Dieser Promo-Code ist für Pakete ungültig." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Die Kreditkarte wurde abgelehnt. Bitte versuchen Sie es noch einmal." },
-
-  "shopping_complete_rental": { "other": "Kauf erfolgreich!" },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "ab dem Zeitpunk der Premiere."
+  },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Bonus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Bitte geben Sie Ihre Kreditkartendetails ein um den Film auszuleihen."
+  },
+  "shopping_terms": {
+    "other": "Durch den Abschluss dieser Transaktion stimme ich den <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">Allgemeinen Geschäftsbedingungen</a> zu."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} Rabatt gewährt"
+  },
+  "shopping_discount_apply": {
+    "other": "Anwenden"
+  },
+  "shopping_discount_code": {
+    "other": "Gutscheincode eingeben."
+  },
+  "shopping_discount_have_code": {
+    "other": "Gutschein einlösen."
+  },
+  "shopping_price_you_pay": {
+    "other": "Sie zahlen"
+  },
+  "shopping_price_nothing": {
+    "other": "nichts"
+  },
+  "shopping_price_free": {
+    "other": "Kostenlos"
+  },
+  "shopping_auth_directions": {
+    "other": "Sie benötigen ein Nutzerkonto. Bitte geben Sie hierfür Ihre Emailadresse ein."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} haben Sie bereits in Ihren Filmen."
+  },
+  "shopping_error_missing_card": {
+    "other": "Bitte geben Sie Ihre Kreditkartendetails ein."
+  },
+  "shopping_error_title": {
+    "other": "Es ist ein Fehler aufgetreten."
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Bitte geben Sie eine gültige CVV-Nummer ein."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Bitte geben Sie eine CVV-Nummer ein."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Bitte geben Sie eine gültige Kreditkarten-Nummer ein."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Bitte geben Sie eine Kreditkarten-Nummer ein."
+  },
+  "shopping_error_card_declined": {
+    "other": "Die Kreditkarte wurde abgelehnt."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Bitte geben Sie ein gültiges Datum ein."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Bitte geben Sie ein gültiges Datum ein."
+  },
+  "shopping_error_expired_card": {
+    "other": "Ihre Kreditkarte ist abgelaufen."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Ihr {{.Ownership}} konnte nicht abgeschlossen werden, weil Ihre Kreditkarte nicht in dem Land ausgestellt wurde, in welchem Sie sich befinden. Bitte benutzen Sie eine andere Karte."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Ihr {{.Ownership}} konnte nicht abgeschlossen werden. Sie scheinen einen Proxy-Service zu benutzen. Bitte deaktivieren Sie alle Dienste und versuchen Sie es erneut."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Dieser Promo-Code kann nicht länger genutzt werden."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Bitte geben Sie einen Promo-Code ein."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Bitte geben Sie einen gültigen Promo-Code ein."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Bitte geben Sie einen gültigen Promo-Code ein."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Bitte geben Sie einen gültigen Promo-Code ein."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Es wurde bereits ein Promo-Code eingelöst."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Dieser Promo-Code wurde bereits eingelöst."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Dieser Promo-Code wurde bereits eingelöst."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Dieser Promo-Code kann nicht länger genutzt werden."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Dieser Promo-Code ist abgelaufen."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Dieser Promo-Code ist für Käufe ungültig."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Dieser Promo-Code ist für Leihen ungültig."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Dieser Promo-Code ist für diesen Film ungültig."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Dieser Promo-Code ist in Ihrem Land ungültig."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Dieser Promo-Code ist ungültig."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Dieser Promo-Code ist für Pakete ungültig."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Die Kreditkarte wurde abgelehnt. Bitte versuchen Sie es noch einmal."
+  },
+  "shopping_complete_rental": {
+    "other": "Kauf erfolgreich!"
+  },
   "shopping_complete_rental_period": {
     "one": "Sie können ihre Leihe während eines Tages so oft ansehen, wie Sie möchten. ",
     "other": "Sie können ihre Leihe während {{.Count}} Tagen so oft ansehen, wie Sie möchten. "
   },
-  "shopping_complete_purchase": { "other": "Vielen Dank für den Kauf von {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Vielen Dank für den Kauf von {{.Title}}, {{.CreditTotal}} wurde Ihrem Konto gutgeschrieben." },
-  "shopping_complete_purchase_coming_soon": { "other": "Ab dem {{.Date}} können Sie den Film ansehen." },
-  "shopping_complete_receipt": { "other": "Die Rechnung wurde Ihnen per Email zugeschickt." },
-  "shopping_complete_library_link": { "other": "Sehen Sie Ihre Bibliothek" },
+  "shopping_complete_purchase": {
+    "other": "Vielen Dank für den Kauf von {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Vielen Dank für den Kauf von {{.Title}}, {{.CreditTotal}} wurde Ihrem Konto gutgeschrieben."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Ab dem {{.Date}} können Sie den Film ansehen."
+  },
+  "shopping_complete_receipt": {
+    "other": "Die Rechnung wurde Ihnen per Email zugeschickt."
+  },
+  "shopping_complete_library_link": {
+    "other": "Sehen Sie Ihre Bibliothek"
+  },
   "shopping_complete_plan": {
     "other": "Ihr Kauf von {{ .Title }} war erfolgreich."
-  },  
-
+  },
   "shopping_complete_rental_watch_window_start": {
     "one": "Ab jetzt können Sie den geliehenen Film bis zum nächsten Tag ansehen.",
     "other": "Ab jetzt können Sie den geliehenen Film in den nächsten {{.Count}} Tagen ansehen."
@@ -307,107 +663,244 @@
     "one": "Ab dem {{.Date}} können Sie Ihren geliehenen Film für einen Tag ansehen",
     "other": "Ab dem {{.Date}} können Sie Ihren geliehenen Film während {{.Count}} Tagen ansehen."
   },
-
-  "shopping_action_rent": { "other": "Ausleihen" },
-  "shopping_action_buy": { "other": "Kaufen" },
-
-  "shopping_payment_method_header": { "other": "Zahlungsmethoden" },
-  "shopping_payment_method_credit_card": { "other": "Kreditkarte" },
-  "shopping_payment_method_giropay": { "other": "Giropay (Deutschland)" },
-
-  "shopping_error_stripe_unknown_error": { "other": "Mit dieser Zahlung ist leider etwas schief gelaufen. Bitte versuchen Sie es zu einem späteren Zeitpunkt noch einmal." },
-  "shopping_error_payment_complete_failed": { "other": "Die Zahlung wurde nicht akzeptiert. Bitte schließen Sie das Fenster und versuchen Sie es noch einmal." },
-
-  "meta_detail_cast_title": { "other": "Gießen" },
-  "meta_detail_crew_title": { "other": "Besatzung" },
-  "meta_detail_languages": { "one": "Sprache", "other": "Sprachen" },
-  "meta_detail_studios": { "one": "Studio", "other": "Studios" },
-  "meta_detail_countries": { "one": "Land", "other": "Länder" },
-  "meta_detail_subtitles": { "other": "Untertitel" },
-  "meta_detail_captions": { "other": "Untertitel [CC]" },
-  "meta_detail_episodes_title": { "other": "Episoden" },
-  "meta_detail_bonus_title": { "other": "Bonusinhalt" },
-  "meta_detail_recommendations_title": { "other": "Das könnte Ihnen auch gefallen" },
-  "meta_detail_bundle_items_title": { "other": "Filme in diesem Paket" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} filme" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} Staffeln" },
-  "bundle_items_mixed": { "other": "{{.Count}} Filme und Staffeln" },
-  "userwishlist_page_header": { "other": "Meine Liste" },
-  "userwishlist_slider_header": { "other": "Meine Liste" },
-  "userwishlist_empty_header":  { "other": "Ihre Liste ist leer." },
-  "userwishlist_empty_content": { "other": "Durchsuchen Sie unsere <a href=\"{{.HomeURL}}\">Filmauswahl</a>, um Ihre Filmliste zu füllen." },
-  "userwishlist_button_add": { "other": "Zu meiner Liste hinzufügen" },
-  "userwishlist_button_remove": { "other": "Meine Liste" },
-  "userwishlist_button_add_compact": { "other": "Meine Liste" },
-  "userwishlist_button_remove_compact": { "other": "Meine Liste" },
-
-  "activatedevice_page_header": { "other": "Gerät aktivieren" },
-  "activatedevice_page_content": { "other": "Folgen Sie den Anleitungen auf Ihrem Gerät um einen PIN-Code zu bekommen. Dafür müssen Ihr Computer und Ihr Gerät mit dem Internet verbunden sein." },
-  "activatedevice_form_pin": { "other": "Geheimzahl" },
-  "activatedevice_form_submit": { "other": "Aktivieren" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN-Code nicht gefunden. Bitte versuchen Sie es noch einmal." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN-Code nicht gefunden. Bitte versuchen Sie es noch einmal." },
-  "activatedevice_signin_prompt": { "other": "Bitte loggen Sie sich ein um ein Gerät zu aktivieren." },
-  "activatedevice_page_activated": { "other": "Das Gerät {{.DeviceName}} wurde erfolgreich aktiviert. Sie können jetzt Ihre Filme auf diesem Gerät ansehen." },
-
-  "userdevices_page_header": { "other": "Geräte" },
+  "shopping_action_rent": {
+    "other": "Ausleihen"
+  },
+  "shopping_action_buy": {
+    "other": "Kaufen"
+  },
+  "shopping_payment_method_header": {
+    "other": "Zahlungsmethoden"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Kreditkarte"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay (Deutschland)"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Mit dieser Zahlung ist leider etwas schief gelaufen. Bitte versuchen Sie es zu einem späteren Zeitpunkt noch einmal."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Die Zahlung wurde nicht akzeptiert. Bitte schließen Sie das Fenster und versuchen Sie es noch einmal."
+  },
+  "meta_detail_cast_title": {
+    "other": "Gießen"
+  },
+  "meta_detail_crew_title": {
+    "other": "Besatzung"
+  },
+  "meta_detail_languages": {
+    "one": "Sprache",
+    "other": "Sprachen"
+  },
+  "meta_detail_studios": {
+    "one": "Studio",
+    "other": "Studios"
+  },
+  "meta_detail_countries": {
+    "one": "Land",
+    "other": "Länder"
+  },
+  "meta_detail_subtitles": {
+    "other": "Untertitel"
+  },
+  "meta_detail_captions": {
+    "other": "Untertitel [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Episoden"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Bonusinhalt"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Das könnte Ihnen auch gefallen"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Filme in diesem Paket"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} filme"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} Staffeln"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} Filme und Staffeln"
+  },
+  "userwishlist_page_header": {
+    "other": "Meine Liste"
+  },
+  "userwishlist_slider_header": {
+    "other": "Meine Liste"
+  },
+  "userwishlist_empty_header": {
+    "other": "Ihre Liste ist leer."
+  },
+  "userwishlist_empty_content": {
+    "other": "Durchsuchen Sie unsere <a href=\"{{.HomeURL}}\">Filmauswahl</a>, um Ihre Filmliste zu füllen."
+  },
+  "userwishlist_button_add": {
+    "other": "Zu meiner Liste hinzufügen"
+  },
+  "userwishlist_button_remove": {
+    "other": "Meine Liste"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Meine Liste"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Meine Liste"
+  },
+  "activatedevice_page_header": {
+    "other": "Gerät aktivieren"
+  },
+  "activatedevice_page_content": {
+    "other": "Folgen Sie den Anleitungen auf Ihrem Gerät um einen PIN-Code zu bekommen. Dafür müssen Ihr Computer und Ihr Gerät mit dem Internet verbunden sein."
+  },
+  "activatedevice_form_pin": {
+    "other": "Geheimzahl"
+  },
+  "activatedevice_form_submit": {
+    "other": "Aktivieren"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN-Code nicht gefunden. Bitte versuchen Sie es noch einmal."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN-Code nicht gefunden. Bitte versuchen Sie es noch einmal."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Bitte loggen Sie sich ein um ein Gerät zu aktivieren."
+  },
+  "activatedevice_page_activated": {
+    "other": "Das Gerät {{.DeviceName}} wurde erfolgreich aktiviert. Sie können jetzt Ihre Filme auf diesem Gerät ansehen."
+  },
+  "userdevices_page_header": {
+    "other": "Geräte"
+  },
   "userdevices_page_content": {
     "one": "Ihre verwendeten Geräte werden hier automatisch angezeigt. Es kann maximal 1 Gerät hinzugefügt werden.",
     "other": "Ihre verwendeten Geräte werden hier automatisch angezeigt. Es können maximal {{.Count}} Geräte hinzugefügt werden."
   },
-  "userdevices_empty_content": { "other": "Im Moment sind 0 Geräte registriert." },
-  "userdevices_header_type": { "other": "Gerätetyp" },
-  "userdevices_header_description": { "other": "Beschreibung" },
-  "userdevices_device_added": { "other": "Hinzugefügt am {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Entfernen" },
-  "userdevices_device_actions_cancel": { "other": "Stornieren" },
-  "userdevices_device_actions_confirm": { "other": "Ja, Gerät entfernen" },
-  "userdevices_device_deleted": { "other": "(Entfernt)" },
-
-  "playlist_page_header": { "other": "Wiedergabeliste" },
-  "playlist_sign_in_warning": { "other": "Bitte melden Sie sich an, um Live-TV zu sehen."},
-  "playlist_share_title": { "other": "Wiedergabeliste" },
-  "playlist_up_next_title": { "other": "Nächster Titel" },
-
-  "pricing_ownership_buy": { "other": "Kaufen" },
-  "pricing_ownership_rent": { "other": "Ausleihen" },
-
-  "classification_intro": { "other": "Bewertung: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Wir verwenden Cookies und andere Identifizierungsmerkmale, um Ihre Online-Erfahrung zu verbessern. Mit der Nutzung unserer Website erklären Sie sich damit einverstanden. Lesen Sie gerne unsere <a href=\"{{.CookiePolicyURL}}\">Datenschutzrichtlinie</a> um herauszufinden, wofür Cookies verwendet werden und wie Sie Ihre Einstellungen ändern können." },
-  "cookie_banner_accept": { "other": "Annehmen" },
-
-  "all_rights_reserved": { "other": "Alle Rechte vorbehalten. Kein Teil dieser Website darf ohne unsere schriftliche Genehmigung reproduziert werden." },
-
-  "availability_coming_soon": {"other": "In Kürze verfügbar"},
-  "availability_available": {"other": "Verfügbar ab {{.ReleaseDate}}"},
-  "availability_expired": { "other": "Abgelaufen" },
-  "availability_sold_out": { "other": "Ausverkauft" },
-  "availability_not_available_in_country": { "other": "Nicht verfügbar" },
-
-  "datetime_today": { "other": "heute {{.Date}}" },
-  "datetime_tomorrow": { "other": "morgen {{.Date}}" },
-  "datetime_yesterday": { "other": "gestern {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "{{.Date}}" },
-
-  "modal_cancel": { "other": "Abbrechen" },
-
-  "combined_auth_signin_prompt": { "other": "Anmelden" },
-  "combined_auth_signup_prompt": { "other": "Konto anlegen" },
-  "combined_auth_terms": { "other": "Ich stimme allen <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Nutzungsbedingungen &amp; Bedingungen</a>." },
-
-  "shopping_card_change": { "other": "Kreditkarte nicht korrekt? <a href=\"{{.SubscriptionsURL}}\">Klicken Sie hier, um Ihre Karte zu aktualisieren.</a>" },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Looks like you're having trouble.</p><p>Reset your PIN or contact us for <a href=\"{{.HelpURL}}\" target=\"_blank\">help</a>" },
-
-  "app_badge_title": { "other": "Laden Sie die App herunter, um Ihre gekauften Inhalte anzuzeigen!" },
-  "app_badge_ios": { "other": "Herunterladen im App Store" },
-  "app_badge_android": { "other": "Bekomm es auf Google Play" },
-
+  "userdevices_empty_content": {
+    "other": "Im Moment sind 0 Geräte registriert."
+  },
+  "userdevices_header_type": {
+    "other": "Gerätetyp"
+  },
+  "userdevices_header_description": {
+    "other": "Beschreibung"
+  },
+  "userdevices_device_added": {
+    "other": "Hinzugefügt am {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Entfernen"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Stornieren"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Ja, Gerät entfernen"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Entfernt)"
+  },
+  "playlist_page_header": {
+    "other": "Wiedergabeliste"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Bitte melden Sie sich an, um Live-TV zu sehen."
+  },
+  "playlist_share_title": {
+    "other": "Wiedergabeliste"
+  },
+  "playlist_up_next_title": {
+    "other": "Nächster Titel"
+  },
+  "pricing_ownership_buy": {
+    "other": "Kaufen"
+  },
+  "pricing_ownership_rent": {
+    "other": "Ausleihen"
+  },
+  "classification_intro": {
+    "other": "Bewertung: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Wir verwenden Cookies und andere Identifizierungsmerkmale, um Ihre Online-Erfahrung zu verbessern. Mit der Nutzung unserer Website erklären Sie sich damit einverstanden. Lesen Sie gerne unsere <a href=\"{{.CookiePolicyURL}}\">Datenschutzrichtlinie</a> um herauszufinden, wofür Cookies verwendet werden und wie Sie Ihre Einstellungen ändern können."
+  },
+  "cookie_banner_accept": {
+    "other": "Annehmen"
+  },
+  "all_rights_reserved": {
+    "other": "Alle Rechte vorbehalten. Kein Teil dieser Website darf ohne unsere schriftliche Genehmigung reproduziert werden."
+  },
+  "availability_coming_soon": {
+    "other": "In Kürze verfügbar"
+  },
+  "availability_available": {
+    "other": "Verfügbar ab {{.ReleaseDate}}"
+  },
+  "availability_expired": {
+    "other": "Abgelaufen"
+  },
+  "availability_sold_out": {
+    "other": "Ausverkauft"
+  },
+  "availability_not_available_in_country": {
+    "other": "Nicht verfügbar"
+  },
+  "datetime_today": {
+    "other": "heute {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "morgen {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "gestern {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "{{.Date}}"
+  },
+  "modal_cancel": {
+    "other": "Abbrechen"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Anmelden"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Konto anlegen"
+  },
+  "combined_auth_terms": {
+    "other": "Ich stimme allen <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Nutzungsbedingungen &amp; Bedingungen</a>."
+  },
+  "shopping_card_change": {
+    "other": "Kreditkarte nicht korrekt? <a href=\"{{.SubscriptionsURL}}\">Klicken Sie hier, um Ihre Karte zu aktualisieren.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Looks like you're having trouble.</p><p>Reset your PIN or contact us for <a href=\"{{.HelpURL}}\" target=\"_blank\">help</a>"
+  },
+  "app_badge_title": {
+    "other": "Laden Sie die App herunter, um Ihre gekauften Inhalte anzuzeigen!"
+  },
+  "app_badge_ios": {
+    "other": "Herunterladen im App Store"
+  },
+  "app_badge_android": {
+    "other": "Bekomm es auf Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Preis"
   },
@@ -478,122 +971,287 @@
   },
   "donate_button_text": {
     "other": "Spenden"
-  }, 
-  "shopping_error_plan_already_owned": { "other": "Sie haben diesen Plan bereits." },
-  "shopping_error_plan_expired": { "other": "Dieser Plan ist nicht mehr verfügbar." },
-
-  "header_banner": { "other": "ABC Cinemas – 21. Filmfestival, 1. – 6. Juni 2021" },
-
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "Sie haben keinen PIN-Satz, der zum Kaufen, Ausleihen und Ansehen einiger Titel erforderlich ist."},
-  "account_form_set_pin": { "other": "PIN festlegen" },
-  "account_form_pin_changed": { "other": "Aktualisiert" },
-  "account_form_change_pin": { "other": "PIN ändern" },
-
-  "user_set_pin_header": { "other": "Legen Sie Ihre PIN fest" },
-  "user_set_pin_button": { "other": "PIN festlegen" },
-  "user_submit_pin_heading": { "other": "Geben Sie Ihre PIN für diesen eingeschränkten Inhalt {{.Action}} ein" },
-  "user_error_wrong_pin_retry": { "other": "Hoppla, Sie haben eine falsche PIN eingegeben" },
-  "user_submit_pin_button": { "other": "Eingeben" },
-  "user_reset_pin_button": { "other": "PIN zurücksetzen" },
-
-  "validation_pincode1_required": { "other": "Bitte geben Sie einen gültigen PIN-Code ein." },
-  "validation_pincode2_required": { "other": "Bitte geben Sie einen gültigen PIN-Code ein." },
-  "validation_pincode1_pattern": { "other": "Bitte geben Sie einen gültigen PIN-Code ein." },
-  "validation_pincode2_pattern": { "other": "Bitte geben Sie einen gültigen PIN-Code ein." },
-  "validation_pincode2_match": { "other": "PIN-Code stimmt nicht überein." },
-
-  "userdevices_delete_limits": { "other": "Sie können alle {{.Period}} Tag(e) {{.Limit}} Gerät(e) aus dieser Liste entfernen."},
-  "userdevices_delete_limit_reached": { "other": "Sie haben dieses Limit erreicht und können derzeit keine Geräte entfernen. Sie können ein Gerät in {{.Days}} Tag(en) löschen." },
-  "shopping_card_new_subscription": { "other": "Diese Karte wird gespeichert und regelmäßig belastet" },
-
-  "changepincode_modal_header": { "other": "Ändern Sie Ihre PIN" },
-  "changepincode_modal_currentpassword": { "other": "Dein aktuelles Passwort" },
-  "changepincode_modal_pincode1": { "other": "Ihre neue 4-stellige PIN" },
-  "changepincode_modal_pincode2": { "other": "Bestätigen Sie Ihre neue 4-stellige PIN" },
-  "changepincode_modal_submit": { "other": "PIN festlegen" },
-  "changepincode_modal_error_wrong_password": { "other": "Dieses Passwort ist falsch." },
-
-  "user_set_pin_intro": { "other": "Sie benötigen eine PIN für {{.Action}} eingeschränkte Inhalte"},
-  "user_error_wrong_pin_reset": { "other": "Klicken Sie hier, um Ihre PIN zurückzusetzen" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Dieser Inhalt ist altersbeschränkt." },
-  "shopping_error_close_button": { "other": "OK" }, 
-
-  "usersubscriptions_subscription_expiry": { "other": "Läuft ab {{.Expiry}}" },
-  "usersubscriptions_subscription_status_cancelled": { "other": "usersubscriptions_subscription_status_cancelled" },
-  "usersubscriptions_subscription_status_errored": { "other": "usersubscriptions_subscription_status_errored" },
-  "usersubscriptions_subscription_status_past_due": { "other": "usersubscriptions_subscription_status_past_due" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Probezeit" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Mein Abonnement kündigen" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Stornieren" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Ja, mein Abonnement kündigen" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Abonnement beenden?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "Dadurch wird das Abonnement des Plans {{.Name}} gekündigt. Sie können den Inhalt des Plans weiterhin ansehen, bis er abläuft {{.Expiry}}." },
-
-  "wcag_skip_links_header": { "other": "Zugänglichkeitslinks" },
-  "wcag_skip_links_content": { "other": "Zum Inhalt springen" },
-
-  "wcag_homepage_h1": { "other": "Startseite" },
-  "wcag_carousel_h2": { "other": "Karussell" },
-  "wcag_collections_h2": { "other": "Sammlungen" },
-
-  "wcag_aria_label_footer": { "other": "Fusszeile" },
-  "wcag_aria_label_nav_main": { "other": "Hauptsächlich" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Navigation umschalten" },
-  "wcag_aria_label_bundle_items": { "other": "Bundle-Artikel" },
-  "wcag_aria_label_carousel": { "other": "Karussell" },
-  "wcag_aria_label_page_collection": { "other": "Seitensammlung" },
-  "wcag_aria_label_collection_list": { "other": "Sammlungsliste" },
-  "wcag_aria_label_collection_slider": { "other": "Sammlungsschieber" },
-  "wcag_aria_label_wishlist": { "other": "Wunschzettel" },
-  "wcag_aria_label_facebook": { "other": "Auf Facebook teilen" },
-  "wcag_aria_label_twitter": { "other": "Auf Twitter teilen" },
-  "wcag_aria_label_linkedin": { "other": "Auf LinkedIn teilen" },
-  "wcag_aria_label_letterboxd": { "other": "Ansicht auf Letterboxd" },
-
-  "signin_form_error_ip_throttled": { "other": "Sie haben sich zu oft nicht angemeldet. Bitte versuchen Sie es später erneut." },
-  "signin_form_error_account_suspended": { "other": "Dein Account wurde vorrübergehend gesperrt. Bitte wenden Sie sich an einen Administrator, wenn Sie glauben, dass dies ein Fehler ist." },
-
-
-  "users_gender_none": { "other": "Keine Angabe" },
-  "users_gender_female": { "other": "Weiblich" },
-  "users_gender_male": { "other": "Männlich" },
-  "users_gender_diverse": { "other": "Vielfältig" },
-  "users_gender_other": { "other": "Andere" },
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "Nur HD" },
-  "pricing_quality_sd_only": { "other": "Nur SD" },
-
-  "shopping_card_save_card": { "other": "Bewahren Sie diese Karte zur späteren Verwendung auf" },
-  "shopping_card_button_change": { "other": "Alle gespeicherten Karten anzeigen" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} endet in {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(läuft ab {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(abgelaufen)" },
-  "shopping_card_use_other": { "other": "Verwenden Sie eine neue Karte" },
-  "shopping_card_use_new_card": { "other": "Karte wechseln" },
-  "shopping_card_update_reason_none": { "other": "Aktualisieren Sie Ihre Kreditkarte. Unterstützte Karten sind Visa, Mastercard und American Express." },
-  "shopping_info_ownership_plan": { "other": "Abonnement" },
-  "shopping_action_credit": { "other": "Nachfüllen" },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Kreditkarte ändern" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Kreditkartendaten aktualisieren" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Aktualisieren" },
-
-  "availability_renting": { "other": "Vermietung" },
-  "availability_not_available": { "other": "Nicht verfügbar" },
-  "availability_in_watch_window": { "other": "Verfügbar im Uhrenfenster" },
-
-  "play": { "other": "Spiel" },
-
-
-  "shopping_error_item_limit_exceeded": { "other": "Leider ist {{.Title}} ausverkauft." },
-
-  "availability_expires": { "other": "Läuft ab {{.Expiry}}" },
-  "availability_available_till": { "other": "Verfügbar bis zum {{.ExpiryDate}}" },
-
-  "validation_terms_required": { "other": "Sie müssen den Nutzungsbedingungen zustimmen." }
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Sie haben diesen Plan bereits."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Dieser Plan ist nicht mehr verfügbar."
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21. Filmfestival, 1. – 6. Juni 2021"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Sie haben keinen PIN-Satz, der zum Kaufen, Ausleihen und Ansehen einiger Titel erforderlich ist."
+  },
+  "account_form_set_pin": {
+    "other": "PIN festlegen"
+  },
+  "account_form_pin_changed": {
+    "other": "Aktualisiert"
+  },
+  "account_form_change_pin": {
+    "other": "PIN ändern"
+  },
+  "user_set_pin_header": {
+    "other": "Legen Sie Ihre PIN fest"
+  },
+  "user_set_pin_button": {
+    "other": "PIN festlegen"
+  },
+  "user_submit_pin_heading": {
+    "other": "Geben Sie Ihre PIN für diesen eingeschränkten Inhalt {{.Action}} ein"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Hoppla, Sie haben eine falsche PIN eingegeben"
+  },
+  "user_submit_pin_button": {
+    "other": "Eingeben"
+  },
+  "user_reset_pin_button": {
+    "other": "PIN zurücksetzen"
+  },
+  "validation_pincode1_required": {
+    "other": "Bitte geben Sie einen gültigen PIN-Code ein."
+  },
+  "validation_pincode2_required": {
+    "other": "Bitte geben Sie einen gültigen PIN-Code ein."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Bitte geben Sie einen gültigen PIN-Code ein."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Bitte geben Sie einen gültigen PIN-Code ein."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN-Code stimmt nicht überein."
+  },
+  "userdevices_delete_limits": {
+    "other": "Sie können alle {{.Period}} Tag(e) {{.Limit}} Gerät(e) aus dieser Liste entfernen."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Sie haben dieses Limit erreicht und können derzeit keine Geräte entfernen. Sie können ein Gerät in {{.Days}} Tag(en) löschen."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Diese Karte wird gespeichert und regelmäßig belastet"
+  },
+  "changepincode_modal_header": {
+    "other": "Ändern Sie Ihre PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Dein aktuelles Passwort"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Ihre neue 4-stellige PIN"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Bestätigen Sie Ihre neue 4-stellige PIN"
+  },
+  "changepincode_modal_submit": {
+    "other": "PIN festlegen"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Dieses Passwort ist falsch."
+  },
+  "user_set_pin_intro": {
+    "other": "Sie benötigen eine PIN für {{.Action}} eingeschränkte Inhalte"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Klicken Sie hier, um Ihre PIN zurückzusetzen"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Dieser Inhalt ist altersbeschränkt."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Läuft ab {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "usersubscriptions_subscription_status_cancelled"
+  },
+  "usersubscriptions_subscription_status_errored": {
+    "other": "usersubscriptions_subscription_status_errored"
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "usersubscriptions_subscription_status_past_due"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Probezeit"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Mein Abonnement kündigen"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Stornieren"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Ja, mein Abonnement kündigen"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Abonnement beenden?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Dadurch wird das Abonnement des Plans {{.Name}} gekündigt. Sie können den Inhalt des Plans weiterhin ansehen, bis er abläuft {{.Expiry}}."
+  },
+  "wcag_skip_links_header": {
+    "other": "Zugänglichkeitslinks"
+  },
+  "wcag_skip_links_content": {
+    "other": "Zum Inhalt springen"
+  },
+  "wcag_homepage_h1": {
+    "other": "Startseite"
+  },
+  "wcag_carousel_h2": {
+    "other": "Karussell"
+  },
+  "wcag_collections_h2": {
+    "other": "Sammlungen"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Fusszeile"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Hauptsächlich"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Navigation umschalten"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Bundle-Artikel"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Karussell"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Seitensammlung"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Sammlungsliste"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Sammlungsschieber"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Wunschzettel"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Auf Facebook teilen"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Auf Twitter teilen"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Auf LinkedIn teilen"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Ansicht auf Letterboxd"
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Sie haben sich zu oft nicht angemeldet. Bitte versuchen Sie es später erneut."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Dein Account wurde vorrübergehend gesperrt. Bitte wenden Sie sich an einen Administrator, wenn Sie glauben, dass dies ein Fehler ist."
+  },
+  "users_gender_none": {
+    "other": "Keine Angabe"
+  },
+  "users_gender_female": {
+    "other": "Weiblich"
+  },
+  "users_gender_male": {
+    "other": "Männlich"
+  },
+  "users_gender_diverse": {
+    "other": "Vielfältig"
+  },
+  "users_gender_other": {
+    "other": "Andere"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "Nur HD"
+  },
+  "pricing_quality_sd_only": {
+    "other": "Nur SD"
+  },
+  "shopping_card_save_card": {
+    "other": "Bewahren Sie diese Karte zur späteren Verwendung auf"
+  },
+  "shopping_card_button_change": {
+    "other": "Alle gespeicherten Karten anzeigen"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} endet in {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(läuft ab {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(abgelaufen)"
+  },
+  "shopping_card_use_other": {
+    "other": "Verwenden Sie eine neue Karte"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Karte wechseln"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Aktualisieren Sie Ihre Kreditkarte. Unterstützte Karten sind Visa, Mastercard und American Express."
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Abonnement"
+  },
+  "shopping_action_credit": {
+    "other": "Nachfüllen"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Kreditkarte ändern"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Kreditkartendaten aktualisieren"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Aktualisieren"
+  },
+  "availability_renting": {
+    "other": "Vermietung"
+  },
+  "availability_not_available": {
+    "other": "Nicht verfügbar"
+  },
+  "availability_in_watch_window": {
+    "other": "Verfügbar im Uhrenfenster"
+  },
+  "play": {
+    "other": "Spiel"
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Leider ist {{.Title}} ausverkauft."
+  },
+  "availability_expires": {
+    "other": "Läuft ab {{.Expiry}}"
+  },
+  "availability_available_till": {
+    "other": "Verfügbar bis zum {{.ExpiryDate}}"
+  },
+  "validation_terms_required": {
+    "other": "Sie müssen den Nutzungsbedingungen zustimmen."
+  }
 }

--- a/site/ee_EE.all.json
+++ b/site/ee_EE.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Seaded" },
-  "powered_by": { "other": "Toiteallikaks" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "koostöös" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "Inglise" },
-  "fr": { "other": "prantsuse keel" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Seaded"
+  },
+  "powered_by": {
+    "other": "Toiteallikaks"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "koostöös"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "Inglise"
+  },
+  "fr": {
+    "other": "prantsuse keel"
+  },
   "episode_name": {
     "other": "Episood"
   },
-
   "season_name": {
     "other": "Hooaeg"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "üks hooaeg",
     "other": "{{.Count}} hooaega"
   },
@@ -38,179 +55,441 @@
     "one": "1 Episood",
     "other": "{{.Count}} Episoodi"
   },
-
-  "date_day": { "other": "Päev" },
-  "date_month": { "other": "Kuu" },
-  "date_year": { "other": "Aasta" },
-
-  "404_page_header": { "other": "Lehte ei leitud..." },
-  "404_page_content": { "other": "<p>Vabandame, näib, otsitud lehte ei eksisteeri.</p><p>Selle asukoht võib olla muutunud või on see kustutatud. Või tegid sa kirjutamisel vea.</p><p>Proovi minna tagasi avalehele ja otsi uuesti.</p><p><a href=\"{{.URL}}\">Tagasi lehele.</a></p>" },
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Logi sisse" },
-  "nav_signup": { "other": "Loo konto" },
-  "nav_signed_in_as": { "other": "Sisse logitud kui" },
-  "nav_library": { "other": "Minu filmid" },
-  "nav_devices": { "other": "Minu seadmed" },
-  "nav_wishlist": { "other": "Minu nimekiri" },
-  "nav_account": { "other": "Minu konto" },
-  "nav_signout": { "other": "Logi välja" },
-  "play_trailer": { "other": "Treiler" },
-  "runtime_hours": { "other": "h" },
-  "runtime_minutes": { "other": "min" },
-
-  "datetime_today": { "other": "täna {{.Date}}" },
-  "datetime_tomorrow": { "other": "homme {{.Date}}" },
-  "datetime_yesterday": { "other": "eile {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "eelmine {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Otsing" },
-  "search_control_submit": { "other": "Otsi" },
-
-  "play_button_watch": { "other" : "Vaata"},
-  "play_button_resume": { "other" : "Jätka"},
-
-  "social_media_buttons_title": { "other": "Jaga" },
-  "social_media_buttons_facebook": { "other": "Jaga Facebookis" },
-  "social_media_buttons_twitter": { "other": "Jaga Twitteris" },
-  "social_media_buttons_linkedin": { "other": "Jaga Linkedinis" },
-  "social_media_buttons_email": { "other": "Jaga meili teel" },
-  "social_media_buttons_email_subject": { "other": "Lingi jagamine" },
-  "social_media_buttons_copied_link": { "other": "Link on lõikelauale kopeeritud!" },
-  "social_media_buttons_copy_link": { "other": "Kopeerida lõikelauale" },
-
-  "accept_invite_page_header": { "other": "Tere tulemast " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Näib, et sa oled kutse juba vastu võtnud. Sa peaksid hoopis <a href=\"{{.SigninURL}}\">sisse logima</a>. Kui oled salasõna unustanud, saad selle <a href=\"{{.ForgotPasswordURL}}\">uuendada</a>." },
-  "acceptinvite_complete": { "other": "Aitäh! Sinu konto on loodud." },
-  "acceptinvite_form_submit": { "other": "Võta kutse vastu." },
-  "acceptinvite_agreement": { "other": "Vajutades Võta kutse vastu kinnitad, et oled lugenud ja nõustud <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">kasutustingimustega</a> ja <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">privaatsustingimustega</a>." },
-
-  "signup_page_header": { "other": "Loo uus konto" },
-  "signup_form_name": { "other": "Nimi" },
-  "signup_form_email": { "other": "E-posti aadress" },
-  "signup_form_password": { "other": "Salasõna" },
-  "signup_form_password_confirmation": { "other": "Kinnita salasõna" },
-  "signup_form_gender": { "other": "Sugu" },
-  "signup_form_dob": { "other": "Sünniaeg" },
-  "signup_form_submit": { "other": "Saada" },
-
-  "signin_page_header": { "other": "Logi sisse" },
-  "signin_form_email": { "other": "E-posti aadress" },
-  "signin_form_password": { "other": "Salasõna" },
-  "signin_form_remember": { "other": "Pea mind meeles" },
-  "signin_form_submit": { "other": "Saada" },
-  "signin_page_forgotpassword": { "other": "Unustasid salasõna?" },
-  "signin_page_createnewaccount": { "other": "Sul pole kontot? Loo uus konto. " },
-  "signup_page_alreadyhaveanaccount": { "other": "Sul juba on konto? Logi sisse." },
-  "signup_form_error_email_already_in_use": { "other": "E-posti aadress on juba kasutusel." },
-  "signin_form_error_incorrect_credentials": { "other": "Kasutajanimi või salasõna ei kehti." },
-  "signin_form_error_ip_throttled": { "other": "Teil pole liiga palju kordi sisselogimine ebaõnnestunud. Palun proovi hiljem uuesti." },
-  "signin_form_error_account_suspended": { "other": "Sinu konto on ajutiselt suletud. Kui arvate, et see on eksitus, võtke ühendust administraatoriga." },
-
-  "signup_form_error_forbidden": { "other": "On juhtunud viga." },
-
-  "combined_auth_continue": { "other": "Jätka" },
-  "combined_auth_change": { "other": "Muuda" },
-  "combined_auth_signin": { "other": "Logi sisse" },
-  "combined_auth_signup": { "other": "Loo konto" },
-  "combined_auth_signin_password": { "other": "Sisse logimiseks sisesta palun oma salasõna." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Vale salasõna." },
-  "combined_auth_error_forbidden": { "other": "On juhtunud viga." },
-  "combined_auth_error_too_many_requests": { "other": "Liiga palju taotlusi. Palun proovi hiljem uuesti." },
-
-  "forgotpassword_page_header": { "other": "Lähtesta oma salasõna" },
-  "forgotpassword_form_email": { "other": "E-posti aadress" },
-  "forgotpassword_form_submit": { "other": "Lähtesta" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Sellise e-posti aadressiga kontot ei ole." },
-  "forgotpassword_form_error_account_suspended": { "other": "Konto on peatatud." },
-  "forgotpassword_complete": { "other": "Aitäh! Salasõna lähtestamise e-kiri peaks kohe su postkasti jüudma." },
-  "forgotpassword_form_error_forbidden": { "other": "On toimunud viga." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Liiga palju taotlusi. Palun proovi hiljem uuesti." },
-
-  "resetpassword_page_header": { "other": "Muuda oma salasõna" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Näib, et salasõna lähtestamisel läks midagi valesti. Palun täida <a href=\"{{.URL}}\">salasõna lähtestamise vorm</a> uuesti." },
-  "resetpassword_form_password": { "other": "Uus salasõna" },
-  "resetpassword_form_password2": { "other": "Kinnita uus salasõna" },
-  "resetpassword_form_submit": { "other": "Muuda" },
-  "resetpassword_complete": { "other": "Aitäh! Sinu salasõna on muudetud ja oled sisse logitud." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Salasõna lähtestamise päring ebaõnnestus. Palun proovi hiljem uuesti." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Salasõna lähtestamise võti on aegunud. Palun täida salasõna lähtestamise vorm uuesti." },
-  "resetpassword_form_error_too_many_requests": { "other": "Liiga palju taotlusi. Palun proovi hiljem uuesti." },
-
-  "account_page_header": { "other": "Minu konto" },
-  "account_form_name": { "other": "Nimi" },
-  "account_form_email": { "other": "E-posti aadress" },
-  "account_form_password": { "other": "Salasõna" },
-  "account_form_change_password": { "other": "Muuda" },
-  "account_form_gender": { "other": "Sugu" },
-  "account_form_dob": { "other": "Sünniaeg" },
-  "account_form_submit": { "other": "Uuenda" },
-  "account_form_submitted": { "other": "Uuendatud" },
-  "account_form_password_changed": { "other": "Uuendatud" },
-  "account_form_error_incorrect_password": { "other": "Salasõna ei kehti." },
-
-  "signup_form_optin": {"other": "Liitu uudiskirjaga"},
-
-  "passwordconfirmation_modal_header": { "other": "Kinnita salasõna" },
-  "passwordconfirmation_modal_label": { "other": "Muudatuste salvestamiseks palun sisesta oma salasõna." },
-  "passwordconfirmation_modal_confirm": { "other": "Kinnita" },
-
-  "changepassword_modal_header": { "other": "Muuda oma salasõna" },
-  "changepassword_modal_currentpassword": { "other": "Praegune salasõnaa" },
-  "changepassword_modal_password": { "other": "Uus salasõna" },
-  "changepassword_modal_password2": { "other": "Kinnita uus salasõna" },
-  "changepassword_modal_submit": { "other": "Uuenda" },
-  "changepassword_modal_error_incorrect_password": { "other": "Salasõna ei kehti." },
-
-  "userlibrary_page_header": { "other": "Minu filmid" },
-  "userlibrary_empty_header":  { "other": "Otsingu tulemused" },
-  "userlibrary_empty_content": { "other": "Täida nimekiri meie <a href=\"{{.HomeURL}}\">valikust</a>. " },
-
-  "searchresults_page_header": { "other": "Otsingu tulemused" },
-  "searchresults_load_more": { "other": "Lae {{.Count}} veel" },
+  "date_day": {
+    "other": "Päev"
+  },
+  "date_month": {
+    "other": "Kuu"
+  },
+  "date_year": {
+    "other": "Aasta"
+  },
+  "404_page_header": {
+    "other": "Lehte ei leitud..."
+  },
+  "404_page_content": {
+    "other": "<p>Vabandame, näib, otsitud lehte ei eksisteeri.</p><p>Selle asukoht võib olla muutunud või on see kustutatud. Või tegid sa kirjutamisel vea.</p><p>Proovi minna tagasi avalehele ja otsi uuesti.</p><p><a href=\"{{.URL}}\">Tagasi lehele.</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Logi sisse"
+  },
+  "nav_signup": {
+    "other": "Loo konto"
+  },
+  "nav_signed_in_as": {
+    "other": "Sisse logitud kui"
+  },
+  "nav_library": {
+    "other": "Minu filmid"
+  },
+  "nav_devices": {
+    "other": "Minu seadmed"
+  },
+  "nav_wishlist": {
+    "other": "Minu nimekiri"
+  },
+  "nav_account": {
+    "other": "Minu konto"
+  },
+  "nav_signout": {
+    "other": "Logi välja"
+  },
+  "play_trailer": {
+    "other": "Treiler"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "min"
+  },
+  "datetime_today": {
+    "other": "täna {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "homme {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "eile {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "eelmine {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Otsing"
+  },
+  "search_control_submit": {
+    "other": "Otsi"
+  },
+  "play_button_watch": {
+    "other": "Vaata"
+  },
+  "play_button_resume": {
+    "other": "Jätka"
+  },
+  "social_media_buttons_title": {
+    "other": "Jaga"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Jaga Facebookis"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Jaga Twitteris"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Jaga Linkedinis"
+  },
+  "social_media_buttons_email": {
+    "other": "Jaga meili teel"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Lingi jagamine"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link on lõikelauale kopeeritud!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Kopeerida lõikelauale"
+  },
+  "accept_invite_page_header": {
+    "other": "Tere tulemast "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Näib, et sa oled kutse juba vastu võtnud. Sa peaksid hoopis <a href=\"{{.SigninURL}}\">sisse logima</a>. Kui oled salasõna unustanud, saad selle <a href=\"{{.ForgotPasswordURL}}\">uuendada</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Aitäh! Sinu konto on loodud."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Võta kutse vastu."
+  },
+  "acceptinvite_agreement": {
+    "other": "Vajutades Võta kutse vastu kinnitad, et oled lugenud ja nõustud <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">kasutustingimustega</a> ja <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">privaatsustingimustega</a>."
+  },
+  "signup_page_header": {
+    "other": "Loo uus konto"
+  },
+  "signup_form_name": {
+    "other": "Nimi"
+  },
+  "signup_form_email": {
+    "other": "E-posti aadress"
+  },
+  "signup_form_password": {
+    "other": "Salasõna"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Kinnita salasõna"
+  },
+  "signup_form_gender": {
+    "other": "Sugu"
+  },
+  "signup_form_dob": {
+    "other": "Sünniaeg"
+  },
+  "signup_form_submit": {
+    "other": "Saada"
+  },
+  "signin_page_header": {
+    "other": "Logi sisse"
+  },
+  "signin_form_email": {
+    "other": "E-posti aadress"
+  },
+  "signin_form_password": {
+    "other": "Salasõna"
+  },
+  "signin_form_remember": {
+    "other": "Pea mind meeles"
+  },
+  "signin_form_submit": {
+    "other": "Saada"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Unustasid salasõna?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Sul pole kontot? Loo uus konto. "
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Sul juba on konto? Logi sisse."
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "E-posti aadress on juba kasutusel."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Kasutajanimi või salasõna ei kehti."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Teil pole liiga palju kordi sisselogimine ebaõnnestunud. Palun proovi hiljem uuesti."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Sinu konto on ajutiselt suletud. Kui arvate, et see on eksitus, võtke ühendust administraatoriga."
+  },
+  "signup_form_error_forbidden": {
+    "other": "On juhtunud viga."
+  },
+  "combined_auth_continue": {
+    "other": "Jätka"
+  },
+  "combined_auth_change": {
+    "other": "Muuda"
+  },
+  "combined_auth_signin": {
+    "other": "Logi sisse"
+  },
+  "combined_auth_signup": {
+    "other": "Loo konto"
+  },
+  "combined_auth_signin_password": {
+    "other": "Sisse logimiseks sisesta palun oma salasõna."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Vale salasõna."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "On juhtunud viga."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Liiga palju taotlusi. Palun proovi hiljem uuesti."
+  },
+  "forgotpassword_page_header": {
+    "other": "Lähtesta oma salasõna"
+  },
+  "forgotpassword_form_email": {
+    "other": "E-posti aadress"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Lähtesta"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Sellise e-posti aadressiga kontot ei ole."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Konto on peatatud."
+  },
+  "forgotpassword_complete": {
+    "other": "Aitäh! Salasõna lähtestamise e-kiri peaks kohe su postkasti jüudma."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "On toimunud viga."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Liiga palju taotlusi. Palun proovi hiljem uuesti."
+  },
+  "resetpassword_page_header": {
+    "other": "Muuda oma salasõna"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Näib, et salasõna lähtestamisel läks midagi valesti. Palun täida <a href=\"{{.URL}}\">salasõna lähtestamise vorm</a> uuesti."
+  },
+  "resetpassword_form_password": {
+    "other": "Uus salasõna"
+  },
+  "resetpassword_form_password2": {
+    "other": "Kinnita uus salasõna"
+  },
+  "resetpassword_form_submit": {
+    "other": "Muuda"
+  },
+  "resetpassword_complete": {
+    "other": "Aitäh! Sinu salasõna on muudetud ja oled sisse logitud."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Salasõna lähtestamise päring ebaõnnestus. Palun proovi hiljem uuesti."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Salasõna lähtestamise võti on aegunud. Palun täida salasõna lähtestamise vorm uuesti."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Liiga palju taotlusi. Palun proovi hiljem uuesti."
+  },
+  "account_page_header": {
+    "other": "Minu konto"
+  },
+  "account_form_name": {
+    "other": "Nimi"
+  },
+  "account_form_email": {
+    "other": "E-posti aadress"
+  },
+  "account_form_password": {
+    "other": "Salasõna"
+  },
+  "account_form_change_password": {
+    "other": "Muuda"
+  },
+  "account_form_gender": {
+    "other": "Sugu"
+  },
+  "account_form_dob": {
+    "other": "Sünniaeg"
+  },
+  "account_form_submit": {
+    "other": "Uuenda"
+  },
+  "account_form_submitted": {
+    "other": "Uuendatud"
+  },
+  "account_form_password_changed": {
+    "other": "Uuendatud"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Salasõna ei kehti."
+  },
+  "signup_form_optin": {
+    "other": "Liitu uudiskirjaga"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Kinnita salasõna"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Muudatuste salvestamiseks palun sisesta oma salasõna."
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Kinnita"
+  },
+  "changepassword_modal_header": {
+    "other": "Muuda oma salasõna"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Praegune salasõnaa"
+  },
+  "changepassword_modal_password": {
+    "other": "Uus salasõna"
+  },
+  "changepassword_modal_password2": {
+    "other": "Kinnita uus salasõna"
+  },
+  "changepassword_modal_submit": {
+    "other": "Uuenda"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Salasõna ei kehti."
+  },
+  "userlibrary_page_header": {
+    "other": "Minu filmid"
+  },
+  "userlibrary_empty_header": {
+    "other": "Otsingu tulemused"
+  },
+  "userlibrary_empty_content": {
+    "other": "Täida nimekiri meie <a href=\"{{.HomeURL}}\">valikust</a>. "
+  },
+  "searchresults_page_header": {
+    "other": "Otsingu tulemused"
+  },
+  "searchresults_load_more": {
+    "other": "Lae {{.Count}} veel"
+  },
   "searchresults_total": {
     "one": "Leitud {{.Count}} vastust otsingule \"{{.Query}}\".",
     "other": "Leitud {{.Count}} vastust otsingule \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "Otsingule \"{{.Query}}\" ei leitud vastuseid" },
-  "searchresults_empty_content": { "other": "Proovi uut otsingut või <a href=\"{{.HomeURL}}\">lehitse</a>." },
-
-  "validation_name_required": { "other": "Palun sisesta oma nimi." },
-  "validation_email_required": { "other": "Palun sisesta oma e-posti aadress." },
-  "validation_email_email": { "other": "Palun sisesta kehtiv e-posti aadress." },
-  "validation_currentpassword_required": { "other": "Palun sisesta praegune salasõna." },
-  "validation_password_required": { "other": "Palun sisesta uus salasõna." },
-  "validation_password2_required": { "other": "Kinnita uus salasõna." },
-  "validation_password2_match": { "other": "Salasõnad on erinevad." },
-  "validation_password_minlength": { "other": "Palun sisesta vähemalt {{.Count}} tähte." },
-  "validation_promocode_required": { "other": "Palun sisesta sooduskood." },
-  "validation_pincode_required": { "other": "Sisestage PIN-kood." },
-  "validation_gender_required": { "other": "Palun vali sulle sobivaim sugu." },
-  "validation_dob_required": { "other": "Palun sisesta oma sünniaeg." },
-  "validation_dob_date": { "other": "Palun sisesta korrektne sünniaeg." },
-
-  "shopping_info_subtitle_hd": { "other": "HD-video nõudmisel." },
-  "shopping_info_subtitle_sd": { "other": "Tutvu nõuetega süsteemile." },
-  "shopping_info_subtitle_wallet": { "other": "Teie Walletis olevaid vahendeid võib kasutada ScreenPlusis mis tahes sisu ostmiseks või rentimiseks." },
-  "shopping_info_subtitle_help": { "other": "Tutvu süsteeminõuetega." },
-  "shopping_info_ownership_buy": { "other": "ost" },
-  "shopping_info_ownership_rent": { "other": "pilet" },
-
-  "shopping_info_sd_only": { "other": "Piiratud ainult SD taasesitusega." },
-  "shopping_info_release_date_title": { "other": "Film on vaadatav alates {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Pileti võid osta juba praegu, kuid film avaneb antud kuupäeval." },
-  "shopping_info_release_date_explanation_buy": { "other": "Pileti võid osta juba praegu, kuid film avaneb antud kuupäeval." },
-
-  "shopping_info_available_until_date_title": { "other": "Vaadatav kuni {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Pärast antud kuupäeva ei saa filmi enam vaadata." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Pärast antud kuupäeva ei saa filmi enam vaadata." },
-
-  "duration_hour": { "one": "1 tund", "other": "{{.Count}} tundi" },
-  "duration_day": { "one": "1 päev", "other": "{{.Count}} päeva" },
-  "shopping_info_rental_period_duration": { "other": "Pilet kehtib {{.ValueUnit}} " },
-  "shopping_info_watch_window_duration": { "other": "{{.Count}} tunnine vaatamise periood. " },
+  "searchresults_empty_header": {
+    "other": "Otsingule \"{{.Query}}\" ei leitud vastuseid"
+  },
+  "searchresults_empty_content": {
+    "other": "Proovi uut otsingut või <a href=\"{{.HomeURL}}\">lehitse</a>."
+  },
+  "validation_name_required": {
+    "other": "Palun sisesta oma nimi."
+  },
+  "validation_email_required": {
+    "other": "Palun sisesta oma e-posti aadress."
+  },
+  "validation_email_email": {
+    "other": "Palun sisesta kehtiv e-posti aadress."
+  },
+  "validation_currentpassword_required": {
+    "other": "Palun sisesta praegune salasõna."
+  },
+  "validation_password_required": {
+    "other": "Palun sisesta uus salasõna."
+  },
+  "validation_password2_required": {
+    "other": "Kinnita uus salasõna."
+  },
+  "validation_password2_match": {
+    "other": "Salasõnad on erinevad."
+  },
+  "validation_password_minlength": {
+    "other": "Palun sisesta vähemalt {{.Count}} tähte."
+  },
+  "validation_promocode_required": {
+    "other": "Palun sisesta sooduskood."
+  },
+  "validation_pincode_required": {
+    "other": "Sisestage PIN-kood."
+  },
+  "validation_gender_required": {
+    "other": "Palun vali sulle sobivaim sugu."
+  },
+  "validation_dob_required": {
+    "other": "Palun sisesta oma sünniaeg."
+  },
+  "validation_dob_date": {
+    "other": "Palun sisesta korrektne sünniaeg."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD-video nõudmisel."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "Tutvu nõuetega süsteemile."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Teie Walletis olevaid vahendeid võib kasutada ScreenPlusis mis tahes sisu ostmiseks või rentimiseks."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Tutvu süsteeminõuetega."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "ost"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "pilet"
+  },
+  "shopping_info_sd_only": {
+    "other": "Piiratud ainult SD taasesitusega."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Film on vaadatav alates {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Pileti võid osta juba praegu, kuid film avaneb antud kuupäeval."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Pileti võid osta juba praegu, kuid film avaneb antud kuupäeval."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Vaadatav kuni {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Pärast antud kuupäeva ei saa filmi enam vaadata."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Pärast antud kuupäeva ei saa filmi enam vaadata."
+  },
+  "duration_hour": {
+    "one": "1 tund",
+    "other": "{{.Count}} tundi"
+  },
+  "duration_day": {
+    "one": "1 päev",
+    "other": "{{.Count}} päeva"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "Pilet kehtib {{.ValueUnit}} "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} tunnine vaatamise periood. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Pärast pileti ostmist on film sinu kontol vaadatav {{.ValueUnit}} jooksul. ",
     "other": "Pärast pileti ostmist on film sinu kontol vaadatav {{.ValueUnit}} jooksul. "
@@ -235,68 +514,154 @@
     "one": "Kui vajutad 'Vaata', on sul on aega 30 tundi, et filmid lõpuni vaadata.",
     "other": "Kui vajutad Play / Mängi konkreetse episoodi aknas, algab esitamine ja sul on {{.Count}} tundi episoodi vaatamiseks."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Boonus" },
-
-  "shopping_enter_card_prompt": { "other": "Sisesta oma krediitkaardi andmed, et lõpetada {{.Verb}}." },
-
-  "shopping_terms": { "other": "Tehingu lõpetamisel nõustud <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">kasutustingimustega</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} soodustus on rakendatud." },
-  "shopping_discount_apply": { "other": "Rakenda" },
-  "shopping_discount_code": { "other": "Sisesta sooduskood." },
-  "shopping_discount_have_code": { "other": "Mul on sooduskood" },
-
-  "shopping_price_you_pay": { "other": "Sina maksad" },
-  "shopping_price_nothing": { "other": "Mitte midagi" },
-  "shopping_price_free": { "other": "Tasuta" },
-
-  "shopping_auth_directions": { "other": "Vajalik on konto olemasolu. Palun sisesta oma e-posti aadress." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} on juba sinu filmide hulgas." },
-
-  "shopping_error_missing_card": { "other": "Palun sisesta oma krediitkaardi andmed." },
-  "shopping_error_title": { "other": "Juhtus viga. " },
-  "shopping_error_incorrect_cvc": { "other": "Palun sisesta kehtiv CVV." },
-  "shopping_error_invalid_cvc": { "other": "Palun sisesta kehtiv CVV." },
-  "shopping_error_incorrect_number": { "other": "Palun sisesta kehtiv krediitkaardi number." },
-  "shopping_error_invalid_number": { "other": "Palun sisesta kehtiv krediitkaardi number." },
-  "shopping_error_card_declined": { "other": "Krediitkaart on tagasi lükatud." },
-  "shopping_error_invalid_expiry_month": { "other": "Palun sisesta kehtiv aegumise tähtaeg." },
-  "shopping_error_invalid_expiry_year": { "other": "Palun sisesta kehtiv aegumise tähtaeg." },
-  "shopping_error_expired_card": { "other": "Krediitkaart on aegunud." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Sinu {{.Ownership}} ei ole lõpule viidud. Sa pead asuma samas riigis, kus krediitkaart on väljastatud. Palun kasuta maksmiseks teist krediitkaarti." },
-  "shopping_error_proxy_detected": { "other": "Sinu {{.Ownership}} ei ole lõpule viidud. Oleme tuvastanud, et sa kasutad proxy teenust või unblockerit. Palun sulge need teenused ja proovi uuesti." },
-
-  "shopping_error_discount_worn_out": { "other": "Seda sooduskoodi ei saa enam kasutada." },
-  "shopping_error_discount_blank": { "other": "Palun sisesta sooduskood." },
-  "shopping_error_discount_not_applied": { "other": "Palun sisesta kehtiv sooduskood." },
-  "shopping_error_discount_invalid": { "other": "Palun sisesta kehtiv sooduskood." },
-  "shopping_error_discount_disabled": { "other": "Palun sisesta kehtiv sooduskood." },
-  "shopping_error_discount_already_applied": { "other": "Sooduskood on selle sessiooni jaoks juba kasutatud." },
-  "shopping_error_discount_already_redeemed": { "other": "Sooduskood on juba kasutatud." },
-  "shopping_error_discount_used_previously": { "other": "Sooduskood on juba kasutatud." },
-  "shopping_error_discount_max_limit": { "other": "Sooduskoodi ei saa enam kasutada." },
-  "shopping_error_discount_expired": { "other": "Sooduskood on aegunud." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Sooduskoodi ei saa ostu juures kasutada." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Sooduskoodi ei saa ostu juures kasutada." },
-  "shopping_error_discount_invalid_item": { "other": "Sooduskoodi ei saa antud toote juures kasutada." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Sooduskoodi ei saa sinu riigis kasutada." },
-  "shopping_error_discounts_not_allowed": { "other": "Sooduskoodi ei saa kasutada." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Sooduskoodi ei saa kogumike juures kasutada." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Krediitkaart on tagasi lükatud. Palun proovi uuesti." },
-
-  "shopping_complete_rental": { "other": "Õnnestus!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Boonus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Sisesta oma krediitkaardi andmed, et lõpetada {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Tehingu lõpetamisel nõustud <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">kasutustingimustega</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} soodustus on rakendatud."
+  },
+  "shopping_discount_apply": {
+    "other": "Rakenda"
+  },
+  "shopping_discount_code": {
+    "other": "Sisesta sooduskood."
+  },
+  "shopping_discount_have_code": {
+    "other": "Mul on sooduskood"
+  },
+  "shopping_price_you_pay": {
+    "other": "Sina maksad"
+  },
+  "shopping_price_nothing": {
+    "other": "Mitte midagi"
+  },
+  "shopping_price_free": {
+    "other": "Tasuta"
+  },
+  "shopping_auth_directions": {
+    "other": "Vajalik on konto olemasolu. Palun sisesta oma e-posti aadress."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} on juba sinu filmide hulgas."
+  },
+  "shopping_error_missing_card": {
+    "other": "Palun sisesta oma krediitkaardi andmed."
+  },
+  "shopping_error_title": {
+    "other": "Juhtus viga. "
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Palun sisesta kehtiv CVV."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Palun sisesta kehtiv CVV."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Palun sisesta kehtiv krediitkaardi number."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Palun sisesta kehtiv krediitkaardi number."
+  },
+  "shopping_error_card_declined": {
+    "other": "Krediitkaart on tagasi lükatud."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Palun sisesta kehtiv aegumise tähtaeg."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Palun sisesta kehtiv aegumise tähtaeg."
+  },
+  "shopping_error_expired_card": {
+    "other": "Krediitkaart on aegunud."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Sinu {{.Ownership}} ei ole lõpule viidud. Sa pead asuma samas riigis, kus krediitkaart on väljastatud. Palun kasuta maksmiseks teist krediitkaarti."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Sinu {{.Ownership}} ei ole lõpule viidud. Oleme tuvastanud, et sa kasutad proxy teenust või unblockerit. Palun sulge need teenused ja proovi uuesti."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Seda sooduskoodi ei saa enam kasutada."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Palun sisesta sooduskood."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Palun sisesta kehtiv sooduskood."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Palun sisesta kehtiv sooduskood."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Palun sisesta kehtiv sooduskood."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Sooduskood on selle sessiooni jaoks juba kasutatud."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Sooduskood on juba kasutatud."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Sooduskood on juba kasutatud."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Sooduskoodi ei saa enam kasutada."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Sooduskood on aegunud."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Sooduskoodi ei saa ostu juures kasutada."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Sooduskoodi ei saa ostu juures kasutada."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Sooduskoodi ei saa antud toote juures kasutada."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Sooduskoodi ei saa sinu riigis kasutada."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Sooduskoodi ei saa kasutada."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Sooduskoodi ei saa kogumike juures kasutada."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Krediitkaart on tagasi lükatud. Palun proovi uuesti."
+  },
+  "shopping_complete_rental": {
+    "other": "Õnnestus!"
+  },
   "shopping_complete_rental_period": {
     "one": "Sul on nüüd aega 30 tundi, et film lõpuni vaadata.",
     "other": "Alusta filmi vaatamisega {{.Count}} päeva jooksul."
   },
-  "shopping_complete_purchase": { "other": "Täname, et ostsid {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Täname, et ostsid {{.Title}}, {{.CreditTotal}} lisati sinu kontole." },
-  "shopping_complete_purchase_coming_soon": { "other": "Saad hakata filmi vaatama alates {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Makse kinnitus saadeti sinu e-posti aadressile." },
-  "shopping_complete_library_link": { "other": "Saad nüüd kogumikus olevaid filme vaatama hakata." },
+  "shopping_complete_purchase": {
+    "other": "Täname, et ostsid {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Täname, et ostsid {{.Title}}, {{.CreditTotal}} lisati sinu kontole."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Saad hakata filmi vaatama alates {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Makse kinnitus saadeti sinu e-posti aadressile."
+  },
+  "shopping_complete_library_link": {
+    "other": "Saad nüüd kogumikus olevaid filme vaatama hakata."
+  },
   "shopping_complete_plan": {
     "other": "Teie ost {{ .Title }} oli edukas."
-  },  
+  },
   "shopping_complete_rental_watch_window_start": {
     "one": "Saad filmi vaatamist alustada {{.Count}} päeva jooksul.",
     "other": "Alusta filmi vaatamisega {{.Count}} päeva jooksul."
@@ -313,147 +678,337 @@
     "one": "Saad filmi vaadata alates {{.Date}} ja sinu pilet kehtib üks päev.",
     "other": "Saad filmi vaadata alates {{.Date}} ja sinu pilet on aktiivne {{.Count}} päeva."
   },
-
-  "shopping_action_rent": { "other": "Osta pilet" },
-  "shopping_action_buy": { "other": "Osta" },
-
-  "meta_detail_cast_title": { "other": "Osades" },
-  "meta_detail_crew_title": { "other": "Meeskond" },
-  "meta_detail_languages": { "one": "Keeled", "other": "Keeled" },
-  "meta_detail_studios": { "one": "Stuudiod", "other": "Stuudiod" },
-  "meta_detail_countries": { "one": "Riigid", "other": "Riigid" },
-  "meta_detail_subtitles": { "other": "Subtiitrid" },
-  "meta_detail_captions": { "other": "Subtiitrid [CC]" },
-  "meta_detail_episodes_title": { "other": "Episoodid" },
-  "meta_detail_bonus_title": { "other": "Lisasisu" },
-  "meta_detail_recommendations_title": { "other": "Sulle võib veel meeldida" },
-  "meta_detail_bundle_items_title": { "other": "Kogumik sisaldab" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} filmi" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} hooaega" },
-  "bundle_items_mixed": { "other": "{{.Count}} filmi ja hooaega" },
-  "userwishlist_page_header": { "other": "Minu nimekiri" },
-  "userwishlist_slider_header": { "other": "Minu nimekiri" },
-  "userwishlist_empty_header":  { "other": "Sinu nimekiri on tühi." },
-  "userwishlist_empty_content": { "other": "Täida see <a href=\"{{.HomeURL}}\">meie valikust</a>." },
-  "userwishlist_button_add": { "other": "Lisa minu nimekirja" },
-  "userwishlist_button_remove": { "other": "Minu nimekiri" },
-  "userwishlist_button_add_compact": { "other": "Minu nimekiri" },
-  "userwishlist_button_remove_compact": { "other": "Minu nimekiri" },
-
-  "activatedevice_page_header": { "other": "Aktiveeri Seade" },
-  "activatedevice_page_content": { "other": "PIN-koodi saamiseks järgige seadmes kuvatavaid juhiseid. Aktiveerimiseks peavad teie arvuti ja seade olema Internetiga ühendatud." },
-  "activatedevice_form_pin": { "other": "PIN-koodi" },
-  "activatedevice_form_submit": { "other": "Aktiveerige" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN-koodi ei leitud, proovige uuesti." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN-koodi ei leitud, proovige uuesti." },
-  "activatedevice_signin_prompt": { "other": "Enne seadme aktiveerimist logige sisse." },
-  "activatedevice_page_activated": { "other": "Täname teid seadme {{.DeviceName}} aktiveerimise eest. Nüüd peaksite saama oma kogu oma teleris või seadmes sirvida." },
-
-  "userdevices_page_header": { "other": "Seadmed" },
+  "shopping_action_rent": {
+    "other": "Osta pilet"
+  },
+  "shopping_action_buy": {
+    "other": "Osta"
+  },
+  "meta_detail_cast_title": {
+    "other": "Osades"
+  },
+  "meta_detail_crew_title": {
+    "other": "Meeskond"
+  },
+  "meta_detail_languages": {
+    "one": "Keeled",
+    "other": "Keeled"
+  },
+  "meta_detail_studios": {
+    "one": "Stuudiod",
+    "other": "Stuudiod"
+  },
+  "meta_detail_countries": {
+    "one": "Riigid",
+    "other": "Riigid"
+  },
+  "meta_detail_subtitles": {
+    "other": "Subtiitrid"
+  },
+  "meta_detail_captions": {
+    "other": "Subtiitrid [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Episoodid"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Lisasisu"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Sulle võib veel meeldida"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Kogumik sisaldab"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} filmi"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} hooaega"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} filmi ja hooaega"
+  },
+  "userwishlist_page_header": {
+    "other": "Minu nimekiri"
+  },
+  "userwishlist_slider_header": {
+    "other": "Minu nimekiri"
+  },
+  "userwishlist_empty_header": {
+    "other": "Sinu nimekiri on tühi."
+  },
+  "userwishlist_empty_content": {
+    "other": "Täida see <a href=\"{{.HomeURL}}\">meie valikust</a>."
+  },
+  "userwishlist_button_add": {
+    "other": "Lisa minu nimekirja"
+  },
+  "userwishlist_button_remove": {
+    "other": "Minu nimekiri"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Minu nimekiri"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Minu nimekiri"
+  },
+  "activatedevice_page_header": {
+    "other": "Aktiveeri Seade"
+  },
+  "activatedevice_page_content": {
+    "other": "PIN-koodi saamiseks järgige seadmes kuvatavaid juhiseid. Aktiveerimiseks peavad teie arvuti ja seade olema Internetiga ühendatud."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN-koodi"
+  },
+  "activatedevice_form_submit": {
+    "other": "Aktiveerige"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN-koodi ei leitud, proovige uuesti."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN-koodi ei leitud, proovige uuesti."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Enne seadme aktiveerimist logige sisse."
+  },
+  "activatedevice_page_activated": {
+    "other": "Täname teid seadme {{.DeviceName}} aktiveerimise eest. Nüüd peaksite saama oma kogu oma teleris või seadmes sirvida."
+  },
+  "userdevices_page_header": {
+    "other": "Seadmed"
+  },
   "userdevices_page_content": {
     "one": "Seade lisatakse selle kasutamisel automaatselt. Seadmete hulka võib kuuluda kuni {{.Count}} seadet.",
     "other": "Seade lisatakse selle kasutamisel automaatselt. Seadmete hulka võib kuuluda kuni {{.Count}} seadet."
   },
-  "userdevices_empty_content": { "other": "Sul on registreeritud 0 seadet." },
-  "userdevices_header_type": { "other": "Seadme tüüp" },
-  "userdevices_header_description": { "other": "Kirjeldus" },
-  "userdevices_device_added": { "other": "Lisatud {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Eemalda" },
-  "userdevices_device_actions_cancel": { "other": "Tühista" },
-  "userdevices_device_actions_confirm": { "other": "Jah, eemalda seade" },
-  "userdevices_device_deleted": { "other": "(Eemaldatud)" },
-
-  "playlist_page_header": { "other": "Esitusloend" },
-  "playlist_sign_in_warning": { "other": "Teleri otseülekande vaatamiseks logige sisse."},
-  "playlist_share_title": { "other": "Esitusloend" },
-  "playlist_up_next_title": { "other": "Järgmisena" },
-
-  "pricing_ownership_buy": { "other": "Osta" },
-  "pricing_ownership_rent": { "other": "Osta pilet" },
-
-  "classification_intro": { "other": "Jaotus: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Kasutuskogemuse parandamiseks kasutab see leht küpsiseid. Lehte edasi kasutades nõustud <a href=\"{{.CookiePolicyURL}}\">küpsiste kasutamisega</a>." },
-  "cookie_banner_accept": { "other": "Nõustu" },
-
-  "all_rights_reserved": { "other": "Kõik õigused kaitstud. Ühtegi selle saidi osa ei tohi reprodutseerida ilma meie kirjaliku loata." },
-
-  "users_gender_none": { "other": "Määramata" },
-  "users_gender_female": { "other": "Naine" },
-  "users_gender_male": { "other": "Mees" },
-  "users_gender_diverse": { "other": "Sooneutraalne" },
-  "users_gender_other": { "other": "Muu" },
-
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "Ainult HD" },
-  "pricing_quality_sd_only": { "other": "Ainult SD" },
-
-  "shopping_card_save_card": { "other": "Hoidke see kaart edaspidiseks kasutamiseks alles" },
-  "shopping_card_button_change": { "other": "Kuva kõik salvestatud kaardid" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}}, mis lõpeb numbritega {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(Aegub {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(aegunud)" },
-  "shopping_card_use_other": { "other": "Kasutage uut kaarti" },
-  "shopping_card_use_new_card": { "other": "Vaheta kaarti" },
-
-  "shopping_info_ownership_plan": { "other": "Tellimus" },
-
-  "shopping_action_credit": { "other": "Täida" },
-
-  "shopping_info_rental_period_coming_soon": { "other": "alates avaldamise kuupäevast ja kellaajast." },
-
-
-  "usersubscriptions_change_payment_method_change": { "other": "Muuda krediitkaarti" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Värskendage krediitkaardi andmeid" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Värskenda" },
-
-  "usersubscriptions_subscription_expiry": { "other": "Aegub {{.Expiry}}" },
-  "usersubscriptions_subscription_status_cancelled": { "other": "usersubscriptions_subscription_status_cancelled" },
-  "usersubscriptions_subscription_status_errored": { "other": "usersubscriptions_subscription_status_errored" },
-  "usersubscriptions_subscription_status_past_due": { "other": "usersubscriptions_subscription_status_past_due" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Prooviperiood" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Tühista minu tellimus" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Tühista" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Jah, tühistage minu tellimus" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Kas tühistada tellimus?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "See tühistab paketi {{.Name}} tellimuse. Saate vaadata paketi sisu, kuni see aegub {{.Expiry}}." },
-
-  "shopping_card_update_reason_none": { "other": "Värskendage oma krediitkaarti. Toetatud kaardid on Visa, Mastercard ja American Express." },
-
-  "availability_coming_soon": { "other": "Tulemas" },
-  "availability_renting": { "other": "Pilet ostetud" },
-  "availability_not_available": { "other": "Pole saadaval" },
-  "availability_in_watch_window": { "other": "Saadaval" },
-  "availability_sold_out": { "other": "Välja müüdud" },
-  "availability_available_till": { "other": "Saadaval kuni {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Pole saadaval" },
-  "availability_available": { "other": "Saadaval {{.ReleaseDate}}" },
-
-  "modal_cancel": { "other": "Tühista" },
-
-  "play": { "other": "Mängi" },
-
-  "combined_auth_signin_prompt": { "other": "Logi sisse" },
-  "combined_auth_signup_prompt": { "other": "Loo konto" },
-  "combined_auth_terms": { "other": "Nõustun kõigi <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">kasutustingimustega</a>." },
-  "signup_terms": { "other": "Nõustun kõigi <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">kasutustingimustega</a>." },
-  "validation_terms_required": { "other": "Sa pead nõustuma kasutustingimustega." },
-  "shopping_error_item_limit_exceeded": { "other": "Kahjuks on {{.Title}} välja müüdud." },
-  "availability_expires": { "other": "Aegub {{.Expiry}}" },
-
-  "shopping_card_change": { "other": "Kas krediitkaart pole õige? <a href=\"{{.SubscriptionsURL}}\">Kaardi värskendamiseks klõpsake siin.</a>" },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Looks like you're having trouble.</p><p>Reset your PIN or contact us for <a href=\"{{.HelpURL}}\" target=\"_blank\">help</a>" },
-
-  "app_badge_title": { "other": "Ostetud sisu vaatamiseks laadige rakendus alla!" },
-  "app_badge_ios": { "other": "Laadige alla App Store'ist" },
-  "app_badge_android": { "other": "Hankige see Google Playst" },
-
+  "userdevices_empty_content": {
+    "other": "Sul on registreeritud 0 seadet."
+  },
+  "userdevices_header_type": {
+    "other": "Seadme tüüp"
+  },
+  "userdevices_header_description": {
+    "other": "Kirjeldus"
+  },
+  "userdevices_device_added": {
+    "other": "Lisatud {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Eemalda"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Tühista"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Jah, eemalda seade"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Eemaldatud)"
+  },
+  "playlist_page_header": {
+    "other": "Esitusloend"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Teleri otseülekande vaatamiseks logige sisse."
+  },
+  "playlist_share_title": {
+    "other": "Esitusloend"
+  },
+  "playlist_up_next_title": {
+    "other": "Järgmisena"
+  },
+  "pricing_ownership_buy": {
+    "other": "Osta"
+  },
+  "pricing_ownership_rent": {
+    "other": "Osta pilet"
+  },
+  "classification_intro": {
+    "other": "Jaotus: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Kasutuskogemuse parandamiseks kasutab see leht küpsiseid. Lehte edasi kasutades nõustud <a href=\"{{.CookiePolicyURL}}\">küpsiste kasutamisega</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Nõustu"
+  },
+  "all_rights_reserved": {
+    "other": "Kõik õigused kaitstud. Ühtegi selle saidi osa ei tohi reprodutseerida ilma meie kirjaliku loata."
+  },
+  "users_gender_none": {
+    "other": "Määramata"
+  },
+  "users_gender_female": {
+    "other": "Naine"
+  },
+  "users_gender_male": {
+    "other": "Mees"
+  },
+  "users_gender_diverse": {
+    "other": "Sooneutraalne"
+  },
+  "users_gender_other": {
+    "other": "Muu"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "Ainult HD"
+  },
+  "pricing_quality_sd_only": {
+    "other": "Ainult SD"
+  },
+  "shopping_card_save_card": {
+    "other": "Hoidke see kaart edaspidiseks kasutamiseks alles"
+  },
+  "shopping_card_button_change": {
+    "other": "Kuva kõik salvestatud kaardid"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}}, mis lõpeb numbritega {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(Aegub {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(aegunud)"
+  },
+  "shopping_card_use_other": {
+    "other": "Kasutage uut kaarti"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Vaheta kaarti"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Tellimus"
+  },
+  "shopping_action_credit": {
+    "other": "Täida"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "alates avaldamise kuupäevast ja kellaajast."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Muuda krediitkaarti"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Värskendage krediitkaardi andmeid"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Värskenda"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Aegub {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "usersubscriptions_subscription_status_cancelled"
+  },
+  "usersubscriptions_subscription_status_errored": {
+    "other": "usersubscriptions_subscription_status_errored"
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "usersubscriptions_subscription_status_past_due"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Prooviperiood"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Tühista minu tellimus"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Tühista"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Jah, tühistage minu tellimus"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Kas tühistada tellimus?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "See tühistab paketi {{.Name}} tellimuse. Saate vaadata paketi sisu, kuni see aegub {{.Expiry}}."
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Värskendage oma krediitkaarti. Toetatud kaardid on Visa, Mastercard ja American Express."
+  },
+  "availability_coming_soon": {
+    "other": "Tulemas"
+  },
+  "availability_renting": {
+    "other": "Pilet ostetud"
+  },
+  "availability_not_available": {
+    "other": "Pole saadaval"
+  },
+  "availability_in_watch_window": {
+    "other": "Saadaval"
+  },
+  "availability_sold_out": {
+    "other": "Välja müüdud"
+  },
+  "availability_available_till": {
+    "other": "Saadaval kuni {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Pole saadaval"
+  },
+  "availability_available": {
+    "other": "Saadaval {{.ReleaseDate}}"
+  },
+  "modal_cancel": {
+    "other": "Tühista"
+  },
+  "play": {
+    "other": "Mängi"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Logi sisse"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Loo konto"
+  },
+  "combined_auth_terms": {
+    "other": "Nõustun kõigi <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">kasutustingimustega</a>."
+  },
+  "signup_terms": {
+    "other": "Nõustun kõigi <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">kasutustingimustega</a>."
+  },
+  "validation_terms_required": {
+    "other": "Sa pead nõustuma kasutustingimustega."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Kahjuks on {{.Title}} välja müüdud."
+  },
+  "availability_expires": {
+    "other": "Aegub {{.Expiry}}"
+  },
+  "shopping_card_change": {
+    "other": "Kas krediitkaart pole õige? <a href=\"{{.SubscriptionsURL}}\">Kaardi värskendamiseks klõpsake siin.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Looks like you're having trouble.</p><p>Reset your PIN or contact us for <a href=\"{{.HelpURL}}\" target=\"_blank\">help</a>"
+  },
+  "app_badge_title": {
+    "other": "Ostetud sisu vaatamiseks laadige rakendus alla!"
+  },
+  "app_badge_ios": {
+    "other": "Laadige alla App Store'ist"
+  },
+  "app_badge_android": {
+    "other": "Hankige see Google Playst"
+  },
   "shopping_price_title_plan": {
     "other": "Hind"
   },
@@ -525,74 +1080,178 @@
   "donate_button_text": {
     "other": "Anneta"
   },
-  "wcag_skip_links_header": { "other": "Juurdepääsetavuse lingid" },
-  "wcag_skip_links_content": { "other": "Jätke sisu juurde" },
-
-  "wcag_homepage_h1": { "other": "Koduleht" },
-  "wcag_carousel_h2": { "other": "Karussell" },
-  "wcag_collections_h2": { "other": "Kollektsioonid" },
-
-  "wcag_aria_label_footer": { "other": "Jalus" },
-  "wcag_aria_label_nav_main": { "other": "Peamine" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Lülitage navigeerimine sisse" },
-  "wcag_aria_label_bundle_items": { "other": "Komplekti esemed" },
-  "wcag_aria_label_carousel": { "other": "Karussell" },
-  "wcag_aria_label_page_collection": { "other": "Lehekülje kollektsioon" },
-  "wcag_aria_label_collection_list": { "other": "Kollektsioonide loend" },
-  "wcag_aria_label_collection_slider": { "other": "Kogumise liugur" },
-  "wcag_aria_label_wishlist": { "other": "Soovinimekiri" },
-  "wcag_aria_label_facebook": { "other": "Jaga Facebook" },
-  "wcag_aria_label_twitter": { "other": "Jaga Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Jagage LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Vaata Letterboxd" },
-  
-  "shopping_error_plan_already_owned": { "other": "See plaan on teil juba olemas." },
-  "shopping_error_plan_expired": { "other": "See plaan pole enam saadaval." },
-  "shopping_payment_method_header": { "other": "Makseviisid" },
-  "shopping_payment_method_credit_card": { "other": "Krediitkaart" },
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  "shopping_error_stripe_unknown_error": { "other": "Selle maksega läks midagi valesti. Palun proovi hiljem uuesti." },
-  "shopping_error_payment_complete_failed": { "other": "Makse lükati tagasi. Sulgege see aken ja proovige uuesti." },
-
-  "header_banner": { "other": "ABC Cinemas – 21. filmifestival, 1.–6. juuni 2021" },
-
-  "account_form_pin_code": { "other": "PIN-kood" },
-  "account_form_pin_code_not_set": { "other": "Teil ei ole määratud PIN-koodi, mida on vaja mõne pealkirja ostmiseks, laenutamiseks ja vaatamiseks."},
-  "account_form_set_pin": { "other": "Määra PIN" },
-  "account_form_pin_changed": { "other": "Uuendatud" },
-  "account_form_change_pin": { "other": "Muuda PIN-koodi" },
-
-  "user_set_pin_header": { "other": "Määrake oma PIN-kood" },
-  "user_set_pin_button": { "other": "Määra PIN" },
-  "user_submit_pin_heading": { "other": "Sisestage selle piiratud sisu {{.Action}} PIN-kood" },
-  "user_error_wrong_pin_retry": { "other": "Oih, sisestasite vale PIN-koodi" },
-  "user_submit_pin_button": { "other": "Sisenema" },
-  "user_reset_pin_button": { "other": "Lähtestage PIN-kood" },
-
-  "validation_pincode1_required": { "other": "Sisestage kehtiv PIN-kood." },
-  "validation_pincode2_required": { "other": "Sisestage kehtiv PIN-kood." },
-  "validation_pincode1_pattern": { "other": "Sisestage kehtiv PIN-kood." },
-  "validation_pincode2_pattern": { "other": "Sisestage kehtiv PIN-kood." },
-  "validation_pincode2_match": { "other": "PIN-kood ei ühti." },
-
-  "userdevices_delete_limits": { "other": "Saate sellest loendist eemaldada {{.Limit}} seadet iga {{.Period}} päeva järel."},
-  "userdevices_delete_limit_reached": { "other": "Olete jõudnud selle limiidini ja te ei saa praegu ühtegi seadet eemaldada. Saate seadme kustutada {{.Days}} päeva pärast." },
-  "shopping_card_new_subscription": { "other": "Seda kaarti salvestatakse ja selle eest võetakse regulaarselt tasu" },
-
-  "changepincode_modal_header": { "other": "Muutke oma PIN-koodi" },
-  "changepincode_modal_currentpassword": { "other": "Teie praegune parool" },
-  "changepincode_modal_pincode1": { "other": "Teie uus 4-kohaline PIN-kood" },
-  "changepincode_modal_pincode2": { "other": "Kinnitage oma uus 4-kohaline PIN-kood" },
-  "changepincode_modal_submit": { "other": "Määra PIN" },
-  "changepincode_modal_error_wrong_password": { "other": "See parool on vale." },
-
-  "user_set_pin_intro": { "other": "Piiratud sisu {{.Action}} jaoks vajate PIN-koodi"},
-  "user_error_wrong_pin_reset": { "other": "PIN-koodi lähtestamiseks klõpsake siin" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Sellel sisul on vanusepiirang." },
-  "shopping_error_close_button": { "other": "Okei" },
-
-  "availability_expired": { "other": "Aegunud"}
+  "wcag_skip_links_header": {
+    "other": "Juurdepääsetavuse lingid"
+  },
+  "wcag_skip_links_content": {
+    "other": "Jätke sisu juurde"
+  },
+  "wcag_homepage_h1": {
+    "other": "Koduleht"
+  },
+  "wcag_carousel_h2": {
+    "other": "Karussell"
+  },
+  "wcag_collections_h2": {
+    "other": "Kollektsioonid"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Jalus"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Peamine"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Lülitage navigeerimine sisse"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Komplekti esemed"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Karussell"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Lehekülje kollektsioon"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Kollektsioonide loend"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Kogumise liugur"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Soovinimekiri"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Jaga Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Jaga Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Jagage LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Vaata Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "See plaan on teil juba olemas."
+  },
+  "shopping_error_plan_expired": {
+    "other": "See plaan pole enam saadaval."
+  },
+  "shopping_payment_method_header": {
+    "other": "Makseviisid"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Krediitkaart"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Selle maksega läks midagi valesti. Palun proovi hiljem uuesti."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Makse lükati tagasi. Sulgege see aken ja proovige uuesti."
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21. filmifestival, 1.–6. juuni 2021"
+  },
+  "account_form_pin_code": {
+    "other": "PIN-kood"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Teil ei ole määratud PIN-koodi, mida on vaja mõne pealkirja ostmiseks, laenutamiseks ja vaatamiseks."
+  },
+  "account_form_set_pin": {
+    "other": "Määra PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Uuendatud"
+  },
+  "account_form_change_pin": {
+    "other": "Muuda PIN-koodi"
+  },
+  "user_set_pin_header": {
+    "other": "Määrake oma PIN-kood"
+  },
+  "user_set_pin_button": {
+    "other": "Määra PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Sisestage selle piiratud sisu {{.Action}} PIN-kood"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Oih, sisestasite vale PIN-koodi"
+  },
+  "user_submit_pin_button": {
+    "other": "Sisenema"
+  },
+  "user_reset_pin_button": {
+    "other": "Lähtestage PIN-kood"
+  },
+  "validation_pincode1_required": {
+    "other": "Sisestage kehtiv PIN-kood."
+  },
+  "validation_pincode2_required": {
+    "other": "Sisestage kehtiv PIN-kood."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Sisestage kehtiv PIN-kood."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Sisestage kehtiv PIN-kood."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN-kood ei ühti."
+  },
+  "userdevices_delete_limits": {
+    "other": "Saate sellest loendist eemaldada {{.Limit}} seadet iga {{.Period}} päeva järel."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Olete jõudnud selle limiidini ja te ei saa praegu ühtegi seadet eemaldada. Saate seadme kustutada {{.Days}} päeva pärast."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Seda kaarti salvestatakse ja selle eest võetakse regulaarselt tasu"
+  },
+  "changepincode_modal_header": {
+    "other": "Muutke oma PIN-koodi"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Teie praegune parool"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Teie uus 4-kohaline PIN-kood"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Kinnitage oma uus 4-kohaline PIN-kood"
+  },
+  "changepincode_modal_submit": {
+    "other": "Määra PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "See parool on vale."
+  },
+  "user_set_pin_intro": {
+    "other": "Piiratud sisu {{.Action}} jaoks vajate PIN-koodi"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "PIN-koodi lähtestamiseks klõpsake siin"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Sellel sisul on vanusepiirang."
+  },
+  "shopping_error_close_button": {
+    "other": "Okei"
+  },
+  "availability_expired": {
+    "other": "Aegunud"
+  }
 }
-  

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Ρυθμίσεις" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.shift72.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Ρυθμίσεις"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
   "episode_name": {
     "other": "Επεισόδιο"
   },
-
   "season_name": {
     "other": "Σεζόν"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "one εποχές",
     "other": "{{.Count}} εποχές"
   },
@@ -38,176 +55,435 @@
     "one": "1 Επεισόδιο",
     "other": "{{.Count}} Επεισόδια"
   },
-
-  "date_day": { "other": "Ημέρα" },
-  "date_month": { "other": "Μήνας" },
-  "date_year": { "other": "Έτος" },
-
-  "404_page_header": { "other": "Αυτή η σελίδα δεν υπάρχει..." },
-  "404_page_content": { "other": "<p>Λυπούμαστε, αλλά φαίνεται πως η σελίδα που αναζητήσατε δεν υπάρχει.</p><p>Ίσως έχει μετακινηθεί ή διαγραφεί, ή ίσως αν γράψατε απ' ευθείας το url να πληκτρολογήσατε κάτι λάθος</p><p>Δοκιμάστε να γυρίσετε στην κεντρική σελίδα και ίσως βρείτε αυτό που αναζητήσατε.</p><p><a href=\"{{.URL}}\">Πίσω στην κεντρική σελίδα</a>"},
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Είσοδος" },
-  "nav_signup": { "other": "Δημιουργία Λογαριασμού" },
-  "nav_signed_in_as": { "other": "Είσοδος ως" },
-  "nav_library": { "other": "Ο κατάλογός μου" },
-  "nav_devices": { "other": "Οι συσκευές μου" },
-  "nav_wishlist": { "other": "Η λίστα μου" },
-  "nav_account": { "other": "Ο λογαριασμός μου" },
-  "nav_signout": { "other": "Έξοδος" },
-  "play_trailer": { "other": "Τρέιλερ" },
-  "runtime_hours": { "other": "ω" },
-  "runtime_minutes": { "other": "λ" },
-
-  "datetime_today": { "other": "Σήμερα {{.Date}}" },
-  "datetime_tomorrow": { "other": "Αύριο {{.Date}}" },
-  "datetime_yesterday": { "other": "Χθες {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "Τελευταία {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Αναζήτηση" },
-  "search_control_submit": { "other": "Υποβάλετε αναζήτηση" },
-
-  "play_button_watch": { "other" : "Αναπαραγωγή"},
-  "play_button_resume": { "other" : "Συνέχιση"},
-
-  "social_media_buttons_title": { "other": "Μοιράσου το" },
-  "social_media_buttons_facebook": { "other": "Κοινοποίηση στο Facebook" },
-  "social_media_buttons_twitter": { "other": "Μοιραστείτε το στο Twitter" },
-  "social_media_buttons_linkedin": { "other": "Κοινή χρήση στο Linkedin" },
-  "social_media_buttons_email": { "other": "Κοινοποίηση μέσω email" },
-  "social_media_buttons_email_subject": { "other": "Κοινή χρήση συνδέσμου" },
-  "social_media_buttons_copied_link": { "other": "Ο σύνδεσμος αντιγράφηκε στο πρόχειρο!" },
-  "social_media_buttons_copy_link": { "other": "Αντιγραφή στο πρόχειρο" },
-
-  "accept_invite_page_header": { "other": "Καλώς ορίσατε " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Φαίνεται πως έχετε ήδη αποδεχθεί αυτή την πρόσκληση, πρέπει να <a href=\"{{.SigninURL}}\">εισέλθετε</a> στο λογαριασμό σας." },
-  "acceptinvite_complete": { "other": "Ευχαριστούμε πολύ. Ο λογαριασμός σας έχει δημιουργηθεί." },
-  "acceptinvite_form_submit": { "other": "Αποδοχή πρόσκλησης" },
-  "acceptinvite_agreement": { "other": "Κλικάροντας την «Αποδοχή πρόσκλησης» συμφωνείτε πως διαβάστε, κατανοείτε και συμφωνείτε με τους <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">όρους και τις προϋποθέσεις</a> και <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">την πολιτική απορρήτου</a>." },
-
-  "signup_page_header": { "other": "Δημιουργία νέου λογαριασμού" },
-  "signup_form_name": { "other": "Όνομα" },
-  "signup_form_email": { "other": "Διεύθυνση ηλ. ταχυδρομείου" },
-  "signup_form_password": { "other": "Κωδικός" },
-  "signup_form_password_confirmation": { "other": "Επαλήθευση κωδικού" },
-  "signup_form_gender": { "other": "Φύλο" },
-  "signup_form_dob": { "other": "Ημ/νία Γέννησης" },
-  "signup_form_submit": { "other": "Υποβολή" },
-
-  "signin_page_header": { "other": "Είσοδος" },
-  "signin_form_email": { "other": "Διεύθυνση ηλ. ταχυδρομείου" },
-  "signin_form_password": { "other": "Κωδικός" },
-  "signin_form_remember": { "other": "Να με θυμάσαι" },
-  "signin_form_submit": { "other": "Υποβολή" },
-  "signin_page_forgotpassword": { "other": "Ξεχάσατε τον κωδικό σας;" },
-  "signin_page_createnewaccount": { "other": "Δεν έχετε λογαριασμό; Εγγραφείτε εδώ" },
-  "signup_page_alreadyhaveanaccount": { "other": "Έχετε ήδη λογαριασμό; Παρακαλώ εισέλθετε" },
-  "signup_form_error_email_already_in_use": { "other": "Αυτή η διεύθυνση ηλ. ταχυδρομείου χρησιμοποιείται ήδη." },
-  "signin_form_error_incorrect_credentials": { "other": "Το όνομα χρήστη ή ο κωδικός είναι λάθος. " },
-  "signup_form_error_forbidden": { "other": "Αντιμετωπίσαμε ένα σφάλμα. " },
-
-  "combined_auth_continue": { "other": "Συνέχεια" },
-  "combined_auth_change": { "other": "Αλλαγή" },
-  "combined_auth_signin": { "other": "Είσοδος" },
-  "combined_auth_signup": { "other": "Δημιουργία λογαριασμού" },
-  "combined_auth_signin_password": { "other": "Παρακαλώ εισάγετε τον κωδικό σας για να εισέλθετε στο λογαριασμό σας." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Ο κωδικός είναι λάθος." },
-  "combined_auth_error_forbidden": { "other": "Αντιμετωπίσαμε ένα σφάλμα." },
-  "combined_auth_error_too_many_requests": { "other": "Πολλά αιτήματα. Παρακαλώ προσπαθήστε αργότερα." },
-
-  "forgotpassword_page_header": { "other": "Επαναφέρετε τον κωδικό σας" },
-  "forgotpassword_form_email": { "other": "Διεύθυνση ηλ. ταχυδρομείου" },
-  "forgotpassword_form_submit": { "other": "Επαναφορά" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Δεν βρέθηκε λογαριασμός που να αντιστοιχεί σε αυτή τη διεύθυνση ηλ. ταχυδρομείου." },
-  "forgotpassword_form_error_account_suspended": { "other": "Ο λογαριασμός σας έχει ακυρωθεί." },
-  "forgotpassword_complete": { "other": "Σας ευχαριστούμε. Θα λάβετε σύντομα ένα μήνυμα για την επαναφορά του κωδικού σας." },
-  "forgotpassword_form_error_forbidden": { "other": "Αντιμετωπίσαμε ένα σφάλμα." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Πολλά αιτήματα. Παρακαλώ προσπαθήστε αργότερα." },
-
-  "resetpassword_page_header": { "other": "Αλλάξτε τον κωδικό σας" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Φαίνεται πως το αίτημα επαναφορά του κωδικού σας έχει ακυρωθεί, παρακαλώ συμπληρώστε τη φόρμα <a href=\"{{.URL}}\">ανάκτησης του κωδικού σας</a> ξανά." },
-  "resetpassword_form_password": { "other": "Νέος κωδικός" },
-  "resetpassword_form_password2": { "other": "Επιβεβαιώστε το νέο σας κωδικό." },
-  "resetpassword_form_submit": { "other": "Αλλαγή" },
-  "resetpassword_complete": { "other": "Σας ευχαριστούμε. Ο κωδικός σας έχει αλλάξει και έχετε εισέλθει στο λογαριασμό σας." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Το αίτημα για επαναφορά του κωδικού σας δεν είναι έγκυρο. Παρακαλώ δοκιμάστε αργότερα." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Το αίτημα επαναφοράς του κωδικού σας έχει λήξει. Παρακαλώ δοκιμάστε ξανά." },
-  "resetpassword_form_error_too_many_requests": { "other": "Πολλά αιτήματα. Παρακαλώ προσπαθήστε αργότερα." },
-
-  "account_page_header": { "other": "Ο λογαριασμός μου" },
-  "account_form_name": { "other": "Όνομα" },
-  "account_form_email": { "other": "Διεύθυνση ηλ. ταχυδρομείου" },
-  "account_form_password": { "other": "Κωδικός" },
-  "account_form_change_password": { "other": "Αλλαγή" },
-  "account_form_gender": { "other": "Φύλο" },
-  "account_form_dob": { "other": "Ημ/νία γέννησης" },
-  "account_form_submit": { "other": "Ανανέωση" },
-  "account_form_submitted": { "other": "Ανανεώθηκε" },
-  "account_form_password_changed": { "other": "Ανανεώθηκε" },
-  "account_form_error_incorrect_password": { "other": "Ο κωδικός είναι λάθος" },
-
-  "signup_form_optin": {"other": "Εγγραφείτε στο newsletter μας."},
-
-  "passwordconfirmation_modal_header": { "other": "Επιβεβαιώστε τον κωδικό σας" },
-  "passwordconfirmation_modal_label": { "other": "Παρακαλώ εισάγεται τον κωδικό σας για να περάσουν οι αλλαγές. " },
-  "passwordconfirmation_modal_confirm": { "other": "Επιβεβαίωση" },
-
-  "changepassword_modal_header": { "other": "Αλλάξτε τον κωδικό σας." },
-  "changepassword_modal_currentpassword": { "other": "Ο τρέχων κωδικός σας." },
-  "changepassword_modal_password": { "other": "Ο νέος σας κωδικός." },
-  "changepassword_modal_password2": { "other": "Επιβεβαιώστε τον νέο σας κωδικό." },
-  "changepassword_modal_submit": { "other": "Ανανέωση" },
-  "changepassword_modal_error_incorrect_password": { "other": "Ο κωδικός είναι λάθος." },
-
-  "userlibrary_page_header": { "other": "Ο κατάλογός μου." },
-  "userlibrary_empty_header":  { "other": "Ο κατάλογός σας είναι άδειος." },
-  "userlibrary_empty_content": { "other": "Γεμίστε τον με <<a href=\"{{.HomeURL}}\">προτάσεις</a> από τη φετινή μας επιλογή." },
-
-  "searchresults_page_header": { "other": "Αποτέλεσματα αναζήτησης." },
-  "searchresults_load_more": { "other": "Φόρτωση {{.Count}} περισσότερων." },
+  "date_day": {
+    "other": "Ημέρα"
+  },
+  "date_month": {
+    "other": "Μήνας"
+  },
+  "date_year": {
+    "other": "Έτος"
+  },
+  "404_page_header": {
+    "other": "Αυτή η σελίδα δεν υπάρχει..."
+  },
+  "404_page_content": {
+    "other": "<p>Λυπούμαστε, αλλά φαίνεται πως η σελίδα που αναζητήσατε δεν υπάρχει.</p><p>Ίσως έχει μετακινηθεί ή διαγραφεί, ή ίσως αν γράψατε απ' ευθείας το url να πληκτρολογήσατε κάτι λάθος</p><p>Δοκιμάστε να γυρίσετε στην κεντρική σελίδα και ίσως βρείτε αυτό που αναζητήσατε.</p><p><a href=\"{{.URL}}\">Πίσω στην κεντρική σελίδα</a>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Είσοδος"
+  },
+  "nav_signup": {
+    "other": "Δημιουργία Λογαριασμού"
+  },
+  "nav_signed_in_as": {
+    "other": "Είσοδος ως"
+  },
+  "nav_library": {
+    "other": "Ο κατάλογός μου"
+  },
+  "nav_devices": {
+    "other": "Οι συσκευές μου"
+  },
+  "nav_wishlist": {
+    "other": "Η λίστα μου"
+  },
+  "nav_account": {
+    "other": "Ο λογαριασμός μου"
+  },
+  "nav_signout": {
+    "other": "Έξοδος"
+  },
+  "play_trailer": {
+    "other": "Τρέιλερ"
+  },
+  "runtime_hours": {
+    "other": "ω"
+  },
+  "runtime_minutes": {
+    "other": "λ"
+  },
+  "datetime_today": {
+    "other": "Σήμερα {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "Αύριο {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "Χθες {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "Τελευταία {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Αναζήτηση"
+  },
+  "search_control_submit": {
+    "other": "Υποβάλετε αναζήτηση"
+  },
+  "play_button_watch": {
+    "other": "Αναπαραγωγή"
+  },
+  "play_button_resume": {
+    "other": "Συνέχιση"
+  },
+  "social_media_buttons_title": {
+    "other": "Μοιράσου το"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Κοινοποίηση στο Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Μοιραστείτε το στο Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Κοινή χρήση στο Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Κοινοποίηση μέσω email"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Κοινή χρήση συνδέσμου"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Ο σύνδεσμος αντιγράφηκε στο πρόχειρο!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Αντιγραφή στο πρόχειρο"
+  },
+  "accept_invite_page_header": {
+    "other": "Καλώς ορίσατε "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Φαίνεται πως έχετε ήδη αποδεχθεί αυτή την πρόσκληση, πρέπει να <a href=\"{{.SigninURL}}\">εισέλθετε</a> στο λογαριασμό σας."
+  },
+  "acceptinvite_complete": {
+    "other": "Ευχαριστούμε πολύ. Ο λογαριασμός σας έχει δημιουργηθεί."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Αποδοχή πρόσκλησης"
+  },
+  "acceptinvite_agreement": {
+    "other": "Κλικάροντας την «Αποδοχή πρόσκλησης» συμφωνείτε πως διαβάστε, κατανοείτε και συμφωνείτε με τους <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">όρους και τις προϋποθέσεις</a> και <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">την πολιτική απορρήτου</a>."
+  },
+  "signup_page_header": {
+    "other": "Δημιουργία νέου λογαριασμού"
+  },
+  "signup_form_name": {
+    "other": "Όνομα"
+  },
+  "signup_form_email": {
+    "other": "Διεύθυνση ηλ. ταχυδρομείου"
+  },
+  "signup_form_password": {
+    "other": "Κωδικός"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Επαλήθευση κωδικού"
+  },
+  "signup_form_gender": {
+    "other": "Φύλο"
+  },
+  "signup_form_dob": {
+    "other": "Ημ/νία Γέννησης"
+  },
+  "signup_form_submit": {
+    "other": "Υποβολή"
+  },
+  "signin_page_header": {
+    "other": "Είσοδος"
+  },
+  "signin_form_email": {
+    "other": "Διεύθυνση ηλ. ταχυδρομείου"
+  },
+  "signin_form_password": {
+    "other": "Κωδικός"
+  },
+  "signin_form_remember": {
+    "other": "Να με θυμάσαι"
+  },
+  "signin_form_submit": {
+    "other": "Υποβολή"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Ξεχάσατε τον κωδικό σας;"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Δεν έχετε λογαριασμό; Εγγραφείτε εδώ"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Έχετε ήδη λογαριασμό; Παρακαλώ εισέλθετε"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Αυτή η διεύθυνση ηλ. ταχυδρομείου χρησιμοποιείται ήδη."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Το όνομα χρήστη ή ο κωδικός είναι λάθος. "
+  },
+  "signup_form_error_forbidden": {
+    "other": "Αντιμετωπίσαμε ένα σφάλμα. "
+  },
+  "combined_auth_continue": {
+    "other": "Συνέχεια"
+  },
+  "combined_auth_change": {
+    "other": "Αλλαγή"
+  },
+  "combined_auth_signin": {
+    "other": "Είσοδος"
+  },
+  "combined_auth_signup": {
+    "other": "Δημιουργία λογαριασμού"
+  },
+  "combined_auth_signin_password": {
+    "other": "Παρακαλώ εισάγετε τον κωδικό σας για να εισέλθετε στο λογαριασμό σας."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Ο κωδικός είναι λάθος."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Αντιμετωπίσαμε ένα σφάλμα."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Πολλά αιτήματα. Παρακαλώ προσπαθήστε αργότερα."
+  },
+  "forgotpassword_page_header": {
+    "other": "Επαναφέρετε τον κωδικό σας"
+  },
+  "forgotpassword_form_email": {
+    "other": "Διεύθυνση ηλ. ταχυδρομείου"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Επαναφορά"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Δεν βρέθηκε λογαριασμός που να αντιστοιχεί σε αυτή τη διεύθυνση ηλ. ταχυδρομείου."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Ο λογαριασμός σας έχει ακυρωθεί."
+  },
+  "forgotpassword_complete": {
+    "other": "Σας ευχαριστούμε. Θα λάβετε σύντομα ένα μήνυμα για την επαναφορά του κωδικού σας."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Αντιμετωπίσαμε ένα σφάλμα."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Πολλά αιτήματα. Παρακαλώ προσπαθήστε αργότερα."
+  },
+  "resetpassword_page_header": {
+    "other": "Αλλάξτε τον κωδικό σας"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Φαίνεται πως το αίτημα επαναφορά του κωδικού σας έχει ακυρωθεί, παρακαλώ συμπληρώστε τη φόρμα <a href=\"{{.URL}}\">ανάκτησης του κωδικού σας</a> ξανά."
+  },
+  "resetpassword_form_password": {
+    "other": "Νέος κωδικός"
+  },
+  "resetpassword_form_password2": {
+    "other": "Επιβεβαιώστε το νέο σας κωδικό."
+  },
+  "resetpassword_form_submit": {
+    "other": "Αλλαγή"
+  },
+  "resetpassword_complete": {
+    "other": "Σας ευχαριστούμε. Ο κωδικός σας έχει αλλάξει και έχετε εισέλθει στο λογαριασμό σας."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Το αίτημα για επαναφορά του κωδικού σας δεν είναι έγκυρο. Παρακαλώ δοκιμάστε αργότερα."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Το αίτημα επαναφοράς του κωδικού σας έχει λήξει. Παρακαλώ δοκιμάστε ξανά."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Πολλά αιτήματα. Παρακαλώ προσπαθήστε αργότερα."
+  },
+  "account_page_header": {
+    "other": "Ο λογαριασμός μου"
+  },
+  "account_form_name": {
+    "other": "Όνομα"
+  },
+  "account_form_email": {
+    "other": "Διεύθυνση ηλ. ταχυδρομείου"
+  },
+  "account_form_password": {
+    "other": "Κωδικός"
+  },
+  "account_form_change_password": {
+    "other": "Αλλαγή"
+  },
+  "account_form_gender": {
+    "other": "Φύλο"
+  },
+  "account_form_dob": {
+    "other": "Ημ/νία γέννησης"
+  },
+  "account_form_submit": {
+    "other": "Ανανέωση"
+  },
+  "account_form_submitted": {
+    "other": "Ανανεώθηκε"
+  },
+  "account_form_password_changed": {
+    "other": "Ανανεώθηκε"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Ο κωδικός είναι λάθος"
+  },
+  "signup_form_optin": {
+    "other": "Εγγραφείτε στο newsletter μας."
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Επιβεβαιώστε τον κωδικό σας"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Παρακαλώ εισάγεται τον κωδικό σας για να περάσουν οι αλλαγές. "
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Επιβεβαίωση"
+  },
+  "changepassword_modal_header": {
+    "other": "Αλλάξτε τον κωδικό σας."
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Ο τρέχων κωδικός σας."
+  },
+  "changepassword_modal_password": {
+    "other": "Ο νέος σας κωδικός."
+  },
+  "changepassword_modal_password2": {
+    "other": "Επιβεβαιώστε τον νέο σας κωδικό."
+  },
+  "changepassword_modal_submit": {
+    "other": "Ανανέωση"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Ο κωδικός είναι λάθος."
+  },
+  "userlibrary_page_header": {
+    "other": "Ο κατάλογός μου."
+  },
+  "userlibrary_empty_header": {
+    "other": "Ο κατάλογός σας είναι άδειος."
+  },
+  "userlibrary_empty_content": {
+    "other": "Γεμίστε τον με <<a href=\"{{.HomeURL}}\">προτάσεις</a> από τη φετινή μας επιλογή."
+  },
+  "searchresults_page_header": {
+    "other": "Αποτέλεσματα αναζήτησης."
+  },
+  "searchresults_load_more": {
+    "other": "Φόρτωση {{.Count}} περισσότερων."
+  },
   "searchresults_total": {
     "one": "Βρέθηκαν {{.Count}} αποτελέσματα για \"{{.Query}}\".",
     "other": "Βρέθηκαν {{.Count}} αποτελέσματα για \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "Δεν βρέθηκαν αποτελέσματα για \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Δοκιμάστε μια διαφορετική αναζήτηση ή <a href=\"{{.HomeURL}}\">δείτε το περιεχόμενό μας</a> για να βρείτε αυτό που ψάχνετε. " },
-  
-  "validation_name_required": { "other": "Παρακαλώ συμπληρώστε το όνομά σας." },
-  "validation_email_required": { "other": "Παρακαλώ συμπληρώστε τη διεύθυνση ηλ. ταχυδορμείου σας." },
-  "validation_email_email": { "other": "Παρακαλώ συμπληρώστε μια έγκυρη διεύθυνση." },
-  "validation_currentpassword_required": { "other": "Παρακαλώ εισάγετε τον τρέχοντα κωδικό σας." },
-  "validation_password_required": { "other": "Παρακαλώ εισάγετε έναν κωδικό." },
-  "validation_password2_required": { "other": "Παρακαλώ επιβεβαιώστε τον κωδικό σας. " },
-  "validation_password2_match": { "other": "Οι κωδικοί δεν ταιριάζουν. " },
-  "validation_password_minlength": { "other": "Παρακαλώ εισάγετε τουλάχιστον {{.Count}} χαρακτήρες." },
-  "validation_promocode_required": { "other": "Παρακαλώ εισάγετε τον κωδικό έκπτωσης." },
-  "validation_pincode_required": { "other": "Εισαγάγετε ένα PIN." },
-  "validation_gender_required": { "other": "Παρακαλώ εισάγετε το φύλο που σας εκφράζει περισσότερο." },
-  "validation_dob_required": { "other": "Παρακαλώ εισάγετε την ημ/νία γέννησής σας. " },
-  "validation_dob_date": { "other": "Παρακαλώ εισάγετε μια έγκυρη ημ/νία." },
-
-  "shopping_info_subtitle_hd": { "other": "Βίντεο HD on Demand." },
-  "shopping_info_subtitle_sd": { "other": "SD Video on Demand." },
-  "shopping_info_subtitle_wallet": { "other": "Τα χρήματα στο Πορτοφόλι σας μπορούν να χρησιμοποιηθούν για την αγορά ή την ενοικίαση οποιουδήποτε περιεχομένου ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "Δείτε εδώ για απαιτήσεις συστήματος." },
-  "shopping_info_ownership_buy": { "other": "αγορά" },
-  "shopping_info_ownership_rent": { "other": "ενοικίαση" },
-
-  "shopping_info_sd_only": { "other": "Περιορίζεται μόνο στην αναπαραγωγή SD. " },
-  "shopping_info_release_date_title": { "other": "Κυκλοφορίες {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Μπορείτε να το ενοικιάσετε τώρα, αλλά δεν θα μπορείτε να το δείτε μέχρι τότε." },
-  "shopping_info_release_date_explanation_buy": { "other": "Μπορείτε να το αγοράσετε τώρα, αλλά δεν θα μπορείτε να το δείτε μέχρι τότε." },
-
-  "shopping_info_available_until_date_title": { "other": "Διαθέσιμο έως {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Δεν θα μπορείτε να παρακολουθήσετε το περιεχόμενο μετά από τότε. " },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Δεν θα μπορείτε να παρακολουθήσετε το περιεχόμενο μετά από τότε. " },
-
-  "duration_hour": { "one": "1 ώρα", "other": "{{.Count}} ώρες" },
-  "duration_day": { "one": "1 μέρα", "other": "{{.Count}} μέρες" },
-  "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} ενοικίασης. " },
-  "shopping_info_watch_window_duration": { "other": "{{.Count}} ώρες μέχρι να ολοκληρωθεί η προβολή. " },
+  "searchresults_empty_header": {
+    "other": "Δεν βρέθηκαν αποτελέσματα για \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Δοκιμάστε μια διαφορετική αναζήτηση ή <a href=\"{{.HomeURL}}\">δείτε το περιεχόμενό μας</a> για να βρείτε αυτό που ψάχνετε. "
+  },
+  "validation_name_required": {
+    "other": "Παρακαλώ συμπληρώστε το όνομά σας."
+  },
+  "validation_email_required": {
+    "other": "Παρακαλώ συμπληρώστε τη διεύθυνση ηλ. ταχυδορμείου σας."
+  },
+  "validation_email_email": {
+    "other": "Παρακαλώ συμπληρώστε μια έγκυρη διεύθυνση."
+  },
+  "validation_currentpassword_required": {
+    "other": "Παρακαλώ εισάγετε τον τρέχοντα κωδικό σας."
+  },
+  "validation_password_required": {
+    "other": "Παρακαλώ εισάγετε έναν κωδικό."
+  },
+  "validation_password2_required": {
+    "other": "Παρακαλώ επιβεβαιώστε τον κωδικό σας. "
+  },
+  "validation_password2_match": {
+    "other": "Οι κωδικοί δεν ταιριάζουν. "
+  },
+  "validation_password_minlength": {
+    "other": "Παρακαλώ εισάγετε τουλάχιστον {{.Count}} χαρακτήρες."
+  },
+  "validation_promocode_required": {
+    "other": "Παρακαλώ εισάγετε τον κωδικό έκπτωσης."
+  },
+  "validation_pincode_required": {
+    "other": "Εισαγάγετε ένα PIN."
+  },
+  "validation_gender_required": {
+    "other": "Παρακαλώ εισάγετε το φύλο που σας εκφράζει περισσότερο."
+  },
+  "validation_dob_required": {
+    "other": "Παρακαλώ εισάγετε την ημ/νία γέννησής σας. "
+  },
+  "validation_dob_date": {
+    "other": "Παρακαλώ εισάγετε μια έγκυρη ημ/νία."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "Βίντεο HD on Demand."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video on Demand."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Τα χρήματα στο Πορτοφόλι σας μπορούν να χρησιμοποιηθούν για την αγορά ή την ενοικίαση οποιουδήποτε περιεχομένου ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Δείτε εδώ για απαιτήσεις συστήματος."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "αγορά"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "ενοικίαση"
+  },
+  "shopping_info_sd_only": {
+    "other": "Περιορίζεται μόνο στην αναπαραγωγή SD. "
+  },
+  "shopping_info_release_date_title": {
+    "other": "Κυκλοφορίες {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Μπορείτε να το ενοικιάσετε τώρα, αλλά δεν θα μπορείτε να το δείτε μέχρι τότε."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Μπορείτε να το αγοράσετε τώρα, αλλά δεν θα μπορείτε να το δείτε μέχρι τότε."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Διαθέσιμο έως {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Δεν θα μπορείτε να παρακολουθήσετε το περιεχόμενο μετά από τότε. "
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Δεν θα μπορείτε να παρακολουθήσετε το περιεχόμενο μετά από τότε. "
+  },
+  "duration_hour": {
+    "one": "1 ώρα",
+    "other": "{{.Count}} ώρες"
+  },
+  "duration_day": {
+    "one": "1 μέρα",
+    "other": "{{.Count}} μέρες"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} ενοικίασης. "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} ώρες μέχρι να ολοκληρωθεί η προβολή. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Με την ενοικίαση, η ταινία θα είναι διαθέσιμη στο λογαριασμό σας για {{.ValueUnit}}. ",
     "other": "Με την ενοικίαση, η ταινία θα είναι διαθέσιμη στο λογαριασμό σας για {{.ValueUnit}}.  "
@@ -232,65 +508,151 @@
     "one": "Με το που πατήσετε αναπαραγωγή σε ένα επεισόδιο, ξεκινά η περίοδος θέασης κι έχετε μια ώρα για να το δείτε, όσες φορές επιθυμείτε.",
     "other": "Με το που πατήσετε αναπαραγωγή σε ένα επεισόδιο, ξεκινά η περίοδος θέασης κι έχετε {{.Count}} ώρες για να το δείτε, όσες φορές επιθυμείτε."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Μπόνους" },
-
-  "shopping_enter_card_prompt": { "other": "Εισάγετε τα στοιχεία της κάρτας σας για να ολοκληρώσετε την {{.Verb}}." },
-
-  "shopping_terms": { "other": "Ολοκληρώνοντας τη συναλλαγή, αποδέχεστε τους <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">όρους και τις προϋποθέσεις</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} έκπτωση συνυπολογίστηκε. " },
-  "shopping_discount_apply": { "other": "Εφαρμογή" },
-  "shopping_discount_code": { "other": "Εισάγετε προωθητικό κωδικό. " },
-  "shopping_discount_have_code": { "other": "Έχω προωθητικό κωδικό. " },
-
-  "shopping_price_you_pay": { "other": "Πληρώνετε" },
-  "shopping_price_nothing": { "other": "Τίποτα" },
-  "shopping_price_free": { "other": "Δωρεάν" },
-
-  "shopping_auth_directions": { "other": "Χρειάζεται πρώτα να δημιουργήσετε λογαριασμό. Παρακαλώ συμπληρώστε τη διεύθυνση ηλ. ταχυδρομείου. " },
-
-  "shopping_error_in_library": { "other": "Το {{.Title}} είναι ήδη στον κατάλογό σας. " },
-
-  "shopping_error_missing_card": { "other": "Παρακαλώ εισάγετε τα στοιχεία της κάρτας σας. " },
-  "shopping_error_title": { "other": "Αντιμετωπίσαμε ένα σφάλμα. " },
-  "shopping_error_incorrect_cvc": { "other": "Παρακαλώ εισάγετε έναν έγκυρο κωδικό CVV. " },
-  "shopping_error_invalid_cvc": { "other": "Παρακαλώ εισάγετε έναν έγκυρο κωδικό CVV. " },
-  "shopping_error_incorrect_number": { "other": "Παρακαλώ εισάγετε έναν έγκυρο αριθμό κάρτας." },
-  "shopping_error_invalid_number": { "other": "Παρακαλώ εισάγεται έναν έγκυρο αριθμό κάρτας." },
-  "shopping_error_card_declined": { "other": "Η κάρτα σας δεν έγινε δεκτή. " },
-  "shopping_error_invalid_expiry_month": { "other": "Παρακαλώ εισάγετε μια έγκυρη ημ/νία λήξης. " },
-  "shopping_error_invalid_expiry_year": { "other": "Παρακαλώ εισάγετε μια έγκυρη ημ/νία λήξης. " },
-  "shopping_error_expired_card": { "other": "Η κάρτα σας έχει λήξει. " },
-  "shopping_error_creditcard_country_mismatch": { "other": "Η {{.Ownership}} σας δεν έχει ολοκληρωθεί. Πρέπει να βρίσκεστε στη χώρα στην οποία εκδόθηκε η κάρτα. Παρακαλώ χρησιμοποιήστε μια άλλη κάρτα για να ολοκληρώσετε την πληρωμή." },
-  "shopping_error_proxy_detected": { "other": "Η {{.Ownership}} σας δεν έχει ολοκληρωθεί. Εντοπίσαμε πως χρησιμοποιείτε unblocker ή υπηρεσία proxy. Παρακαλώ απενεργοποιήστε τα και δοκιμάστε ξανά." },
-
-  "shopping_error_discount_worn_out": { "other": "Αυτός ο κωδικός προσφοράς δεν μπορεί πλέον να χρησιμοποιηθεί." },
-  "shopping_error_discount_blank": { "other": "Παρακαλώ εισάγετε έναν προωθητικό κωδικό. " },
-  "shopping_error_discount_not_applied": { "other": "Παρακαλώ εισάγετε έναν έγκυρο προωθητικό κωδικό. " },
-  "shopping_error_discount_invalid": { "other": "Παρακαλώ εισάγετε έναν έγκυρο προωθητικό κωδικό." },
-  "shopping_error_discount_disabled": { "other": "Παρακαλώ εισάγετε έναν έγκυρο προωθητικό κωδικό." },
-  "shopping_error_discount_already_applied": { "other": "Έχει ήδη χρησιμοποιηθεί ένας προωθητικός κωδικός για αυτή τη συναλλαγή." },
-  "shopping_error_discount_already_redeemed": { "other": "Αυτός ο προωθητικός κωδικός έχει ήδη χρησιμοποιηθεί." },
-  "shopping_error_discount_used_previously": { "other": "Αυτός ο προωθητικός κωδικός έχει ήδη χρησιμοποιηθεί." },
-  "shopping_error_discount_max_limit": { "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί πια." },
-  "shopping_error_discount_expired": { "other": "Αυτός ο προωθητικός κωδικός έχει λήξει." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί κατά την αγορά." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί κατά την ενοικίαση." },
-  "shopping_error_discount_invalid_item": { "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί για το συγκεκριμένο προϊόν." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί στη χώρα που διαμένετε." },
-  "shopping_error_discounts_not_allowed": { "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί για πακέτα." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Η πιστωτική σας κάρτα δεν έγινε δεκτή. Παρακαλώ προσπαθήστε ξανά." },
-
-  "shopping_complete_rental": { "other": "Επιτυχία!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Μπόνους"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Εισάγετε τα στοιχεία της κάρτας σας για να ολοκληρώσετε την {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Ολοκληρώνοντας τη συναλλαγή, αποδέχεστε τους <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">όρους και τις προϋποθέσεις</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} έκπτωση συνυπολογίστηκε. "
+  },
+  "shopping_discount_apply": {
+    "other": "Εφαρμογή"
+  },
+  "shopping_discount_code": {
+    "other": "Εισάγετε προωθητικό κωδικό. "
+  },
+  "shopping_discount_have_code": {
+    "other": "Έχω προωθητικό κωδικό. "
+  },
+  "shopping_price_you_pay": {
+    "other": "Πληρώνετε"
+  },
+  "shopping_price_nothing": {
+    "other": "Τίποτα"
+  },
+  "shopping_price_free": {
+    "other": "Δωρεάν"
+  },
+  "shopping_auth_directions": {
+    "other": "Χρειάζεται πρώτα να δημιουργήσετε λογαριασμό. Παρακαλώ συμπληρώστε τη διεύθυνση ηλ. ταχυδρομείου. "
+  },
+  "shopping_error_in_library": {
+    "other": "Το {{.Title}} είναι ήδη στον κατάλογό σας. "
+  },
+  "shopping_error_missing_card": {
+    "other": "Παρακαλώ εισάγετε τα στοιχεία της κάρτας σας. "
+  },
+  "shopping_error_title": {
+    "other": "Αντιμετωπίσαμε ένα σφάλμα. "
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Παρακαλώ εισάγετε έναν έγκυρο κωδικό CVV. "
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Παρακαλώ εισάγετε έναν έγκυρο κωδικό CVV. "
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Παρακαλώ εισάγετε έναν έγκυρο αριθμό κάρτας."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Παρακαλώ εισάγεται έναν έγκυρο αριθμό κάρτας."
+  },
+  "shopping_error_card_declined": {
+    "other": "Η κάρτα σας δεν έγινε δεκτή. "
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Παρακαλώ εισάγετε μια έγκυρη ημ/νία λήξης. "
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Παρακαλώ εισάγετε μια έγκυρη ημ/νία λήξης. "
+  },
+  "shopping_error_expired_card": {
+    "other": "Η κάρτα σας έχει λήξει. "
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Η {{.Ownership}} σας δεν έχει ολοκληρωθεί. Πρέπει να βρίσκεστε στη χώρα στην οποία εκδόθηκε η κάρτα. Παρακαλώ χρησιμοποιήστε μια άλλη κάρτα για να ολοκληρώσετε την πληρωμή."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Η {{.Ownership}} σας δεν έχει ολοκληρωθεί. Εντοπίσαμε πως χρησιμοποιείτε unblocker ή υπηρεσία proxy. Παρακαλώ απενεργοποιήστε τα και δοκιμάστε ξανά."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Αυτός ο κωδικός προσφοράς δεν μπορεί πλέον να χρησιμοποιηθεί."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Παρακαλώ εισάγετε έναν προωθητικό κωδικό. "
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Παρακαλώ εισάγετε έναν έγκυρο προωθητικό κωδικό. "
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Παρακαλώ εισάγετε έναν έγκυρο προωθητικό κωδικό."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Παρακαλώ εισάγετε έναν έγκυρο προωθητικό κωδικό."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Έχει ήδη χρησιμοποιηθεί ένας προωθητικός κωδικός για αυτή τη συναλλαγή."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Αυτός ο προωθητικός κωδικός έχει ήδη χρησιμοποιηθεί."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Αυτός ο προωθητικός κωδικός έχει ήδη χρησιμοποιηθεί."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί πια."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Αυτός ο προωθητικός κωδικός έχει λήξει."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί κατά την αγορά."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί κατά την ενοικίαση."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί για το συγκεκριμένο προϊόν."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί στη χώρα που διαμένετε."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Αυτός ο προωθητικός κωδικός δεν μπορεί να χρησιμοποιηθεί για πακέτα."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Η πιστωτική σας κάρτα δεν έγινε δεκτή. Παρακαλώ προσπαθήστε ξανά."
+  },
+  "shopping_complete_rental": {
+    "other": "Επιτυχία!"
+  },
   "shopping_complete_rental_period": {
     "one": "Μπορείτε τώρα να το παρακολουθήσετε όσες φορές επιθυμείτε για τις επόμενες {{.Count}} μέρες.",
     "other": "Μπορείτε τώρα να το παρακολουθήσετε όσες φορές επιθυμείτε για τις επόμενες {{.Count}} μέρες."
   },
-  "shopping_complete_purchase": { "other": "Ευχαριστούμε για την αγορά του {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Ευχαριστούμε για την αγορά του {{.Title}}.  {{.CreditTotal}} έχουν προστεθεί στο λογαριασμό σας." },
-  "shopping_complete_purchase_coming_soon": { "other": "Μπορείτε να το παρακολουθήσετε από {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Η απόδειξή σας έχει σταλεί με e-mail." },
-  "shopping_complete_library_link": { "other": "Δείτε την ταινιοθήκη σας" },
+  "shopping_complete_purchase": {
+    "other": "Ευχαριστούμε για την αγορά του {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Ευχαριστούμε για την αγορά του {{.Title}}.  {{.CreditTotal}} έχουν προστεθεί στο λογαριασμό σας."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Μπορείτε να το παρακολουθήσετε από {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Η απόδειξή σας έχει σταλεί με e-mail."
+  },
+  "shopping_complete_library_link": {
+    "other": "Δείτε την ταινιοθήκη σας"
+  },
   "shopping_complete_plan": {
     "other": "Η αγορά του {{ .Title }} ήταν επιτυχής."
   },
@@ -310,145 +672,322 @@
     "one": "Μπορείτε να το παρακολουθήσετε από {{.Date}} και η ενοικίαση θα είναι ενεργή για {{.Count}} ημέρες.",
     "other": "Μπορείτε να το παρακολουθήσετε από {{.Date}} και η ενοικίαση θα είναι ενεργή για {{.Count}} ημέρες."
   },
-
-  "shopping_action_rent": { "other": "Ενοικίαση" },
-  "shopping_action_buy": { "other": "Αγορά" },
-
-  "meta_detail_cast_title": { "other": "Πρωταγωνιστούν" },
-  "meta_detail_crew_title": { "other": "Επιτελείο" },
-  "meta_detail_languages": { "one": "Γλώσσες", "other": "Γλώσσες" },
-  "meta_detail_studios": { "one": "Εταιρίες", "other": "Εταιρίες" },
-  "meta_detail_countries": { "one": "Χώρες", "other": "Χώρες" },
-  "meta_detail_subtitles": { "other": "Υπότιτλοι" },
-  "meta_detail_captions": { "other": "Υπότιτλοι [CC]" },
-  "meta_detail_episodes_title": { "other": "Επεισόδια" },
-  "meta_detail_bonus_title": { "other": "Έξτρα υλικό" },
-  "meta_detail_recommendations_title": { "other": "Ίσως σας αρέσουν και τα" },
-  "meta_detail_bundle_items_title": { "other": "Περιεχόμενο σε αυτό το πακέτο." },
-
-  "bundle_items_all_films": { "other": "{{.Count}} ταινίες" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} σεζόν" },
-  "bundle_items_mixed": { "other": "{{.Count}} ταινιών και σεζόν" },
-  "userwishlist_page_header": { "other": "Η λίστα μου." },
-  "userwishlist_slider_header": { "other": "Η λίστα μου." },
-  "userwishlist_empty_header":  { "other": "Η λίστα σας είναι άδεια." },
-  "userwishlist_empty_content": { "other": "Γεμίστε τη με <a href=\"{{.HomeURL}}\">υλικό</a> από την επιλογή μας." },
-  "userwishlist_button_add": { "other": "Πρόσθεσε στη λίστα μου." },
-  "userwishlist_button_remove": { "other": "Η λίστα μου." },
-  "userwishlist_button_add_compact": { "other": "Η λίστα μου." },
-  "userwishlist_button_remove_compact": { "other": "Η λίστα μου." },
-
-  "activatedevice_page_header": { "other": "Ενεργοποίηση συσκευής" },
-  "activatedevice_page_content": { "other": "Ακολουθήστε τις οδηγίες στη συσκευή σας για να αποκτήσετε ένα PIN. Ο υπολογιστής και η συσκευή σας πρέπει να είναι συνδεδεμένα στο Διαδίκτυο για να ενεργοποιηθούν." },
-  "activatedevice_form_pin": { "other": "Κωδικό PIN" },
-  "activatedevice_form_submit": { "other": "Θέτω εις ενέργειαν" },
-  "activatedevice_form_error_invalid_code": { "other": "Το PIN δεν βρέθηκε, δοκιμάστε ξανά." },
-  "activatedevice_form_error_pin_not_found": { "other": "Το PIN δεν βρέθηκε, δοκιμάστε ξανά." },
-  "activatedevice_signin_prompt": { "other": "Παρακαλούμε συνδεθείτε πριν καταχωρήσετε τη συσκευή σας." },
-  "activatedevice_page_activated": { "other": "Σας ευχαριστούμε για την ενεργοποίηση {{.DeviceName}}. Θα πρέπει τώρα να μπορείτε να περιηγηθείτε στη βιβλιοθήκη σας στην τηλεόραση ή τη συσκευή σας." },
-
-  "userdevices_page_header": { "other": "Συσκευές" },
+  "shopping_action_rent": {
+    "other": "Ενοικίαση"
+  },
+  "shopping_action_buy": {
+    "other": "Αγορά"
+  },
+  "meta_detail_cast_title": {
+    "other": "Πρωταγωνιστούν"
+  },
+  "meta_detail_crew_title": {
+    "other": "Επιτελείο"
+  },
+  "meta_detail_languages": {
+    "one": "Γλώσσες",
+    "other": "Γλώσσες"
+  },
+  "meta_detail_studios": {
+    "one": "Εταιρίες",
+    "other": "Εταιρίες"
+  },
+  "meta_detail_countries": {
+    "one": "Χώρες",
+    "other": "Χώρες"
+  },
+  "meta_detail_subtitles": {
+    "other": "Υπότιτλοι"
+  },
+  "meta_detail_captions": {
+    "other": "Υπότιτλοι [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Επεισόδια"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Έξτρα υλικό"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Ίσως σας αρέσουν και τα"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Περιεχόμενο σε αυτό το πακέτο."
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} ταινίες"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} σεζόν"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} ταινιών και σεζόν"
+  },
+  "userwishlist_page_header": {
+    "other": "Η λίστα μου."
+  },
+  "userwishlist_slider_header": {
+    "other": "Η λίστα μου."
+  },
+  "userwishlist_empty_header": {
+    "other": "Η λίστα σας είναι άδεια."
+  },
+  "userwishlist_empty_content": {
+    "other": "Γεμίστε τη με <a href=\"{{.HomeURL}}\">υλικό</a> από την επιλογή μας."
+  },
+  "userwishlist_button_add": {
+    "other": "Πρόσθεσε στη λίστα μου."
+  },
+  "userwishlist_button_remove": {
+    "other": "Η λίστα μου."
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Η λίστα μου."
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Η λίστα μου."
+  },
+  "activatedevice_page_header": {
+    "other": "Ενεργοποίηση συσκευής"
+  },
+  "activatedevice_page_content": {
+    "other": "Ακολουθήστε τις οδηγίες στη συσκευή σας για να αποκτήσετε ένα PIN. Ο υπολογιστής και η συσκευή σας πρέπει να είναι συνδεδεμένα στο Διαδίκτυο για να ενεργοποιηθούν."
+  },
+  "activatedevice_form_pin": {
+    "other": "Κωδικό PIN"
+  },
+  "activatedevice_form_submit": {
+    "other": "Θέτω εις ενέργειαν"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "Το PIN δεν βρέθηκε, δοκιμάστε ξανά."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "Το PIN δεν βρέθηκε, δοκιμάστε ξανά."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Παρακαλούμε συνδεθείτε πριν καταχωρήσετε τη συσκευή σας."
+  },
+  "activatedevice_page_activated": {
+    "other": "Σας ευχαριστούμε για την ενεργοποίηση {{.DeviceName}}. Θα πρέπει τώρα να μπορείτε να περιηγηθείτε στη βιβλιοθήκη σας στην τηλεόραση ή τη συσκευή σας."
+  },
+  "userdevices_page_header": {
+    "other": "Συσκευές"
+  },
   "userdevices_page_content": {
     "one": "Οι συσκευές θα προστίθενται αυτόματα όταν τις χρησιμοποιείτε. Έχετε όριο για {{.Count}} συσκευές.",
     "other": "Οι συσκευές θα προστίθενται αυτόματα όταν τις χρησιμοποιείτε. Έχετε όριο για {{.Count}} συσκευές."
   },
-  "userdevices_empty_content": { "other": "Προς το παρόν έχετε 0 εγγεγραμμένες συσκευές." },
-  "userdevices_header_type": { "other": "Τύπος συσκευής" },
-  "userdevices_header_description": { "other": "Περιγραφή" },
-  "userdevices_device_added": { "other": "Προστέθηκε {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Αφαίρεση" },
-  "userdevices_device_actions_cancel": { "other": "Άκυρο" },
-  "userdevices_device_actions_confirm": { "other": "Ναι, αφαίρεσε τη συσκευή" },
-  "userdevices_device_deleted": { "other": "(Αφαιρέθηκε)" },
-
-  "playlist_page_header": { "other": "Λίστα αναπαραγωγής" },
-  "playlist_sign_in_warning": { "other": "Συνδεθείτε για να παρακολουθήσετε ζωντανή τηλεόραση."},
-  "playlist_share_title": { "other": "Λίστα αναπαραγωγής" },
-  "playlist_up_next_title": { "other": "επόμενο" },
-
-  "pricing_ownership_buy": { "other": "Αγορά" },
-  "pricing_ownership_rent": { "other": "Ενοικίαση" },
-
-  "classification_intro": { "other": "Κατηγοριοποίηση " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Αυτός ο ιστότοπος χρησιμοποιεί cookies για να βελτιώσει την ψηφιακή εμπειρία σας. Χρησιμοποιώντας τη σελίδα, αποδέχεστε τον <a href=\"{{.CookiePolicyURL}}\"> κανονισμό cookies</a>" },
-  "cookie_banner_accept": { "other": "Αποδέχομαι" },
-
-  "all_rights_reserved": { "other": "Με την επιφύλαξη κάθε δικαιώματος. Απαγορεύεται η αναπαραγωγή του περιεχομένου του ιστοτόπου, χωρίς την απαραίτητη γραπτή άδεια." },
-
-  "users_gender_none": { "other": "Μη προσδιορισμένο" },
-  "users_gender_female": { "other": "Θηλυκό" },
-  "users_gender_male": { "other": "Αρσενικό" },
-  "users_gender_diverse": { "other": "LGBTQI+" },
-  "users_gender_other": { "other": "Άλλο" },
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "Μόνο HD" },
-  "pricing_quality_sd_only": { "other": "Μόνο SD" },
-
-  "shopping_card_save_card": { "other": "Αποθηκεύστε αυτήν την κάρτα για μελλοντική αναφορά" },
-  "shopping_card_button_change": { "other": "Εμφάνιση όλων των αποθηκευμένων καρτών" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} τελειώνει σε {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(λήγει {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(έχει λήξει)" },
-  "shopping_card_use_other": { "other": "Χρησιμοποιήστε μια νέα κάρτα" },
-  "shopping_card_use_new_card": { "other": "Αλλαγή κάρτας" },
-
-  "shopping_info_ownership_plan": { "other": "Συνδρομή" },
-
-  "shopping_action_credit": { "other": "Προσθήκη πίστωσης" },
-
-
-  "shopping_info_rental_period_coming_soon": { "other": "Από την ημέρα και ώρα της κυκλοφορίας." },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Αλλαγή πιστωτικής κάρτας" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Ενημερώστε τα στοιχεία της πιστωτικής σας κάρτας" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Αλλαγή" },
-
-  "usersubscriptions_subscription_expiry": { "other": "Τελειώνει {{.Expiry}}" },
-
-
-  
-  "usersubscriptions_subscription_status_trialing": { "other": "Δοκιμαστική περίοδος" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Ακύρωση της συνδρομής μου" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Ματαίωση" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Ναι, ακυρώστε τη συνδρομή μου" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Ακύρωση συνδρομής;" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "Αυτό θα ακυρώσει τη συνδρομή στο {{.Name}} σχέδιο. Θα εξακολουθείτε να μπορείτε να παρακολουθείτε το περιεχόμενο του προγράμματος έως και {{.Expiry}}." },
-
-
-
-  "availability_coming_soon": { "other": "Προσεχώς" },
-  "availability_renting": { "other": "Ενοικίαση" },
-  "availability_not_available": { "other": "Μη διαθέσιμο" },
-  "availability_in_watch_window": { "other": "Διαθέσιμο" },
-  "availability_sold_out": { "other": "Εξαντλημένο" },
-  "availability_available_till": { "other": "Διαθέσιμο έως {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Μη διαθέσιμο" },
-  "availability_available": { "other": "Διαθέσιμο {{.ReleaseDate}}" },
-
-  "modal_cancel": { "other": "Άκυρο" },
-
-  "play": { "other": "Αναπαραγωγή" },
-
-  "combined_auth_signin_prompt": { "other": "Είσοδος" },
-  "combined_auth_signup_prompt": { "other": "Εγγραφή" },
-  "combined_auth_terms": { "other": "Συμφωνώ σε όλους τους <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">όρους και τις προϋποθέσεις</a>." },
-  "signup_terms": { "other": "Συμφωνώ σε όλους τους <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">όρους και τις προϋποθέσεις</a>." },
-  "validation_terms_required": { "other": "Πρέπει να συμφωνήσετε στους όρους και τις προϋποθέσεις." },
-  "shopping_error_item_limit_exceeded": { "other": "Δυστυχώς, το {{.Title}} έχει εξαντληθεί." },
-
-  "shopping_card_change": { "other": "Είναι λανθασμένη η πιστωτική κάρτα; <a href=\"{{.SubscriptionsURL}}\">Κάντε κλικ εδώ για να ενημερώσετε την κάρτα σας.</a>" },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Φαίνεται ότι έχεις πρόβλημα.</p><p>Επαναφέρετε το PIN σας ή επικοινωνήστε μαζί μας για <a href=\"{{.HelpURL}}\" target=\"_blank\">βοήθεια</a>" },
-
-  "app_badge_title": { "other": "Κατεβάστε την εφαρμογή για να δείτε το περιεχόμενο που αγοράσατε!" },
-  "app_badge_ios": { "other": "Λήψη στο App Store" },
-  "app_badge_android": { "other": "Αποκτήστε το στο Google Play" },
-
+  "userdevices_empty_content": {
+    "other": "Προς το παρόν έχετε 0 εγγεγραμμένες συσκευές."
+  },
+  "userdevices_header_type": {
+    "other": "Τύπος συσκευής"
+  },
+  "userdevices_header_description": {
+    "other": "Περιγραφή"
+  },
+  "userdevices_device_added": {
+    "other": "Προστέθηκε {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Αφαίρεση"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Άκυρο"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Ναι, αφαίρεσε τη συσκευή"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Αφαιρέθηκε)"
+  },
+  "playlist_page_header": {
+    "other": "Λίστα αναπαραγωγής"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Συνδεθείτε για να παρακολουθήσετε ζωντανή τηλεόραση."
+  },
+  "playlist_share_title": {
+    "other": "Λίστα αναπαραγωγής"
+  },
+  "playlist_up_next_title": {
+    "other": "επόμενο"
+  },
+  "pricing_ownership_buy": {
+    "other": "Αγορά"
+  },
+  "pricing_ownership_rent": {
+    "other": "Ενοικίαση"
+  },
+  "classification_intro": {
+    "other": "Κατηγοριοποίηση "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Αυτός ο ιστότοπος χρησιμοποιεί cookies για να βελτιώσει την ψηφιακή εμπειρία σας. Χρησιμοποιώντας τη σελίδα, αποδέχεστε τον <a href=\"{{.CookiePolicyURL}}\"> κανονισμό cookies</a>"
+  },
+  "cookie_banner_accept": {
+    "other": "Αποδέχομαι"
+  },
+  "all_rights_reserved": {
+    "other": "Με την επιφύλαξη κάθε δικαιώματος. Απαγορεύεται η αναπαραγωγή του περιεχομένου του ιστοτόπου, χωρίς την απαραίτητη γραπτή άδεια."
+  },
+  "users_gender_none": {
+    "other": "Μη προσδιορισμένο"
+  },
+  "users_gender_female": {
+    "other": "Θηλυκό"
+  },
+  "users_gender_male": {
+    "other": "Αρσενικό"
+  },
+  "users_gender_diverse": {
+    "other": "LGBTQI+"
+  },
+  "users_gender_other": {
+    "other": "Άλλο"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "Μόνο HD"
+  },
+  "pricing_quality_sd_only": {
+    "other": "Μόνο SD"
+  },
+  "shopping_card_save_card": {
+    "other": "Αποθηκεύστε αυτήν την κάρτα για μελλοντική αναφορά"
+  },
+  "shopping_card_button_change": {
+    "other": "Εμφάνιση όλων των αποθηκευμένων καρτών"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} τελειώνει σε {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(λήγει {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(έχει λήξει)"
+  },
+  "shopping_card_use_other": {
+    "other": "Χρησιμοποιήστε μια νέα κάρτα"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Αλλαγή κάρτας"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Συνδρομή"
+  },
+  "shopping_action_credit": {
+    "other": "Προσθήκη πίστωσης"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "Από την ημέρα και ώρα της κυκλοφορίας."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Αλλαγή πιστωτικής κάρτας"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Ενημερώστε τα στοιχεία της πιστωτικής σας κάρτας"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Αλλαγή"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Τελειώνει {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Δοκιμαστική περίοδος"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Ακύρωση της συνδρομής μου"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Ματαίωση"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Ναι, ακυρώστε τη συνδρομή μου"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Ακύρωση συνδρομής;"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Αυτό θα ακυρώσει τη συνδρομή στο {{.Name}} σχέδιο. Θα εξακολουθείτε να μπορείτε να παρακολουθείτε το περιεχόμενο του προγράμματος έως και {{.Expiry}}."
+  },
+  "availability_coming_soon": {
+    "other": "Προσεχώς"
+  },
+  "availability_renting": {
+    "other": "Ενοικίαση"
+  },
+  "availability_not_available": {
+    "other": "Μη διαθέσιμο"
+  },
+  "availability_in_watch_window": {
+    "other": "Διαθέσιμο"
+  },
+  "availability_sold_out": {
+    "other": "Εξαντλημένο"
+  },
+  "availability_available_till": {
+    "other": "Διαθέσιμο έως {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Μη διαθέσιμο"
+  },
+  "availability_available": {
+    "other": "Διαθέσιμο {{.ReleaseDate}}"
+  },
+  "modal_cancel": {
+    "other": "Άκυρο"
+  },
+  "play": {
+    "other": "Αναπαραγωγή"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Είσοδος"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Εγγραφή"
+  },
+  "combined_auth_terms": {
+    "other": "Συμφωνώ σε όλους τους <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">όρους και τις προϋποθέσεις</a>."
+  },
+  "signup_terms": {
+    "other": "Συμφωνώ σε όλους τους <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">όρους και τις προϋποθέσεις</a>."
+  },
+  "validation_terms_required": {
+    "other": "Πρέπει να συμφωνήσετε στους όρους και τις προϋποθέσεις."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Δυστυχώς, το {{.Title}} έχει εξαντληθεί."
+  },
+  "shopping_card_change": {
+    "other": "Είναι λανθασμένη η πιστωτική κάρτα; <a href=\"{{.SubscriptionsURL}}\">Κάντε κλικ εδώ για να ενημερώσετε την κάρτα σας.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Φαίνεται ότι έχεις πρόβλημα.</p><p>Επαναφέρετε το PIN σας ή επικοινωνήστε μαζί μας για <a href=\"{{.HelpURL}}\" target=\"_blank\">βοήθεια</a>"
+  },
+  "app_badge_title": {
+    "other": "Κατεβάστε την εφαρμογή για να δείτε το περιεχόμενο που αγοράσατε!"
+  },
+  "app_badge_ios": {
+    "other": "Λήψη στο App Store"
+  },
+  "app_badge_android": {
+    "other": "Αποκτήστε το στο Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Τιμή"
   },
@@ -520,82 +1059,190 @@
   "donate_button_text": {
     "other": "Προσφέρω"
   },
-
-  "wcag_skip_links_header": { "other": "Σύνδεσμοι προσβασιμότητας" },
-  "wcag_skip_links_content": { "other": "Μετάβαση στο Περιεχόμενο" },
-
-  "wcag_homepage_h1": { "other": "Σπίτι" },
-  "wcag_carousel_h2": { "other": "Στροβιλοδρόμιο" },
-  "wcag_collections_h2": { "other": "Συλλογές" },
-
-  "wcag_aria_label_footer": { "other": "Υποσέλιδο" },
-  "wcag_aria_label_nav_main": { "other": "περιεχόμενο" },
-  "wcag_aria_label_nav_sub": { "other": "Υπο" },
-  "wcag_aria_label_toggle_nav": { "other": "Εναλλαγή πλοήγησης" },
-  "wcag_aria_label_bundle_items": { "other": "Είδη Δέσμης" },
-  "wcag_aria_label_carousel": { "other": "Στροβιλοδρόμιο" },
-  "wcag_aria_label_page_collection": { "other": "Συλλογή σελίδων" },
-  "wcag_aria_label_collection_list": { "other": "Λίστα συλλογής" },
-  "wcag_aria_label_collection_slider": { "other": "Ρυθμιστικό συλλογής" },
-  "wcag_aria_label_wishlist": { "other": "Λίστα επιθυμιών" },
-  "wcag_aria_label_facebook": { "other": "Μοιραστείτε το στο Facebook" },
-  "wcag_aria_label_twitter": { "other": "Μοιραστείτε το στο Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Μοιραστείτε το στο LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Προβολή στο Letterboxd" }, 
-
-  "shopping_error_plan_already_owned": { "other": "Έχετε ήδη αυτό το σχέδιο." },
-  "shopping_error_plan_expired": { "other": "Αυτό το αντικείμενο δεν είναι πλέον διαθέσιμο." },
-  "shopping_payment_method_header": { "other": "Μέθοδοι πληρωμής" },
-  "shopping_payment_method_credit_card": { "other": "Πιστωτική κάρτα" },
-
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  "shopping_error_stripe_unknown_error": { "other": "Κάτι πήγε στραβά με αυτήν την πληρωμή. Παρακαλώ δοκιμάστε ξανά αργότερα." },
-  "shopping_error_payment_complete_failed": { "other": "Η πληρωμή απορρίφθηκε. Κλείστε αυτό το παράθυρο και δοκιμάστε ξανά." },
-
-  "header_banner": { "other": "πανό κεφαλίδας" },
-
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "Δεν έχετε σετ PIN, το οποίο απαιτείται για να αγοράσετε, να νοικιάσετε κάποιες ταινίες."},
-  "account_form_set_pin": { "other": "Ορισμός PIN" },
-  "account_form_pin_changed": { "other": "άλλαξε" },
-  "account_form_change_pin": { "other": "Αλλαγή PIN" },
-
-  "user_set_pin_header": { "other": "Ορίστε το PIN σας" },
-  "user_set_pin_button": { "other": "Ορισμός PIN" },
-  "user_submit_pin_heading": { "other": "Εισαγάγετε το PIN σας στο {{.Action}} αυτό το περιορισμένο περιεχόμενο." },
-  "user_error_wrong_pin_retry": { "other": "Ωχ, πληκτρολογήσατε λάθος PIN" },
-  "user_submit_pin_button": { "other": "Εισαγω" },
-  "user_reset_pin_button": { "other": "Επαναφορά PIN" },
-
-  "validation_pincode1_required": { "other": "εισάγετε ένα έγκυρο PIN" },
-  "validation_pincode2_required": { "other": "εισάγετε ένα έγκυρο PIN" },
-  "validation_pincode1_pattern": { "other": "εισάγετε ένα έγκυρο PIN." },
-  "validation_pincode2_pattern": { "other": "εισάγετε ένα έγκυρο PIN" },
-  "validation_pincode2_match": { "other": "Το PIN δεν ταιριάζει." },
-
-  "userdevices_delete_limits": { "other": "Μπορείτε να αφαιρέσετε {{.Limit}} συσκευές από αυτήν τη λίστα κάθε {{.Period}} ημέρες."},
-  "userdevices_delete_limit_reached": { "other": "Έχετε συμπληρώσει αυτό το όριο και δεν μπορείτε να αφαιρέσετε καμία συσκευή αυτήν τη στιγμή. Μπορείτε να διαγράψετε μια συσκευή σε {{.Days}} ημέρες." },
-  "shopping_card_new_subscription": { "other": "Αυτή η κάρτα θα αποθηκευτεί και θα χρεώνεται τακτικά" },
-
-"changepincode_modal_header": { "other": "Αλλάξτε το PIN σας" },
-"changepincode_modal_currentpassword": { "other": "Το τρέχον συνθηματικό σας" },
-"changepincode_modal_pincode1": { "other": "Το νέο 4ψήφιο PIN σας" },
-"changepincode_modal_pincode2": { "other": "Επιβεβαιώστε το νέο 4ψήφιο PIN σας" },
-"changepincode_modal_submit": { "other": "Ορισμός PIN" },
-"changepincode_modal_error_wrong_password": { "other": "Αυτός ο κωδικός πρόσβασης είναι λανθασμένος." },
-
-"user_set_pin_intro": { "other": "Χρειάζεστε ένα PIN για να {{.Action}} περιορισμένο περιεχόμενο"},
-"user_error_wrong_pin_reset": { "other": "Κάντε κλικ εδώ για να επαναφέρετε το PIN σας" },
-"user_error_too_many_pin_errors_help_page_link": { "other": "" },
-"shopping_error_age_restricted": { "other": "Αυτό το περιεχόμενο είναι περιορισμένο ηλικίας." },
-"shopping_error_close_button": { "other": "εντάξει" }, 
-
-"shopping_card_update_reason_none": { "other": "Ενημερώστε την πιστωτική σας κάρτα. Οι υποστηριζόμενες κάρτες είναι Visa, Mastercard και American Express." },
-
-"availability_expires": { "other": "λήγει {{.Expiry}}" },
-"availability_expired": { "other": "έχει λήξει"},
-
-"signin_form_error_ip_throttled": { "other": "Έχετε αποτύχει να συνδεθείτε πάρα πολλές φορές. Παρακαλώ δοκιμάστε ξανά αργότερα." },
-"signin_form_error_account_suspended": { "other": "Ο λογαριασμός σας έχει τεθεί προσωρινά σε αναστολή. Επικοινωνήστε με έναν διαχειριστή εάν πιστεύετε ότι πρόκειται για λάθος." }
-
+  "wcag_skip_links_header": {
+    "other": "Σύνδεσμοι προσβασιμότητας"
+  },
+  "wcag_skip_links_content": {
+    "other": "Μετάβαση στο Περιεχόμενο"
+  },
+  "wcag_homepage_h1": {
+    "other": "Σπίτι"
+  },
+  "wcag_carousel_h2": {
+    "other": "Στροβιλοδρόμιο"
+  },
+  "wcag_collections_h2": {
+    "other": "Συλλογές"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Υποσέλιδο"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "περιεχόμενο"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Υπο"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Εναλλαγή πλοήγησης"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Είδη Δέσμης"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Στροβιλοδρόμιο"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Συλλογή σελίδων"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Λίστα συλλογής"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Ρυθμιστικό συλλογής"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Λίστα επιθυμιών"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Μοιραστείτε το στο Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Μοιραστείτε το στο Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Μοιραστείτε το στο LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Προβολή στο Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Έχετε ήδη αυτό το σχέδιο."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Αυτό το αντικείμενο δεν είναι πλέον διαθέσιμο."
+  },
+  "shopping_payment_method_header": {
+    "other": "Μέθοδοι πληρωμής"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Πιστωτική κάρτα"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Κάτι πήγε στραβά με αυτήν την πληρωμή. Παρακαλώ δοκιμάστε ξανά αργότερα."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Η πληρωμή απορρίφθηκε. Κλείστε αυτό το παράθυρο και δοκιμάστε ξανά."
+  },
+  "header_banner": {
+    "other": "πανό κεφαλίδας"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Δεν έχετε σετ PIN, το οποίο απαιτείται για να αγοράσετε, να νοικιάσετε κάποιες ταινίες."
+  },
+  "account_form_set_pin": {
+    "other": "Ορισμός PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "άλλαξε"
+  },
+  "account_form_change_pin": {
+    "other": "Αλλαγή PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Ορίστε το PIN σας"
+  },
+  "user_set_pin_button": {
+    "other": "Ορισμός PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Εισαγάγετε το PIN σας στο {{.Action}} αυτό το περιορισμένο περιεχόμενο."
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Ωχ, πληκτρολογήσατε λάθος PIN"
+  },
+  "user_submit_pin_button": {
+    "other": "Εισαγω"
+  },
+  "user_reset_pin_button": {
+    "other": "Επαναφορά PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "εισάγετε ένα έγκυρο PIN"
+  },
+  "validation_pincode2_required": {
+    "other": "εισάγετε ένα έγκυρο PIN"
+  },
+  "validation_pincode1_pattern": {
+    "other": "εισάγετε ένα έγκυρο PIN."
+  },
+  "validation_pincode2_pattern": {
+    "other": "εισάγετε ένα έγκυρο PIN"
+  },
+  "validation_pincode2_match": {
+    "other": "Το PIN δεν ταιριάζει."
+  },
+  "userdevices_delete_limits": {
+    "other": "Μπορείτε να αφαιρέσετε {{.Limit}} συσκευές από αυτήν τη λίστα κάθε {{.Period}} ημέρες."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Έχετε συμπληρώσει αυτό το όριο και δεν μπορείτε να αφαιρέσετε καμία συσκευή αυτήν τη στιγμή. Μπορείτε να διαγράψετε μια συσκευή σε {{.Days}} ημέρες."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Αυτή η κάρτα θα αποθηκευτεί και θα χρεώνεται τακτικά"
+  },
+  "changepincode_modal_header": {
+    "other": "Αλλάξτε το PIN σας"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Το τρέχον συνθηματικό σας"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Το νέο 4ψήφιο PIN σας"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Επιβεβαιώστε το νέο 4ψήφιο PIN σας"
+  },
+  "changepincode_modal_submit": {
+    "other": "Ορισμός PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Αυτός ο κωδικός πρόσβασης είναι λανθασμένος."
+  },
+  "user_set_pin_intro": {
+    "other": "Χρειάζεστε ένα PIN για να {{.Action}} περιορισμένο περιεχόμενο"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Κάντε κλικ εδώ για να επαναφέρετε το PIN σας"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Αυτό το περιεχόμενο είναι περιορισμένο ηλικίας."
+  },
+  "shopping_error_close_button": {
+    "other": "εντάξει"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Ενημερώστε την πιστωτική σας κάρτα. Οι υποστηριζόμενες κάρτες είναι Visa, Mastercard και American Express."
+  },
+  "availability_expires": {
+    "other": "λήγει {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "έχει λήξει"
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Έχετε αποτύχει να συνδεθείτε πάρα πολλές φορές. Παρακαλώ δοκιμάστε ξανά αργότερα."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Ο λογαριασμός σας έχει τεθεί προσωρινά σε αναστολή. Επικοινωνήστε με έναν διαχειριστή εάν πιστεύετε ότι πρόκειται για λάθος."
+  }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Settings" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Settings"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
   "episode_name": {
     "other": "Episode"
   },
-
   "season_name": {
     "other": "Season"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "one season",
     "other": "{{.Count}} seasons"
   },
@@ -38,198 +55,495 @@
     "one": "1 Episode",
     "other": "{{.Count}} Episodes"
   },
-
-  "date_day": { "other": "Day" },
-  "date_month": { "other": "Month" },
-  "date_year": { "other": "Year" },
-
-  "404_page_header": { "other": "That page doesn't exist..." },
-  "404_page_content": { "other": "<p>Sorry, it looks like the page that you're looking for doesn't exist.</p><p>It could have been moved or deleted, or perhaps you misspelled something.</p><p>Try going back to the homepage to find what you were looking for.</p><p><a href=\"{{.URL}}\">Back to the Homepage</a></p>" },
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Sign In" },
-  "nav_signup": { "other": "Create Account" },
-  "nav_signed_in_as": { "other": "Signed in as" },
-  "nav_library": { "other": "My Library" },
-  "nav_devices": { "other": "My Devices" },
-  "nav_wishlist": { "other": "My List" },
-  "nav_account": { "other": "My Account" },
-  "nav_signout": { "other": "Sign Out" },
-  "play_trailer": { "other": "Trailer" },
-  "header_banner": { "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021" },
-  "runtime_hours": { "other": "h" },
-  "runtime_minutes": { "other": "m" },
-
-  "datetime_today": { "other": "today {{.Date}}" },
-  "datetime_tomorrow": { "other": "tomorrow {{.Date}}" },
-  "datetime_yesterday": { "other": "yesterday {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "last {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Search" },
-  "search_control_submit": { "other": "Submit search" },
-
-  "play_button_watch": { "other" : "Play Now"},
-  "play_button_resume": { "other" : "Continue"},
-
-  "social_media_buttons_title": { "other": "Share" },
-  "social_media_buttons_facebook": { "other": "Share on Facebook" },
-  "social_media_buttons_twitter": { "other": "Share on Twitter" },
-  "social_media_buttons_linkedin": { "other": "Share on Linkedin" },
-  "social_media_buttons_email": { "other": "Share via email" },
-  "social_media_buttons_email_subject": { "other": "Link share" },
-  "social_media_buttons_copied_link": { "other": "Link copied to clipboard!" },
-  "social_media_buttons_copy_link": { "other": "Copy to clipboard" },
-
-  "accept_invite_page_header": { "other": "Welcome" },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "It looks like you have already claimed this invite, you should <a href=\"{{.SigninURL}}\">sign in</a> instead. If you have forgotten your password, you can also <a href=\"{{.ForgotPasswordURL}}\">reset your password</a>." },
-  "acceptinvite_complete": { "other": "Thank you. Your account has been created." },
-  "acceptinvite_form_submit": { "other": "Accept Invitation" },
-  "acceptinvite_agreement": { "other": "By clicking \"Accept Invitation\" you agree that you have read and understood our <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; conditions</a> and <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">privacy policy</a>." },
-
-  "signup_page_header": { "other": "Create New Account" },
-  "signup_form_name": { "other": "Name" },
-  "signup_form_email": { "other": "Email address" },
-  "signup_form_password": { "other": "Password" },
-  "signup_form_password_confirmation": { "other": "Confirm your password" },
-  "signup_form_gender": { "other": "Gender" },
-  "signup_form_dob": { "other": "Birth date" },
-  "signup_form_submit": { "other": "Submit" },
-
-  "signin_page_header": { "other": "Sign In" },
-  "signin_form_email": { "other": "Email address" },
-  "signin_form_password": { "other": "Password" },
-  "signin_form_remember": { "other": "Remember me" },
-  "signin_form_submit": { "other": "Submit" },
-  "signin_page_forgotpassword": { "other": "Forgotten your password?" },
-  "signin_page_createnewaccount": { "other": "Don't have an account? Create new account" },
-  "signup_page_alreadyhaveanaccount": { "other": "Already have an account? Sign in" },
-  "signup_form_error_email_already_in_use": { "other": "That email address is already in use." },
-  "signin_form_error_incorrect_credentials": { "other": "The username or password is incorrect." },
-  "signin_form_error_ip_throttled": { "other": "You have failed to sign in too many times. Please try again later." },
-  "signin_form_error_account_suspended": { "other": "Your account has been temporarily suspended. Please contact an admin if you believe this is in error." },
-
-  "signup_form_error_forbidden": { "other": "An error has occurred." },
-
-  "combined_auth_continue": { "other": "Continue" },
-  "combined_auth_change": { "other": "change" },
-  "combined_auth_signin": { "other": "Sign in" },
-  "combined_auth_signup": { "other": "Create Account" },
-  "combined_auth_signin_password": { "other": "Please enter your password to sign in to your account." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "That password is incorrect." },
-  "combined_auth_error_forbidden": { "other": "An error has occurred." },
-  "combined_auth_error_too_many_requests": { "other": "Too many requests, please try again later." },
-
-  "forgotpassword_page_header": { "other": "Reset your Password" },
-  "forgotpassword_form_email": { "other": "Email address" },
-  "forgotpassword_form_submit": { "other": "Reset" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "An account matching that email address does not exist." },
-  "forgotpassword_form_error_account_suspended": { "other": "This account is suspended." },
-  "forgotpassword_complete": { "other": "Thank you. A password reset email should appear in your inbox shortly." },
-  "forgotpassword_form_error_forbidden": { "other": "An error has occurred." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Too many requests, please try again later." },
-
-  "resetpassword_page_header": { "other": "Change your Password" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "It appears as if this reset password request is invalid, please fill out the <a href=\"{{.URL}}\">Forgot Password</a> form again." },
-  "resetpassword_form_password": { "other": "New password" },
-  "resetpassword_form_password2": { "other": "Confirm your new password" },
-  "resetpassword_form_submit": { "other": "Change" },
-  "resetpassword_complete": { "other": "Thank you. Your password has been changed, and you have been signed in." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "The reset password request is invalid. Please try again later." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "The reset password token has expired. Please request a new one." },
-  "resetpassword_form_error_too_many_requests": { "other": "Too many requests, please try again later." },
-
-  "account_page_header": { "other": "My Account" },
-  "account_form_name": { "other": "Name" },
-  "account_form_email": { "other": "Email address" },
-  "account_form_password": { "other": "Password" },
-  "account_form_change_password": { "other": "Change" },
-  "account_form_gender": { "other": "Gender" },
-  "account_form_dob": { "other": "Birth date" },
-  "account_form_submit": { "other": "Update" },
-  "account_form_submitted": { "other": "Updated" },
-  "account_form_password_changed": { "other": "Updated" },
-  "account_form_error_incorrect_password": { "other": "That password is incorrect." },
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "You don't have a PIN set, which is required for purchasing, renting and watching some titles."},
-  "account_form_set_pin": { "other": "Set PIN" },
-  "account_form_pin_changed": { "other": "Updated" },
-  "account_form_change_pin": { "other": "Change PIN" },
-
-  "user_set_pin_header": { "other": "Set your PIN" },
-  "user_set_pin_button": { "other": "Set PIN" },
-  "user_submit_pin_heading": { "other": "Enter your PIN to {{.Action}} this restricted content" },
-  "user_error_wrong_pin_retry": { "other": "Oops, you have entered an incorrect PIN" },
-  "user_error_too_many_pin_errors": { "other": "<p>Looks like you're having trouble.</p><p>Reset your PIN or contact us for <a href=\"{{.HelpURL}}\" target=\"_blank\">help</a>" },
-  "user_submit_pin_button": { "other": "Enter" },
-  "user_reset_pin_button": { "other": "Reset PIN" },
-
-  "signup_form_optin": {"other": "Sign up for our free newsletter"},
-
-  "passwordconfirmation_modal_header": { "other": "Confirm your password" },
-  "passwordconfirmation_modal_label": { "other": "Please enter your password in order to update your changes" },
-  "passwordconfirmation_modal_confirm": { "other": "Confirm" },
-
-  "changepassword_modal_header": { "other": "Change your password" },
-  "changepassword_modal_currentpassword": { "other": "Your current password" },
-  "changepassword_modal_password": { "other": "Your new password" },
-  "changepassword_modal_password2": { "other": "Confirm your new password" },
-  "changepassword_modal_submit": { "other": "Update" },
-  "changepassword_modal_error_incorrect_password": { "other": "That password is incorrect." },
-
-  "userlibrary_page_header": { "other": "My Library" },
-  "userlibrary_empty_header":  { "other": "Your library is empty." },
-  "userlibrary_empty_content": { "other": "Fill it by <a href=\"{{.HomeURL}}\">browsing</a> our great selection." },
-
-  "searchresults_page_header": { "other": "Search Results" },
-  "searchresults_load_more": { "other": "Load {{.Count}} more" },
+  "date_day": {
+    "other": "Day"
+  },
+  "date_month": {
+    "other": "Month"
+  },
+  "date_year": {
+    "other": "Year"
+  },
+  "404_page_header": {
+    "other": "That page doesn't exist..."
+  },
+  "404_page_content": {
+    "other": "<p>Sorry, it looks like the page that you're looking for doesn't exist.</p><p>It could have been moved or deleted, or perhaps you misspelled something.</p><p>Try going back to the homepage to find what you were looking for.</p><p><a href=\"{{.URL}}\">Back to the Homepage</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Sign In"
+  },
+  "nav_signup": {
+    "other": "Create Account"
+  },
+  "nav_signed_in_as": {
+    "other": "Signed in as"
+  },
+  "nav_library": {
+    "other": "My Library"
+  },
+  "nav_devices": {
+    "other": "My Devices"
+  },
+  "nav_wishlist": {
+    "other": "My List"
+  },
+  "nav_account": {
+    "other": "My Account"
+  },
+  "nav_signout": {
+    "other": "Sign Out"
+  },
+  "play_trailer": {
+    "other": "Trailer"
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "m"
+  },
+  "datetime_today": {
+    "other": "today {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "tomorrow {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "yesterday {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "last {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Search"
+  },
+  "search_control_submit": {
+    "other": "Submit search"
+  },
+  "play_button_watch": {
+    "other": "Play Now"
+  },
+  "play_button_resume": {
+    "other": "Continue"
+  },
+  "social_media_buttons_title": {
+    "other": "Share"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Share on Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Share on Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Share on Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Share via email"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Link share"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link copied to clipboard!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Copy to clipboard"
+  },
+  "accept_invite_page_header": {
+    "other": "Welcome"
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "It looks like you have already claimed this invite, you should <a href=\"{{.SigninURL}}\">sign in</a> instead. If you have forgotten your password, you can also <a href=\"{{.ForgotPasswordURL}}\">reset your password</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Thank you. Your account has been created."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Accept Invitation"
+  },
+  "acceptinvite_agreement": {
+    "other": "By clicking \"Accept Invitation\" you agree that you have read and understood our <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; conditions</a> and <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">privacy policy</a>."
+  },
+  "signup_page_header": {
+    "other": "Create New Account"
+  },
+  "signup_form_name": {
+    "other": "Name"
+  },
+  "signup_form_email": {
+    "other": "Email address"
+  },
+  "signup_form_password": {
+    "other": "Password"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Confirm your password"
+  },
+  "signup_form_gender": {
+    "other": "Gender"
+  },
+  "signup_form_dob": {
+    "other": "Birth date"
+  },
+  "signup_form_submit": {
+    "other": "Submit"
+  },
+  "signin_page_header": {
+    "other": "Sign In"
+  },
+  "signin_form_email": {
+    "other": "Email address"
+  },
+  "signin_form_password": {
+    "other": "Password"
+  },
+  "signin_form_remember": {
+    "other": "Remember me"
+  },
+  "signin_form_submit": {
+    "other": "Submit"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Forgotten your password?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Don't have an account? Create new account"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Already have an account? Sign in"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "That email address is already in use."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "The username or password is incorrect."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "You have failed to sign in too many times. Please try again later."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Your account has been temporarily suspended. Please contact an admin if you believe this is in error."
+  },
+  "signup_form_error_forbidden": {
+    "other": "An error has occurred."
+  },
+  "combined_auth_continue": {
+    "other": "Continue"
+  },
+  "combined_auth_change": {
+    "other": "change"
+  },
+  "combined_auth_signin": {
+    "other": "Sign in"
+  },
+  "combined_auth_signup": {
+    "other": "Create Account"
+  },
+  "combined_auth_signin_password": {
+    "other": "Please enter your password to sign in to your account."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "That password is incorrect."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "An error has occurred."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Too many requests, please try again later."
+  },
+  "forgotpassword_page_header": {
+    "other": "Reset your Password"
+  },
+  "forgotpassword_form_email": {
+    "other": "Email address"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Reset"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "An account matching that email address does not exist."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "This account is suspended."
+  },
+  "forgotpassword_complete": {
+    "other": "Thank you. A password reset email should appear in your inbox shortly."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "An error has occurred."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Too many requests, please try again later."
+  },
+  "resetpassword_page_header": {
+    "other": "Change your Password"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "It appears as if this reset password request is invalid, please fill out the <a href=\"{{.URL}}\">Forgot Password</a> form again."
+  },
+  "resetpassword_form_password": {
+    "other": "New password"
+  },
+  "resetpassword_form_password2": {
+    "other": "Confirm your new password"
+  },
+  "resetpassword_form_submit": {
+    "other": "Change"
+  },
+  "resetpassword_complete": {
+    "other": "Thank you. Your password has been changed, and you have been signed in."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "The reset password request is invalid. Please try again later."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "The reset password token has expired. Please request a new one."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Too many requests, please try again later."
+  },
+  "account_page_header": {
+    "other": "My Account"
+  },
+  "account_form_name": {
+    "other": "Name"
+  },
+  "account_form_email": {
+    "other": "Email address"
+  },
+  "account_form_password": {
+    "other": "Password"
+  },
+  "account_form_change_password": {
+    "other": "Change"
+  },
+  "account_form_gender": {
+    "other": "Gender"
+  },
+  "account_form_dob": {
+    "other": "Birth date"
+  },
+  "account_form_submit": {
+    "other": "Update"
+  },
+  "account_form_submitted": {
+    "other": "Updated"
+  },
+  "account_form_password_changed": {
+    "other": "Updated"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "That password is incorrect."
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "You don't have a PIN set, which is required for purchasing, renting and watching some titles."
+  },
+  "account_form_set_pin": {
+    "other": "Set PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Updated"
+  },
+  "account_form_change_pin": {
+    "other": "Change PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Set your PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Set PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Enter your PIN to {{.Action}} this restricted content"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Oops, you have entered an incorrect PIN"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Looks like you're having trouble.</p><p>Reset your PIN or contact us for <a href=\"{{.HelpURL}}\" target=\"_blank\">help</a>"
+  },
+  "user_submit_pin_button": {
+    "other": "Enter"
+  },
+  "user_reset_pin_button": {
+    "other": "Reset PIN"
+  },
+  "signup_form_optin": {
+    "other": "Sign up for our free newsletter"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Confirm your password"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Please enter your password in order to update your changes"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Confirm"
+  },
+  "changepassword_modal_header": {
+    "other": "Change your password"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Your current password"
+  },
+  "changepassword_modal_password": {
+    "other": "Your new password"
+  },
+  "changepassword_modal_password2": {
+    "other": "Confirm your new password"
+  },
+  "changepassword_modal_submit": {
+    "other": "Update"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "That password is incorrect."
+  },
+  "userlibrary_page_header": {
+    "other": "My Library"
+  },
+  "userlibrary_empty_header": {
+    "other": "Your library is empty."
+  },
+  "userlibrary_empty_content": {
+    "other": "Fill it by <a href=\"{{.HomeURL}}\">browsing</a> our great selection."
+  },
+  "searchresults_page_header": {
+    "other": "Search Results"
+  },
+  "searchresults_load_more": {
+    "other": "Load {{.Count}} more"
+  },
   "searchresults_total": {
     "one": "Found 1 result for \"{{.Query}}\".",
     "other": "Found {{.Count}} results for \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "There were no search results for \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Try another search or <a href=\"{{.HomeURL}}\">browse our content</a> to find what you're looking for." },
-
-  "validation_name_required": { "other": "Please enter your name." },
-  "validation_email_required": { "other": "Please enter your email address." },
-  "validation_email_email": { "other": "Please enter a valid email address." },
-  "validation_currentpassword_required": { "other": "Please enter your current password." },
-  "validation_password_required": { "other": "Please enter a password." },
-  "validation_password2_required": { "other": "Please confirm your password." },
-  "validation_password2_match": { "other": "Your passwords do not match." },
-  "validation_password_minlength": { "other": "Please enter at least {{.Count}} characters." },
-  "validation_promocode_required": { "other": "Please enter a promo code." },
-  "validation_pincode_required": { "other": "Please enter a PIN code." },
-  "validation_pincode1_required": { "other": "Please enter a valid PIN code." },
-  "validation_pincode2_required": { "other": "Please enter a valid PIN code." },
-  "validation_pincode1_pattern": { "other": "Please enter a valid PIN code." },
-  "validation_pincode2_pattern": { "other": "Please enter a valid PIN code." },
-  "validation_pincode2_match": { "other": "PIN code does not match." },
-  "validation_gender_required": { "other": "Please select the closest gender you identify with." },
-  "validation_dob_required": { "other": "Please enter your date of birth." },
-  "validation_dob_date": { "other": "Please enter a valid date of birth." },
-
-  "shopping_info_subtitle_hd": { "other": "HD Video on Demand." },
-  "shopping_info_subtitle_sd": { "other": "SD Video on Demand." },
-  "shopping_info_subtitle_wallet": { "other": "Funds in your Wallet may be used for the purchase or rental of any content on ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "See here for system requirements." },
-  "shopping_info_ownership_buy": { "other": "purchase" },
-  "shopping_info_ownership_rent": { "other": "rental" },
-
-  "shopping_info_sd_only": { "other": "Limited to SD playback only." },
-  "shopping_info_release_date_title": { "other": "Releases {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "You can rent it now, but you won't be able to watch it until then." },
-  "shopping_info_release_date_explanation_buy": { "other": "You can buy it now, but you won't be able to watch it until then." },
-
-  "shopping_info_available_until_date_title": { "other": "Available until {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "You will not be able to view the content after this." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "You will not be able to view the content after this." },
-  
-  "duration_hour": { "one": "1 hour", "other": "{{.Count}} hours" },
-  "duration_day": { "one": "1 day", "other": "{{.Count}} days" },
-  "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} rental " },
-  "shopping_info_watch_window_duration": { "other": "{{.Count}} hour playback window. " },
+  "searchresults_empty_header": {
+    "other": "There were no search results for \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Try another search or <a href=\"{{.HomeURL}}\">browse our content</a> to find what you're looking for."
+  },
+  "validation_name_required": {
+    "other": "Please enter your name."
+  },
+  "validation_email_required": {
+    "other": "Please enter your email address."
+  },
+  "validation_email_email": {
+    "other": "Please enter a valid email address."
+  },
+  "validation_currentpassword_required": {
+    "other": "Please enter your current password."
+  },
+  "validation_password_required": {
+    "other": "Please enter a password."
+  },
+  "validation_password2_required": {
+    "other": "Please confirm your password."
+  },
+  "validation_password2_match": {
+    "other": "Your passwords do not match."
+  },
+  "validation_password_minlength": {
+    "other": "Please enter at least {{.Count}} characters."
+  },
+  "validation_promocode_required": {
+    "other": "Please enter a promo code."
+  },
+  "validation_pincode_required": {
+    "other": "Please enter a PIN code."
+  },
+  "validation_pincode1_required": {
+    "other": "Please enter a valid PIN code."
+  },
+  "validation_pincode2_required": {
+    "other": "Please enter a valid PIN code."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Please enter a valid PIN code."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Please enter a valid PIN code."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN code does not match."
+  },
+  "validation_gender_required": {
+    "other": "Please select the closest gender you identify with."
+  },
+  "validation_dob_required": {
+    "other": "Please enter your date of birth."
+  },
+  "validation_dob_date": {
+    "other": "Please enter a valid date of birth."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Video on Demand."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video on Demand."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Funds in your Wallet may be used for the purchase or rental of any content on ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "See here for system requirements."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "purchase"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "rental"
+  },
+  "shopping_info_sd_only": {
+    "other": "Limited to SD playback only."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Releases {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "You can rent it now, but you won't be able to watch it until then."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "You can buy it now, but you won't be able to watch it until then."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Available until {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "You will not be able to view the content after this."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "You will not be able to view the content after this."
+  },
+  "duration_hour": {
+    "one": "1 hour",
+    "other": "{{.Count}} hours"
+  },
+  "duration_day": {
+    "one": "1 day",
+    "other": "{{.Count}} days"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} rental "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} hour playback window. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Once rented, your film will be available in your account for {{.ValueUnit}}. ",
     "other": "Once rented, your film will be available in your account for {{.ValueUnit}}. "
@@ -254,69 +568,157 @@
     "one": "Once you press play on an episode, the watch window begins and you have an hour to watch that episode as many times as you like.",
     "other": "Once you press play on an episode, the watch window begins and you have {{.Count}} hours to watch that episode as many times as you like."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Bonus" },
-
-  "shopping_enter_card_prompt": { "other": "Enter your credit card details below to complete your {{.Verb}}." },
-
-  "shopping_terms": { "other": "By completing this transaction, I agree to the <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">terms and conditions</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} discount applied." },
-  "shopping_discount_apply": { "other": "Apply" },
-  "shopping_discount_code": { "other": "Enter a promo code." },
-  "shopping_discount_have_code": { "other": "I have a promo code." },
-
-  "shopping_price_you_pay": { "other": "You pay" },
-  "shopping_price_nothing": { "other": "Nothing" },
-  "shopping_price_free": { "other": "Free" },
-
-  "shopping_auth_directions": { "other": "An account is needed first. Please enter your email address." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} is already in your library." },
-
-  "shopping_error_missing_card": { "other": "Please enter your Credit Card details." },
-  "shopping_error_title": { "other": "An error occurred" },
-  "shopping_error_incorrect_cvc": { "other": "Please enter a valid CVV." },
-  "shopping_error_invalid_cvc": { "other": "Please enter a valid CVV." },
-  "shopping_error_incorrect_number": { "other": "Please enter a valid Credit Card Number." },
-  "shopping_error_invalid_number": { "other": "Please enter a valid Credit Card Number." },
-  "shopping_error_card_declined": { "other": "The Credit Card has been declined." },
-  "shopping_error_invalid_expiry_month": { "other": "Please enter a valid Expiry." },
-  "shopping_error_invalid_expiry_year": { "other": "Please enter a valid Expiry." },
-  "shopping_error_expired_card": { "other": "The Credit Card has expired." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Your {{.Ownership}} has not been completed. You need to be in the country your credit card was issued. Please use another card for making the payment." },
-  "shopping_error_proxy_detected": { "other": "Your {{.Ownership}} has not been completed. We have detected that you are using an unblocker or proxy service. Please turn off any of these services and try again." },
-
-  "shopping_error_discount_worn_out": { "other": "That promo code can no longer be used." },
-  "shopping_error_discount_blank": { "other": "Please enter a promo code." },
-  "shopping_error_discount_not_applied": { "other": "Please enter a valid promo code." },
-  "shopping_error_discount_invalid": { "other": "Please enter a valid promo code." },
-  "shopping_error_discount_disabled": { "other": "Please enter a valid promo code." },
-  "shopping_error_discount_already_applied": { "other": "A promo code has already been used for this session." },
-  "shopping_error_discount_already_redeemed": { "other": "That promo code has already been used." },
-  "shopping_error_discount_used_previously": { "other": "That promo code has already been used." },
-  "shopping_error_discount_max_limit": { "other": "That promo code can no longer be used." },
-  "shopping_error_discount_expired": { "other": "That promo code has expired." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "That promo code can not be used when purchasing." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "That promo code can not be used when renting." },
-  "shopping_error_discount_invalid_item": { "other": "That promo code can not be used with this item." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "That promo code can not be used in your country." },
-  "shopping_error_discounts_not_allowed": { "other": "That promo code can not be used." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "That promo code can not be used on bundles." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "The Credit Card has been declined. Please try again." },
-
-  "shopping_error_plan_already_owned": { "other": "You already have this plan." },
-  "shopping_error_plan_expired": { "other": "This plan is no longer available." },
-
-  "shopping_complete_rental": { "other": "Success!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Bonus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Enter your credit card details below to complete your {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "By completing this transaction, I agree to the <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">terms and conditions</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} discount applied."
+  },
+  "shopping_discount_apply": {
+    "other": "Apply"
+  },
+  "shopping_discount_code": {
+    "other": "Enter a promo code."
+  },
+  "shopping_discount_have_code": {
+    "other": "I have a promo code."
+  },
+  "shopping_price_you_pay": {
+    "other": "You pay"
+  },
+  "shopping_price_nothing": {
+    "other": "Nothing"
+  },
+  "shopping_price_free": {
+    "other": "Free"
+  },
+  "shopping_auth_directions": {
+    "other": "An account is needed first. Please enter your email address."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} is already in your library."
+  },
+  "shopping_error_missing_card": {
+    "other": "Please enter your Credit Card details."
+  },
+  "shopping_error_title": {
+    "other": "An error occurred"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Please enter a valid CVV."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Please enter a valid CVV."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Please enter a valid Credit Card Number."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Please enter a valid Credit Card Number."
+  },
+  "shopping_error_card_declined": {
+    "other": "The Credit Card has been declined."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Please enter a valid Expiry."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Please enter a valid Expiry."
+  },
+  "shopping_error_expired_card": {
+    "other": "The Credit Card has expired."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Your {{.Ownership}} has not been completed. You need to be in the country your credit card was issued. Please use another card for making the payment."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Your {{.Ownership}} has not been completed. We have detected that you are using an unblocker or proxy service. Please turn off any of these services and try again."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "That promo code can no longer be used."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Please enter a promo code."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Please enter a valid promo code."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Please enter a valid promo code."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Please enter a valid promo code."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "A promo code has already been used for this session."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "That promo code has already been used."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "That promo code has already been used."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "That promo code can no longer be used."
+  },
+  "shopping_error_discount_expired": {
+    "other": "That promo code has expired."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "That promo code can not be used when purchasing."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "That promo code can not be used when renting."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "That promo code can not be used with this item."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "That promo code can not be used in your country."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "That promo code can not be used."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "That promo code can not be used on bundles."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "The Credit Card has been declined. Please try again."
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "You already have this plan."
+  },
+  "shopping_error_plan_expired": {
+    "other": "This plan is no longer available."
+  },
+  "shopping_complete_rental": {
+    "other": "Success!"
+  },
   "shopping_complete_rental_period": {
     "one": "You are now able to watch it as often as you like over the next day.",
     "other": "You are now able to watch it as often as you like over the next {{.Count}} days."
   },
-  "shopping_complete_purchase": { "other": "Thank you for purchasing {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Thank you for purchasing {{.Title}}, {{.CreditTotal}} has been added to your account." },
-  "shopping_complete_purchase_coming_soon": { "other": "You will be able to watch it from {{.Date}}." },
-  "shopping_complete_receipt": { "other": "A receipt has been emailed to you." },
-  "shopping_complete_library_link": { "other": "View your library" },
-
+  "shopping_complete_purchase": {
+    "other": "Thank you for purchasing {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Thank you for purchasing {{.Title}}, {{.CreditTotal}} has been added to your account."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "You will be able to watch it from {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "A receipt has been emailed to you."
+  },
+  "shopping_complete_library_link": {
+    "other": "View your library"
+  },
   "shopping_complete_rental_watch_window_start": {
     "one": "You are now able to start watching it within the next day.",
     "other": "You are now able to start watching it within the next {{.Count}} days."
@@ -333,109 +735,256 @@
     "one": "You will be able to watch it from {{.Date}} and your rental will remain active for a day.",
     "other": "You will be able to watch it from {{.Date}} and your rental will remain active for {{.Count}} days."
   },
-
-  "shopping_action_rent": { "other": "Rent" },
-  "shopping_action_buy": { "other": "Buy" },
-
-  "shopping_payment_method_header": { "other": "Payment methods" },
-  "shopping_payment_method_credit_card": { "other": "Credit card" },
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-
-  "shopping_error_stripe_unknown_error": { "other": "Something went wrong with this payment. Please try again later." },
-  "shopping_error_payment_complete_failed": { "other": "The payment was declined. Close this window and try again." },
-
-  "meta_detail_cast_title": { "other": "Cast" },
-  "meta_detail_crew_title": { "other": "Crew" },
-  "meta_detail_languages": { "one": "Language", "other": "Languages" },
-  "meta_detail_studios": { "one": "Studio", "other": "Studios" },
-  "meta_detail_countries": { "one": "Country", "other": "Countries" },
-  "meta_detail_subtitles": { "other": "Subtitles" },
-  "meta_detail_captions": { "other": "Closed Captions [CC]" },
-  "meta_detail_episodes_title": { "other": "Episodes" },
-  "meta_detail_bonus_title": { "other": "Bonus Content" },
-  "meta_detail_recommendations_title": { "other": "You may also like" },
-  "meta_detail_bundle_items_title": { "other": "Content included in this bundle" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} films" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} seasons" },
-  "bundle_items_mixed": { "other": "{{.Count}} films and seasons" },
-  "userwishlist_page_header": { "other": "My List" },
-  "userwishlist_slider_header": { "other": "My List" },
-  "userwishlist_empty_header":  { "other": "Your list is empty." },
-  "userwishlist_empty_content": { "other": "Fill it by <a href=\"{{.HomeURL}}\">browsing</a> our great selection." },
-  "userwishlist_button_add": { "other": "Add to My List" },
-  "userwishlist_button_remove": { "other": "My List" },
-  "userwishlist_button_add_compact": { "other": "My List" },
-  "userwishlist_button_remove_compact": { "other": "My List" },
-
-  "activatedevice_page_header": { "other": "Activate Device" },
-  "activatedevice_page_content": { "other": "Follow the instructions on your device to get a PIN code. Your computer and device must both be connected to the internet to activate." },
-  "activatedevice_form_pin": { "other": "PIN Code" },
-  "activatedevice_form_submit": { "other": "Activate" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN Code not found, please try again." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN Code not found, please try again." },
-  "activatedevice_signin_prompt": { "other": "Please sign in before activating your device." },
-  "activatedevice_page_activated": { "other": "Thank you for activating {{.DeviceName}}. You should now be able to browse your library on your television or device." },
-
-  "userdevices_page_header": { "other": "Devices" },
+  "shopping_action_rent": {
+    "other": "Rent"
+  },
+  "shopping_action_buy": {
+    "other": "Buy"
+  },
+  "shopping_payment_method_header": {
+    "other": "Payment methods"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Credit card"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Something went wrong with this payment. Please try again later."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "The payment was declined. Close this window and try again."
+  },
+  "meta_detail_cast_title": {
+    "other": "Cast"
+  },
+  "meta_detail_crew_title": {
+    "other": "Crew"
+  },
+  "meta_detail_languages": {
+    "one": "Language",
+    "other": "Languages"
+  },
+  "meta_detail_studios": {
+    "one": "Studio",
+    "other": "Studios"
+  },
+  "meta_detail_countries": {
+    "one": "Country",
+    "other": "Countries"
+  },
+  "meta_detail_subtitles": {
+    "other": "Subtitles"
+  },
+  "meta_detail_captions": {
+    "other": "Closed Captions [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Episodes"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Bonus Content"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "You may also like"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Content included in this bundle"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} films"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} seasons"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} films and seasons"
+  },
+  "userwishlist_page_header": {
+    "other": "My List"
+  },
+  "userwishlist_slider_header": {
+    "other": "My List"
+  },
+  "userwishlist_empty_header": {
+    "other": "Your list is empty."
+  },
+  "userwishlist_empty_content": {
+    "other": "Fill it by <a href=\"{{.HomeURL}}\">browsing</a> our great selection."
+  },
+  "userwishlist_button_add": {
+    "other": "Add to My List"
+  },
+  "userwishlist_button_remove": {
+    "other": "My List"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "My List"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "My List"
+  },
+  "activatedevice_page_header": {
+    "other": "Activate Device"
+  },
+  "activatedevice_page_content": {
+    "other": "Follow the instructions on your device to get a PIN code. Your computer and device must both be connected to the internet to activate."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN Code"
+  },
+  "activatedevice_form_submit": {
+    "other": "Activate"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN Code not found, please try again."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN Code not found, please try again."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Please sign in before activating your device."
+  },
+  "activatedevice_page_activated": {
+    "other": "Thank you for activating {{.DeviceName}}. You should now be able to browse your library on your television or device."
+  },
+  "userdevices_page_header": {
+    "other": "Devices"
+  },
   "userdevices_page_content": {
     "one": "Devices will be automatically added here when you use them. You are limited to only one device.",
     "other": "Devices will be automatically added here when you use them. You are limited to {{.Count}} devices."
   },
-  "userdevices_empty_content": { "other": "You currently have 0 registered devices." },
-  "userdevices_header_type": { "other": "Device Type" },
-  "userdevices_header_description": { "other": "Description" },
-  "userdevices_device_added": { "other": "Added {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Remove" },
-  "userdevices_device_actions_cancel": { "other": "Cancel" },
-  "userdevices_device_actions_confirm": { "other": "Yes, remove device" },
-  "userdevices_device_deleted": { "other": "(Removed)" },
-  "userdevices_delete_limits": { "other": "You can remove {{.Limit}} device(s) from this list every {{.Period}} day(s)."},
-  "userdevices_delete_limit_reached": { "other": "You have reached this limit and can't remove any devices right now. You can delete a device in {{.Days}} day(s)." },
-
-  "playlist_page_header": { "other": "Playlist" },
-  "playlist_sign_in_warning": { "other": "Please sign in to watch live TV."},
-  "playlist_share_title": { "other": "Playlist" },
-  "playlist_up_next_title": { "other": "Up Next" },
-
-  "pricing_ownership_buy": { "other": "Buy" },
-  "pricing_ownership_rent": { "other": "Rent" },
-
-  "classification_intro": { "other": "Rating: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "This site uses cookies to enhance your experience. By using this site, you accept our <a href=\"{{.CookiePolicyURL}}\">cookie usage</a>." },
-  "cookie_banner_accept": { "other": "Accept" },
-
-  "all_rights_reserved": { "other": "All rights reserved. No part of this site may be reproduced without our written permission." },
-
-  "users_gender_none": { "other": "Not specified" },
-  "users_gender_female": { "other": "Female" },
-  "users_gender_male": { "other": "Male" },
-  "users_gender_diverse": { "other": "Diverse" },
-  "users_gender_other": { "other": "Other" },
-
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HD Only" },
-  "pricing_quality_sd_only": { "other": "SD Only" },
-
-  "shopping_card_save_card": { "other": "Save this card for future use" },
-  "shopping_card_button_change": { "other": "Show all saved cards" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} ending in {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(expires {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(expired)" },
-  "shopping_card_use_other": { "other": "Use a new card" },
-  "shopping_card_use_new_card": { "other": "Change card" },
-  "shopping_card_update_reason_none": { "other": "Update your credit card. Supported cards are Visa, Mastercard and American Express." },
-  "shopping_card_new_subscription": { "other": "This card will be saved and charged regularly" },
-  "shopping_card_change": { "other": "Credit card not correct? <a href=\"{{.SubscriptionsURL}}\">Click here to update your card.</a>" },
-
-  "shopping_info_ownership_plan": { "other": "Subscription"},
-
-  "shopping_price_title_plan": { "other": "Price" },
+  "userdevices_empty_content": {
+    "other": "You currently have 0 registered devices."
+  },
+  "userdevices_header_type": {
+    "other": "Device Type"
+  },
+  "userdevices_header_description": {
+    "other": "Description"
+  },
+  "userdevices_device_added": {
+    "other": "Added {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Remove"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Cancel"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Yes, remove device"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Removed)"
+  },
+  "userdevices_delete_limits": {
+    "other": "You can remove {{.Limit}} device(s) from this list every {{.Period}} day(s)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "You have reached this limit and can't remove any devices right now. You can delete a device in {{.Days}} day(s)."
+  },
+  "playlist_page_header": {
+    "other": "Playlist"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Please sign in to watch live TV."
+  },
+  "playlist_share_title": {
+    "other": "Playlist"
+  },
+  "playlist_up_next_title": {
+    "other": "Up Next"
+  },
+  "pricing_ownership_buy": {
+    "other": "Buy"
+  },
+  "pricing_ownership_rent": {
+    "other": "Rent"
+  },
+  "classification_intro": {
+    "other": "Rating: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "This site uses cookies to enhance your experience. By using this site, you accept our <a href=\"{{.CookiePolicyURL}}\">cookie usage</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Accept"
+  },
+  "all_rights_reserved": {
+    "other": "All rights reserved. No part of this site may be reproduced without our written permission."
+  },
+  "users_gender_none": {
+    "other": "Not specified"
+  },
+  "users_gender_female": {
+    "other": "Female"
+  },
+  "users_gender_male": {
+    "other": "Male"
+  },
+  "users_gender_diverse": {
+    "other": "Diverse"
+  },
+  "users_gender_other": {
+    "other": "Other"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD Only"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD Only"
+  },
+  "shopping_card_save_card": {
+    "other": "Save this card for future use"
+  },
+  "shopping_card_button_change": {
+    "other": "Show all saved cards"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} ending in {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(expires {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(expired)"
+  },
+  "shopping_card_use_other": {
+    "other": "Use a new card"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Change card"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Update your credit card. Supported cards are Visa, Mastercard and American Express."
+  },
+  "shopping_card_new_subscription": {
+    "other": "This card will be saved and charged regularly"
+  },
+  "shopping_card_change": {
+    "other": "Credit card not correct? <a href=\"{{.SubscriptionsURL}}\">Click here to update your card.</a>"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Subscription"
+  },
+  "shopping_price_title_plan": {
+    "other": "Price"
+  },
   "shopping_price_plan_note": {
     "zero": "Charged every {{.Interval}}.",
     "one": "Charged every {{.Interval}} after your 24 hour free trial ends.",
@@ -445,18 +994,27 @@
     "one": "{{.Interval}}",
     "other": "{{.Count}} {{.Interval}}s"
   },
-
-  "shopping_enter_card_prompt_plan": { "other": "Enter your credit card details below in order start your subscription." },
-
-  "shopping_action_credit": { "other": "Top up" },
-  "shopping_action_plan": { "other": "Complete" },
-
-  "shopping_complete_subscription": { "other": "Your subscription purchase was successful. You are now subscribed to {{.Title}}." },
-  "shopping_complete_subscription_browse": { "other": "Feel free to <a href=\"/\">browse around</a> the site, or <a href=\"/search.html\">search</a> for something specific." },
-
-  "shopping_complete_plan": { "other": "Your purchase of {{.Title}} was successful." },
-
-  "shopping_info_rental_period_coming_soon": { "other": "from the date and time of release." },
+  "shopping_enter_card_prompt_plan": {
+    "other": "Enter your credit card details below in order start your subscription."
+  },
+  "shopping_action_credit": {
+    "other": "Top up"
+  },
+  "shopping_action_plan": {
+    "other": "Complete"
+  },
+  "shopping_complete_subscription": {
+    "other": "Your subscription purchase was successful. You are now subscribed to {{.Title}}."
+  },
+  "shopping_complete_subscription_browse": {
+    "other": "Feel free to <a href=\"/\">browse around</a> the site, or <a href=\"/search.html\">search</a> for something specific."
+  },
+  "shopping_complete_plan": {
+    "other": "Your purchase of {{.Title}} was successful."
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "from the date and time of release."
+  },
   "shopping_info_plan_offer": {
     "one": "Automatically renews every {{.Interval}}",
     "other": "Automatically renews every {{.Count}} {{.Interval}}s"
@@ -465,96 +1023,226 @@
     "one": "Try your free 24hr trial now!",
     "other": "Try your free {{.Count}} day trial!"
   },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Change Credit Card" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Update credit card details" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Update" },
-
-  "usersubscriptions_subscription_expiry": { "other": "Expires {{.Expiry}}" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Trial Period" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Cancel my subscription" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Cancel" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Yes, cancel my subscription" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Cancel subscription?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "This will cancel the subscription to the {{.Name}} plan. You will still be able to watch the content in the plan until it expires {{.Expiry}}." },
-
-
-  "availability_coming_soon": { "other": "Coming soon" },
-  "availability_renting": { "other": "Renting" },
-  "availability_not_available": { "other": "Not available" },
-  "availability_in_watch_window": { "other": "Available in watch window" },
-  "availability_sold_out": { "other": "Sold Out" },
-  "availability_available_till": { "other": "Available until {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Not available in your country" },
-  "availability_available": { "other": "Available {{.ReleaseDate}}" },
-  "availability_expires": { "other": "Expires {{.Expiry}}" },
-  "availability_expired": { "other": "Expired"},
-
-  "modal_cancel": { "other": "Cancel" },
-
-  "play": { "other": "Play" },
-
-  "combined_auth_signin_prompt": { "other": "Sign in" },
-  "combined_auth_signup_prompt": { "other": "Create Account" },
-  "combined_auth_terms": { "other": "I agree to all the <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; conditions</a>." },
-  "signup_terms": { "other": "I agree to all the <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; conditions</a>." },
-  "validation_terms_required": { "other": "You must agree to the terms and conditions." },
-  "shopping_error_item_limit_exceeded": { "other": "Unfortunately, {{.Title}} has sold out." },
-
-  "changepincode_modal_header": { "other": "Change your PIN" },
-  "changepincode_modal_currentpassword": { "other": "Your current password" },
-  "changepincode_modal_pincode1": { "other": "Your new 4 digit PIN" },
-  "changepincode_modal_pincode2": { "other": "Confirm your new 4 digit PIN" },
-  "changepincode_modal_submit": { "other": "Set PIN" },
-  "changepincode_modal_error_wrong_password": { "other": "That password is incorrect." },
-
-  "user_set_pin_intro": { "other": "You need a PIN to {{.Action}} restricted content"},
-  "user_error_wrong_pin_reset": { "other": "Click here to reset your PIN" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "This content is age restricted." },
-  "shopping_error_close_button": { "other": "OK" },
-
-  "wcag_skip_links_header": { "other": "Accessibility Links" },
-  "wcag_skip_links_content": { "other": "Skip to main content" },
-
-  "wcag_homepage_h1": { "other": "Homepage" },
-  "wcag_carousel_h2": { "other": "Carousel" },
-  "wcag_collections_h2": { "other": "Collections" },
-
-  "wcag_aria_label_footer": { "other": "Footer" },
-  "wcag_aria_label_nav_main": { "other": "Main" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Toggle Navigation" },
-  "wcag_aria_label_bundle_items": { "other": "Bundle Items" },
-  "wcag_aria_label_carousel": { "other": "Carousel" },
-  "wcag_aria_label_page_collection": { "other": "Page Collection" },
-  "wcag_aria_label_collection_list": { "other": "Collection List" },
-  "wcag_aria_label_collection_slider": { "other": "Collection Slider" },
-  "wcag_aria_label_wishlist": { "other": "Wishlist" },
-  "wcag_aria_label_facebook": { "other": "Share on Facebook" },
-  "wcag_aria_label_twitter": { "other": "Share on Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Share on LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "View on Letterboxd" },
-
-  "app_badge_title": { "other": "Download the app to view your purchased content!" },
-  "app_badge_ios": { "other": "Download on the App Store" },
-  "app_badge_android": { "other": "Get it on Google Play" },
-
-  "plans_page_header": { "other": "Available Plans" },
-  "plan_label_owned" : {"other": "You own this plan" },
-  "plan_expiry_date" : { "other": "Sales close: "},
-  "plan_read_more"   : { "other": "Find out more" },
-
-  "plan_page_read_more": { "other": "Read more" },
-  "plan_page_header_text": { "other": "Enjoy {{.Name}}" },
-  "page_plan_explore_intro": { "other": "OR" },
-  "page_plan_explore_link": { "other": "Explore other passes" },
-  "plan_showcase_page_ownership_button_buy": { "other": "Buy now" },
-  "plan_free_link_text": { "other": "Sign up for free" },
-
-  "awards_in_competition": { "other": "In Competition" },
-  "awards_winner": { "other": "Winner" },
-
-  "donate_button_text": { "other": "Donate" }
-
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Change Credit Card"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Update credit card details"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Update"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Expires {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Trial Period"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Cancel my subscription"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Cancel"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Yes, cancel my subscription"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Cancel subscription?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "This will cancel the subscription to the {{.Name}} plan. You will still be able to watch the content in the plan until it expires {{.Expiry}}."
+  },
+  "availability_coming_soon": {
+    "other": "Coming soon"
+  },
+  "availability_renting": {
+    "other": "Renting"
+  },
+  "availability_not_available": {
+    "other": "Not available"
+  },
+  "availability_in_watch_window": {
+    "other": "Available in watch window"
+  },
+  "availability_sold_out": {
+    "other": "Sold Out"
+  },
+  "availability_available_till": {
+    "other": "Available until {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Not available in your country"
+  },
+  "availability_available": {
+    "other": "Available {{.ReleaseDate}}"
+  },
+  "availability_expires": {
+    "other": "Expires {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Expired"
+  },
+  "modal_cancel": {
+    "other": "Cancel"
+  },
+  "play": {
+    "other": "Play"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Sign in"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Create Account"
+  },
+  "combined_auth_terms": {
+    "other": "I agree to all the <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; conditions</a>."
+  },
+  "signup_terms": {
+    "other": "I agree to all the <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; conditions</a>."
+  },
+  "validation_terms_required": {
+    "other": "You must agree to the terms and conditions."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Unfortunately, {{.Title}} has sold out."
+  },
+  "changepincode_modal_header": {
+    "other": "Change your PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Your current password"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Your new 4 digit PIN"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Confirm your new 4 digit PIN"
+  },
+  "changepincode_modal_submit": {
+    "other": "Set PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "That password is incorrect."
+  },
+  "user_set_pin_intro": {
+    "other": "You need a PIN to {{.Action}} restricted content"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Click here to reset your PIN"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "This content is age restricted."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "wcag_skip_links_header": {
+    "other": "Accessibility Links"
+  },
+  "wcag_skip_links_content": {
+    "other": "Skip to main content"
+  },
+  "wcag_homepage_h1": {
+    "other": "Homepage"
+  },
+  "wcag_carousel_h2": {
+    "other": "Carousel"
+  },
+  "wcag_collections_h2": {
+    "other": "Collections"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Footer"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Main"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Toggle Navigation"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Bundle Items"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Carousel"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Page Collection"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Collection List"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Collection Slider"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Wishlist"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Share on Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Share on Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Share on LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "View on Letterboxd"
+  },
+  "app_badge_title": {
+    "other": "Download the app to view your purchased content!"
+  },
+  "app_badge_ios": {
+    "other": "Download on the App Store"
+  },
+  "app_badge_android": {
+    "other": "Get it on Google Play"
+  },
+  "plans_page_header": {
+    "other": "Available Plans"
+  },
+  "plan_label_owned": {
+    "other": "You own this plan"
+  },
+  "plan_expiry_date": {
+    "other": "Sales close: "
+  },
+  "plan_read_more": {
+    "other": "Find out more"
+  },
+  "plan_page_read_more": {
+    "other": "Read more"
+  },
+  "plan_page_header_text": {
+    "other": "Enjoy {{.Name}}"
+  },
+  "page_plan_explore_intro": {
+    "other": "OR"
+  },
+  "page_plan_explore_link": {
+    "other": "Explore other passes"
+  },
+  "plan_showcase_page_ownership_button_buy": {
+    "other": "Buy now"
+  },
+  "plan_free_link_text": {
+    "other": "Sign up for free"
+  },
+  "awards_in_competition": {
+    "other": "In Competition"
+  },
+  "awards_winner": {
+    "other": "Winner"
+  },
+  "donate_button_text": {
+    "other": "Donate"
+  }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Configuración" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.shift72.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "Français" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Configuración"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "Français"
+  },
   "episode_name": {
     "other": "Episodio"
   },
-
   "season_name": {
     "other": "Temporada"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "una temporada",
     "other": "{{.Count}} temporadas"
   },
@@ -38,176 +55,435 @@
     "one": "1 Episodio",
     "other": "{{.Count}} Episodios"
   },
-
-  "date_day": { "other": "Día" },
-  "date_month": { "other": "Mes" },
-  "date_year": { "other": "Año" },
-
-  "404_page_header": { "other": "Esa página no existe..." },
-  "404_page_content": { "other": "<p>En este momento, parece que la página que está buscando no existe.</p><p>Podría haber sida movida o eliminada, o tal vez algo mal escrito. </p><p>Trate volver a la página principal va a encontrar lo que busca. </p><p><a href=\"{{.URL}}\">Volver a la página principal </a></p>" },
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Iniciar sesión" },
-  "nav_signup": { "other": "Crear cuenta" },
-  "nav_signed_in_as": { "other": "Iniciaste sesión como" },
-  "nav_library": { "other": "Mi biblioteca" },
-  "nav_devices": { "other": "Mis dispositivos" },
-  "nav_wishlist": { "other": "Mi Lista" },
-  "nav_account": { "other": "Mi Cuenta" },
-  "nav_signout": { "other": "Cerrar sesión" },
-  "play_trailer": { "other": "Trailer" },
-  "runtime_hours": { "other": "h" },
-  "runtime_minutes": { "other": "m" },
-
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "pasado {{.Date}}" },
-  "datetime_today": { "other": "hoy {{.Date}}" },
-  "datetime_tomorrow": { "other": "mañana {{.Date}}" },
-  "datetime_yesterday": { "other": "ayer {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Buscar" },
-  "search_control_submit": { "other": "Aplicar búsqueda" },
-
-  "play_button_watch": { "other" : "Reproducir"},
-  "play_button_resume": { "other" : "Reproducir"},
-
-  "social_media_buttons_title": { "other": "Compartir" },
-  "social_media_buttons_facebook": { "other": "Compartir en Facebook" },
-  "social_media_buttons_twitter": { "other": "Compartir en Twitter" },
-  "social_media_buttons_linkedin": { "other": "Compartir en Linkedin" },
-  "social_media_buttons_email": { "other": "Compartir via correo electrónico" },
-  "social_media_buttons_email_subject": { "other": "Compartir enlace" },
-  "social_media_buttons_copied_link": { "other": "¡Link copiado al portapapeles!" },
-  "social_media_buttons_copy_link": { "other": "Copiar al portapapeles" },
-
-  "accept_invite_page_header": { "other": "Bienvenido " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Parece que ya ha reclamado esta invitación, usted debe <a href=\"{{.SigninURL}}\">iniciar sesión</a> sin embargo. Si ha olvidado su contraseña, usted puede <a href=\"{{.ForgotPasswordURL}}\">recuperar su contraseña</a>." },
-  "acceptinvite_complete": { "other": "Gracias. Su cuenta ha sido creada." },
-  "acceptinvite_form_submit": { "other": "Aceptar invitación" },
-  "acceptinvite_agreement": { "other": "Haciendo click en \"Aceptar invitación\" usted acepta que ha leido y acepta nuestros <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a> y nuestra <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">política de privacidad</a>." },
-
-  "signup_page_header": { "other": "Crear cuenta" },
-  "signup_form_name": { "other": "Nombre" },
-  "signup_form_email": { "other": "Dirección de email" },
-  "signup_form_password": { "other": "Contraseña" },
-  "signup_form_password_confirmation": { "other": "Confirma tu contraseña" },
-  "signup_form_gender": { "other": "Género" },
-  "signup_form_dob": { "other": "Fecha de nacimiento" },
-  "signup_form_submit": { "other": "Enviar" },
-
-  "signin_page_header": { "other": "Iniciar sesión" },
-  "signin_form_email": { "other": "Dirección de email" },
-  "signin_form_password": { "other": "Contraseña" },
-  "signin_form_remember": { "other": "Recordar mi cuenta" },
-  "signin_form_submit": { "other": "Enviar" },
-  "signin_page_forgotpassword": { "other": "¿Olvidaste tu contraseña?" },
-  "signin_page_createnewaccount": { "other": "¿No tiene una cuenta? Cree una nueva cuenta" },
-  "signup_page_alreadyhaveanaccount": { "other": "¿Ya tienes una cuenta? Inicia sesión aquí" },
-  "signup_form_error_email_already_in_use": { "other": "Esta dirección de email ya esta en use." },
-  "signin_form_error_incorrect_credentials": { "other": "El usuario o contraseña son incorrectos." },
-  "signup_form_error_forbidden": { "other": "Un error ha ocurrido." },
-
-  "combined_auth_continue": { "other": "Continuar" },
-  "combined_auth_change": { "other": "cambiar" },
-  "combined_auth_signin": { "other": "Iniciar sesión" },
-  "combined_auth_signup": { "other": "Crear cuenta" },
-  "combined_auth_signin_password": { "other": "Por favor ingrese su contraseña para iniciar sesión." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Su contraseña es incorrecta." },
-  "combined_auth_error_forbidden": { "other": "Un error ha ocurrido." },
-  "combined_auth_error_too_many_requests": { "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde." },
-
-  "forgotpassword_page_header": { "other": "Recuperar su contraseña" },
-  "forgotpassword_form_email": { "other": "Dirección de email" },
-  "forgotpassword_form_submit": { "other": "Enviar" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Una cuenta con esa dirección de correo  electrónico no existe." },
-  "forgotpassword_form_error_account_suspended": { "other": "Esta cuenta ha sido suspendida." },
-  "forgotpassword_complete": { "other": "Gracias. Una forma de recuperar su contraseña debería aparecer pronto en su buzón de correo." },
-  "forgotpassword_form_error_forbidden": { "other": "Un error ha ocurrido." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde." },
-
-  "resetpassword_page_header": { "other": "Cambiar contraseña" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Si aparece que la opción de recuperar contraseña es inválida. por favor llene de nuevo el formulario de <a href=\"{{.URL}}\">recuperar contrasela</a>." },
-  "resetpassword_form_password": { "other": "Nueva Contraseña" },
-  "resetpassword_form_password2": { "other": "Confirma tu contraseña" },
-  "resetpassword_form_submit": { "other": "Enviar" },
-  "resetpassword_complete": { "other": "Gracias. La contraseña ha sido cambiada y su sesión ha sido iniciada." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "La solicitud de recuperar la contraseña no es válida. Por favor, inténtelo de nuevo más tarde." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "La llave de recuperar la contraseña ha expirado. Por favor, solicitar una nueva." },
-  "resetpassword_form_error_too_many_requests": { "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde." },
-
-  "account_page_header": { "other": "Mi Cuenta" },
-  "account_form_name": { "other": "Nombre" },
-  "account_form_email": { "other": "Dirección de email" },
-  "account_form_password": { "other": "Contraseña" },
-  "account_form_change_password": { "other": "Cambiar" },
-  "account_form_gender": { "other": "Género" },
-  "account_form_dob": { "other": "Fecha de nacimiento" },
-  "account_form_submit": { "other": "Enviar" },
-  "account_form_submitted": { "other": "Actualizado" },
-  "account_form_password_changed": { "other": "Actualizado" },
-  "account_form_error_incorrect_password": { "other": "Esa contraseña es incorrecta." },
-
-  "signup_form_optin": {"other": "Suscribirse a nuestro boletín de forma gratuita"},
-
-  "passwordconfirmation_modal_header": { "other": "Confirme su contraseña" },
-  "passwordconfirmation_modal_label": { "other": "Por favor, introduzca su contraseña con el fin de actualizar los cambios" },
-  "passwordconfirmation_modal_confirm": { "other": "Confirmar" },
-
-  "changepassword_modal_header": { "other": "Cambie su contraseña" },
-  "changepassword_modal_currentpassword": { "other": "Su contraseña actual" },
-  "changepassword_modal_password": { "other": "Su nueva contraseña" },
-  "changepassword_modal_password2": { "other": "Confirme su Contraseña" },
-  "changepassword_modal_submit": { "other": "Enviar" },
-  "changepassword_modal_error_incorrect_password": { "other": "Esa contraseña es incorrecta." },
-
-  "userlibrary_page_header": { "other": "Mi biblioteca" },
-  "userlibrary_empty_header":  { "other": "Su biblioteca esta vacía." },
-  "userlibrary_empty_content": { "other": "Llénala <a href=\"{{.HomeURL}}\">navegando</a> la programación." },
-
-  "searchresults_page_header": { "other": "Resultados de la búsqueda" },
-  "searchresults_load_more": { "other": "Cargar {{.Count}} más" },
+  "date_day": {
+    "other": "Día"
+  },
+  "date_month": {
+    "other": "Mes"
+  },
+  "date_year": {
+    "other": "Año"
+  },
+  "404_page_header": {
+    "other": "Esa página no existe..."
+  },
+  "404_page_content": {
+    "other": "<p>En este momento, parece que la página que está buscando no existe.</p><p>Podría haber sida movida o eliminada, o tal vez algo mal escrito. </p><p>Trate volver a la página principal va a encontrar lo que busca. </p><p><a href=\"{{.URL}}\">Volver a la página principal </a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Iniciar sesión"
+  },
+  "nav_signup": {
+    "other": "Crear cuenta"
+  },
+  "nav_signed_in_as": {
+    "other": "Iniciaste sesión como"
+  },
+  "nav_library": {
+    "other": "Mi biblioteca"
+  },
+  "nav_devices": {
+    "other": "Mis dispositivos"
+  },
+  "nav_wishlist": {
+    "other": "Mi Lista"
+  },
+  "nav_account": {
+    "other": "Mi Cuenta"
+  },
+  "nav_signout": {
+    "other": "Cerrar sesión"
+  },
+  "play_trailer": {
+    "other": "Trailer"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "m"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "pasado {{.Date}}"
+  },
+  "datetime_today": {
+    "other": "hoy {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "mañana {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "ayer {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Buscar"
+  },
+  "search_control_submit": {
+    "other": "Aplicar búsqueda"
+  },
+  "play_button_watch": {
+    "other": "Reproducir"
+  },
+  "play_button_resume": {
+    "other": "Reproducir"
+  },
+  "social_media_buttons_title": {
+    "other": "Compartir"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Compartir en Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Compartir en Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Compartir en Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Compartir via correo electrónico"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Compartir enlace"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "¡Link copiado al portapapeles!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Copiar al portapapeles"
+  },
+  "accept_invite_page_header": {
+    "other": "Bienvenido "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Parece que ya ha reclamado esta invitación, usted debe <a href=\"{{.SigninURL}}\">iniciar sesión</a> sin embargo. Si ha olvidado su contraseña, usted puede <a href=\"{{.ForgotPasswordURL}}\">recuperar su contraseña</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Gracias. Su cuenta ha sido creada."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Aceptar invitación"
+  },
+  "acceptinvite_agreement": {
+    "other": "Haciendo click en \"Aceptar invitación\" usted acepta que ha leido y acepta nuestros <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a> y nuestra <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">política de privacidad</a>."
+  },
+  "signup_page_header": {
+    "other": "Crear cuenta"
+  },
+  "signup_form_name": {
+    "other": "Nombre"
+  },
+  "signup_form_email": {
+    "other": "Dirección de email"
+  },
+  "signup_form_password": {
+    "other": "Contraseña"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Confirma tu contraseña"
+  },
+  "signup_form_gender": {
+    "other": "Género"
+  },
+  "signup_form_dob": {
+    "other": "Fecha de nacimiento"
+  },
+  "signup_form_submit": {
+    "other": "Enviar"
+  },
+  "signin_page_header": {
+    "other": "Iniciar sesión"
+  },
+  "signin_form_email": {
+    "other": "Dirección de email"
+  },
+  "signin_form_password": {
+    "other": "Contraseña"
+  },
+  "signin_form_remember": {
+    "other": "Recordar mi cuenta"
+  },
+  "signin_form_submit": {
+    "other": "Enviar"
+  },
+  "signin_page_forgotpassword": {
+    "other": "¿Olvidaste tu contraseña?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "¿No tiene una cuenta? Cree una nueva cuenta"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "¿Ya tienes una cuenta? Inicia sesión aquí"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Esta dirección de email ya esta en use."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "El usuario o contraseña son incorrectos."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Un error ha ocurrido."
+  },
+  "combined_auth_continue": {
+    "other": "Continuar"
+  },
+  "combined_auth_change": {
+    "other": "cambiar"
+  },
+  "combined_auth_signin": {
+    "other": "Iniciar sesión"
+  },
+  "combined_auth_signup": {
+    "other": "Crear cuenta"
+  },
+  "combined_auth_signin_password": {
+    "other": "Por favor ingrese su contraseña para iniciar sesión."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Su contraseña es incorrecta."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Un error ha ocurrido."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde."
+  },
+  "forgotpassword_page_header": {
+    "other": "Recuperar su contraseña"
+  },
+  "forgotpassword_form_email": {
+    "other": "Dirección de email"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Enviar"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Una cuenta con esa dirección de correo  electrónico no existe."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Esta cuenta ha sido suspendida."
+  },
+  "forgotpassword_complete": {
+    "other": "Gracias. Una forma de recuperar su contraseña debería aparecer pronto en su buzón de correo."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Un error ha ocurrido."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde."
+  },
+  "resetpassword_page_header": {
+    "other": "Cambiar contraseña"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Si aparece que la opción de recuperar contraseña es inválida. por favor llene de nuevo el formulario de <a href=\"{{.URL}}\">recuperar contrasela</a>."
+  },
+  "resetpassword_form_password": {
+    "other": "Nueva Contraseña"
+  },
+  "resetpassword_form_password2": {
+    "other": "Confirma tu contraseña"
+  },
+  "resetpassword_form_submit": {
+    "other": "Enviar"
+  },
+  "resetpassword_complete": {
+    "other": "Gracias. La contraseña ha sido cambiada y su sesión ha sido iniciada."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "La solicitud de recuperar la contraseña no es válida. Por favor, inténtelo de nuevo más tarde."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "La llave de recuperar la contraseña ha expirado. Por favor, solicitar una nueva."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde."
+  },
+  "account_page_header": {
+    "other": "Mi Cuenta"
+  },
+  "account_form_name": {
+    "other": "Nombre"
+  },
+  "account_form_email": {
+    "other": "Dirección de email"
+  },
+  "account_form_password": {
+    "other": "Contraseña"
+  },
+  "account_form_change_password": {
+    "other": "Cambiar"
+  },
+  "account_form_gender": {
+    "other": "Género"
+  },
+  "account_form_dob": {
+    "other": "Fecha de nacimiento"
+  },
+  "account_form_submit": {
+    "other": "Enviar"
+  },
+  "account_form_submitted": {
+    "other": "Actualizado"
+  },
+  "account_form_password_changed": {
+    "other": "Actualizado"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Esa contraseña es incorrecta."
+  },
+  "signup_form_optin": {
+    "other": "Suscribirse a nuestro boletín de forma gratuita"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Confirme su contraseña"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Por favor, introduzca su contraseña con el fin de actualizar los cambios"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Confirmar"
+  },
+  "changepassword_modal_header": {
+    "other": "Cambie su contraseña"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Su contraseña actual"
+  },
+  "changepassword_modal_password": {
+    "other": "Su nueva contraseña"
+  },
+  "changepassword_modal_password2": {
+    "other": "Confirme su Contraseña"
+  },
+  "changepassword_modal_submit": {
+    "other": "Enviar"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Esa contraseña es incorrecta."
+  },
+  "userlibrary_page_header": {
+    "other": "Mi biblioteca"
+  },
+  "userlibrary_empty_header": {
+    "other": "Su biblioteca esta vacía."
+  },
+  "userlibrary_empty_content": {
+    "other": "Llénala <a href=\"{{.HomeURL}}\">navegando</a> la programación."
+  },
+  "searchresults_page_header": {
+    "other": "Resultados de la búsqueda"
+  },
+  "searchresults_load_more": {
+    "other": "Cargar {{.Count}} más"
+  },
   "searchresults_total": {
     "one": "Encontrado 1 resultado para \"{{.Query}}\".",
     "other": "Encontrado {{.Count}} resultados para \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "No hubo resultados de búsqueda para \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Intentar otra busqueda o <a href=\"{{.HomeURL}}\"> Navegar nuestro contenido </a> para encontrar lo que está buscando." },
-
-  "validation_name_required": { "other": "Por favor, escriba su nombre." },
-  "validation_email_required": { "other": "Por favor, introduzca su dirección de correo electrónico." },
-  "validation_email_email": { "other": "Por favor, introduzca una dirección de correo electrónico válida." },
-  "validation_currentpassword_required": { "other": "Por favor, introduzca su contraseña actual." },
-  "validation_password_required": { "other": "Por favor ingrese una contraseña." },
-  "validation_password2_required": { "other": "Por favor confirma su contraseña." },
-  "validation_password2_match": { "other": "Sus contraseñas no coinciden." },
-  "validation_password_minlength": { "other": "Por favor, introduzca al menos {{.Count}} caracteres." },
-  "validation_promocode_required": { "other": "Por favor, introduzca un código promocional." },
-  "validation_pincode_required": { "other": "Por favor, introduzca un código PIN." },
-  "validation_gender_required": { "other": "Por favor, seleccione el género más cercano con el que se identifique." },
-  "validation_dob_required": { "other": "Por favor, introduzca su fecha de nacimiento." },
-  "validation_dob_date": { "other": "Por favor ingresa una fecha de nacimiento valida." },
-
-  "shopping_info_subtitle_hd": { "other": "HD Video bajo demanda." },
-  "shopping_info_subtitle_sd": { "other": "SD vídeo bajo demanda." },
-  "shopping_info_subtitle_wallet": { "other": "Los fondos de su cartera pueden ser utilizados para la compra o alquiler de cualquier contenido en ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "Vea aquí los requisitos del sistema." },
-  "shopping_info_ownership_buy": { "other": "Compra" },
-  "shopping_info_ownership_rent": { "other": "Alquiler" },
-
-  "shopping_info_sd_only": { "other": "Limitado a la reproducción SD solamente." },
-  "shopping_info_release_date_title": { "other": "Disponible el {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Se puede alquilar ahora, pero usted no podrá de ver el título hasta entonces." },
-  "shopping_info_release_date_explanation_buy": { "other": "Usted puede comprar ahora, pero usted no podrá de ver el título hasta entonces." },
-
-  "shopping_info_available_until_date_title": { "other": "Hasta disponible {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Usted no podrá ver el contenido después de esto." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Usted no podrá ver el contenido después de esto." },
-
-  "duration_hour": { "one": "1 hora", "other": "{{.Count}} horas" },
-  "duration_day": { "one": "1 día", "other": "{{.Count}} dias" },
-  "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} de alquiler " },
-  "shopping_info_watch_window_duration": { "other": "{{.Count}} hora(s) de ventana de visualización. " },
+  "searchresults_empty_header": {
+    "other": "No hubo resultados de búsqueda para \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Intentar otra busqueda o <a href=\"{{.HomeURL}}\"> Navegar nuestro contenido </a> para encontrar lo que está buscando."
+  },
+  "validation_name_required": {
+    "other": "Por favor, escriba su nombre."
+  },
+  "validation_email_required": {
+    "other": "Por favor, introduzca su dirección de correo electrónico."
+  },
+  "validation_email_email": {
+    "other": "Por favor, introduzca una dirección de correo electrónico válida."
+  },
+  "validation_currentpassword_required": {
+    "other": "Por favor, introduzca su contraseña actual."
+  },
+  "validation_password_required": {
+    "other": "Por favor ingrese una contraseña."
+  },
+  "validation_password2_required": {
+    "other": "Por favor confirma su contraseña."
+  },
+  "validation_password2_match": {
+    "other": "Sus contraseñas no coinciden."
+  },
+  "validation_password_minlength": {
+    "other": "Por favor, introduzca al menos {{.Count}} caracteres."
+  },
+  "validation_promocode_required": {
+    "other": "Por favor, introduzca un código promocional."
+  },
+  "validation_pincode_required": {
+    "other": "Por favor, introduzca un código PIN."
+  },
+  "validation_gender_required": {
+    "other": "Por favor, seleccione el género más cercano con el que se identifique."
+  },
+  "validation_dob_required": {
+    "other": "Por favor, introduzca su fecha de nacimiento."
+  },
+  "validation_dob_date": {
+    "other": "Por favor ingresa una fecha de nacimiento valida."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Video bajo demanda."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD vídeo bajo demanda."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Los fondos de su cartera pueden ser utilizados para la compra o alquiler de cualquier contenido en ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Vea aquí los requisitos del sistema."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "Compra"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "Alquiler"
+  },
+  "shopping_info_sd_only": {
+    "other": "Limitado a la reproducción SD solamente."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Disponible el {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Se puede alquilar ahora, pero usted no podrá de ver el título hasta entonces."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Usted puede comprar ahora, pero usted no podrá de ver el título hasta entonces."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Hasta disponible {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Usted no podrá ver el contenido después de esto."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Usted no podrá ver el contenido después de esto."
+  },
+  "duration_hour": {
+    "one": "1 hora",
+    "other": "{{.Count}} horas"
+  },
+  "duration_day": {
+    "one": "1 día",
+    "other": "{{.Count}} dias"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} de alquiler "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} hora(s) de ventana de visualización. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Una vez rentada, la película estará disponible en su cuenta por {{.ValueUnit}}. ",
     "other": "Una vez rentada, la película estará disponible en su cuenta {{.ValueUnit}}. "
@@ -232,69 +508,154 @@
     "one": "Una vez que presiona play en un episodio, la ventana de visualización comienza y tiene una hora para ver ese episodio tantas veces como desee.",
     "other": "Una vez que presiona play en un episodio, la ventana de visualización comienza y tiene {{.Count}} horas para ver ese episodio tantas veces como desee."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% de bonificación" },
-
-  "shopping_enter_card_prompt": { "other": "Introduzca sus datos de la tarjeta de crédito a continuación para completar su {{.Verb}}." },
-
-  "shopping_terms": { "other": "Al completar esta transacción, acepto los <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">términos y condiciones</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} de descuento aplicado." },
-  "shopping_discount_apply": { "other": "Aplicar" },
-  "shopping_discount_code": { "other": "Introduzca un código promocional." },
-  "shopping_discount_have_code": { "other": "Tengo un código promocional." },
-
-  "shopping_price_you_pay": { "other": "Usted paga" },
-  "shopping_price_nothing": { "other": "Nada" },
-  "shopping_price_free": { "other": "Gratis" },
-
-  "shopping_auth_directions": { "other": "Se necesita una cuenta en primer lugar. Por favor, introduzca su dirección de correo electrónico." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} ya está en su biblioteca." },
-
-  "shopping_error_missing_card": { "other": "Por favor, introduzca los datos de su tarjeta de crédito." },
-  "shopping_error_title": { "other": "Ocurrió un error" },
-  "shopping_error_incorrect_cvc": { "other": "Por favor, introduzca una CVV válida." },
-  "shopping_error_invalid_cvc": { "other": "Por favor, introduzca una CVV válida." },
-  "shopping_error_incorrect_number": { "other": "Por favor, introduzca un número de  tarjeta de crédito válido." },
-  "shopping_error_invalid_number": { "other": "Por favor, introduzca un número de  tarjeta de crédito válido." },
-  "shopping_error_card_declined": { "other": "La tarjeta de crédito ha sido rechazada." },
-  "shopping_error_invalid_expiry_month": { "other": "Por favor, introduzca una caducidad válida." },
-  "shopping_error_invalid_expiry_year": { "other": "Por favor, introduzca una caducidad válida." },
-  "shopping_error_expired_card": { "other": "La tarjeta de crédito ha expirado." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Su {{.Ownership}} no se ha completado. Es necesario estar en el país en que se emitió su tarjeta de crédito. Utiliza otra tarjeta para realizar el pago." },
-  "shopping_error_proxy_detected": { "other": "Su {{.Ownership}} no se ha completado. Hemos detectado que está utilizando un servicio desatascador o proxy. Por favor, apague cualquiera de estos servicios y vuelve a intentarlo." },
-
-  "shopping_error_discount_worn_out": { "other": "Ese código promocional ya no puede ser utilizado." },
-  "shopping_error_discount_blank": { "other": "Por favor, introduzca un código promocional." },
-  "shopping_error_discount_not_applied": { "other": "Por favor, introduzca un código promocional válido." },
-  "shopping_error_discount_invalid": { "other": "Por favor, introduzca un código promocional válido." },
-  "shopping_error_discount_disabled": { "other": "Por favor, introduzca un código promocional válido." },
-  "shopping_error_discount_already_applied": { "other": "Un código promocional ya se ha utilizado para esta sesión.." },
-  "shopping_error_discount_already_redeemed": { "other": "Ese código promocional ya se ha utilizado." },
-  "shopping_error_discount_used_previously": { "other": "Ese código promocional ya se ha utilizado." },
-  "shopping_error_discount_max_limit": { "other": "Ese código promocional ya no puede ser utilizado." },
-  "shopping_error_discount_expired": { "other": "Ese código promocional ha caducado." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Ese código promocional no se puede utilizar en la compra." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Ese código promocional no se puede utilizar en la renta." },
-  "shopping_error_discount_invalid_item": { "other": "Ese código promocional no se puede utilizar con este item." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Ese código promocional no se puede utilizar en su país." },
-  "shopping_error_discounts_not_allowed": { "other": "Ese código promocional no se puede utilizar." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Ese código promocional no se puede utilizar en los paquetes." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "La tarjeta de crédito ha sido rechazada. Inténtelo de nuevo." },
-
-  "shopping_complete_rental": { "other": "¡Éxito!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% de bonificación"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Introduzca sus datos de la tarjeta de crédito a continuación para completar su {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Al completar esta transacción, acepto los <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">términos y condiciones</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} de descuento aplicado."
+  },
+  "shopping_discount_apply": {
+    "other": "Aplicar"
+  },
+  "shopping_discount_code": {
+    "other": "Introduzca un código promocional."
+  },
+  "shopping_discount_have_code": {
+    "other": "Tengo un código promocional."
+  },
+  "shopping_price_you_pay": {
+    "other": "Usted paga"
+  },
+  "shopping_price_nothing": {
+    "other": "Nada"
+  },
+  "shopping_price_free": {
+    "other": "Gratis"
+  },
+  "shopping_auth_directions": {
+    "other": "Se necesita una cuenta en primer lugar. Por favor, introduzca su dirección de correo electrónico."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} ya está en su biblioteca."
+  },
+  "shopping_error_missing_card": {
+    "other": "Por favor, introduzca los datos de su tarjeta de crédito."
+  },
+  "shopping_error_title": {
+    "other": "Ocurrió un error"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Por favor, introduzca una CVV válida."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Por favor, introduzca una CVV válida."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Por favor, introduzca un número de  tarjeta de crédito válido."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Por favor, introduzca un número de  tarjeta de crédito válido."
+  },
+  "shopping_error_card_declined": {
+    "other": "La tarjeta de crédito ha sido rechazada."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Por favor, introduzca una caducidad válida."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Por favor, introduzca una caducidad válida."
+  },
+  "shopping_error_expired_card": {
+    "other": "La tarjeta de crédito ha expirado."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Su {{.Ownership}} no se ha completado. Es necesario estar en el país en que se emitió su tarjeta de crédito. Utiliza otra tarjeta para realizar el pago."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Su {{.Ownership}} no se ha completado. Hemos detectado que está utilizando un servicio desatascador o proxy. Por favor, apague cualquiera de estos servicios y vuelve a intentarlo."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Ese código promocional ya no puede ser utilizado."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Por favor, introduzca un código promocional."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Por favor, introduzca un código promocional válido."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Por favor, introduzca un código promocional válido."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Por favor, introduzca un código promocional válido."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Un código promocional ya se ha utilizado para esta sesión.."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Ese código promocional ya se ha utilizado."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Ese código promocional ya se ha utilizado."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Ese código promocional ya no puede ser utilizado."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Ese código promocional ha caducado."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Ese código promocional no se puede utilizar en la compra."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Ese código promocional no se puede utilizar en la renta."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Ese código promocional no se puede utilizar con este item."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Ese código promocional no se puede utilizar en su país."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Ese código promocional no se puede utilizar."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Ese código promocional no se puede utilizar en los paquetes."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "La tarjeta de crédito ha sido rechazada. Inténtelo de nuevo."
+  },
+  "shopping_complete_rental": {
+    "other": "¡Éxito!"
+  },
   "shopping_complete_rental_period": {
     "one": "Ahora puedes verlo tantas veces como quieras durante el día siguiente.",
     "other": "Ahora puede ver tantas veces como desee durante los próximos {{.Count}} días."
   },
-  "shopping_complete_purchase": { "other": "Gracias por la compra {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Gracias por comprar {{.Title}}, {{.CreditTotal}} ha sido añadido a su cuenta." },
-  "shopping_complete_purchase_coming_soon": { "other": "Estará disponible para verse en {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Un recibo se ha enviado por correo electrónico." },
-  "shopping_complete_library_link": { "other": "Ir a vuestra biblioteca." },
+  "shopping_complete_purchase": {
+    "other": "Gracias por la compra {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Gracias por comprar {{.Title}}, {{.CreditTotal}} ha sido añadido a su cuenta."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Estará disponible para verse en {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Un recibo se ha enviado por correo electrónico."
+  },
+  "shopping_complete_library_link": {
+    "other": "Ir a vuestra biblioteca."
+  },
   "shopping_complete_plan": {
     "other": "Su compra de {{ .Title }} fue exitosa."
   },
-  
   "shopping_complete_rental_watch_window_start": {
     "one": "Ahora puede ver dentro del próximo día.",
     "other": "Ahora puede ver dentro de los próximos {{.Count}} días."
@@ -311,103 +672,235 @@
     "one": "Podrá ver desde {{.Date}} y su alquiler se mantendrá activo durante un día.",
     "other": "Podrá ver desde {{.Date}} y su alquiler se mantendrá activo durante {{.Count}} días."
   },
-
-  "shopping_action_rent": { "other": "Alquilar" },
-  "shopping_action_buy": { "other": "Comprar" },
-
-  "shopping_payment_method_header": { "other": "Métodos de pago" },
-  "shopping_payment_method_credit_card": { "other": "Tarjeta de crédito" },
-  "shopping_payment_method_giropay": { "other": "Giropay (Alemania) " },
-  
-  "shopping_error_stripe_unknown_error": { "other": "Hubo un error con este pago. Por favor, intente más tarde." },
-  "shopping_error_payment_complete_failed": { "other": "Este pago fue rechazado. Cierre esta ventana e inténtelo de nuevo." },
-
-  "meta_detail_cast_title": { "other": "Emitir" },
-  "meta_detail_crew_title": { "other": "Equipo" },
-  "meta_detail_languages": { "one": "Idioma", "other": "Idiomas" },
-  "meta_detail_studios": { "one": "Estudio", "other": "Estudios" },
-  "meta_detail_countries": { "one": "País", "other": "Países" },
-  "meta_detail_subtitles": { "other": "Subtítulos" },
-  "meta_detail_captions": { "other": "Subtítulos [CC]" },
-  "meta_detail_episodes_title": { "other": "Episodios" },
-  "meta_detail_bonus_title": { "other": "Contenido extra" },
-  "meta_detail_recommendations_title": { "other": "También le puede interesar" },
-  "meta_detail_bundle_items_title": { "other": "Los contenidos incluidos en este paquete" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} películas" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} temporadas" },
-  "bundle_items_mixed": { "other": "{{.Count}} películas y temporadas" },
-  "userwishlist_page_header": { "other": "Mi Lista" },
-  "userwishlist_slider_header": { "other": "Mi Lista" },
-  "userwishlist_empty_header":  { "other": "Su lista está vacía." },
-  "userwishlist_empty_content": { "other": "Llénala <a href=\"{{.HomeURL}}\">navegando</a> la programación." },
-  "userwishlist_button_add": { "other": "Agregar a mi lista" },
-  "userwishlist_button_remove": { "other": "Mi Lista" },
-  "userwishlist_button_add_compact": { "other": "Mi Lista" },
-  "userwishlist_button_remove_compact": { "other": "Mi Lista" },
-
-  "activatedevice_page_header": { "other": "Activar dispositivo" },
-  "activatedevice_page_content": { "other": "Siga las instrucciones de su dispositivo para obtener un código PIN. El ordenador y el dispositivo tanto deben estar conectados a Internet para que pueda activarse." },
-  "activatedevice_form_pin": { "other": "Código PIN" },
-  "activatedevice_form_submit": { "other": "Activar" },
-  "activatedevice_form_error_invalid_code": { "other": "Código PIN no encontrado, por favor intente de nuevo." },
-  "activatedevice_form_error_pin_not_found": { "other": "Código PIN no encontrado, por favor intente de nuevo." },
-  "activatedevice_signin_prompt": { "other": "Por favor inicie sesión antes de activar el dispositivo." },
-  "activatedevice_page_activated": { "other": "Gracias por la activación {{.DeviceName}}. Ahora podrá navegar en su biblioteca en su televisor o dispositivo." },
-
-  "userdevices_page_header": { "other": "Dispositivos" },
+  "shopping_action_rent": {
+    "other": "Alquilar"
+  },
+  "shopping_action_buy": {
+    "other": "Comprar"
+  },
+  "shopping_payment_method_header": {
+    "other": "Métodos de pago"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Tarjeta de crédito"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay (Alemania) "
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Hubo un error con este pago. Por favor, intente más tarde."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Este pago fue rechazado. Cierre esta ventana e inténtelo de nuevo."
+  },
+  "meta_detail_cast_title": {
+    "other": "Emitir"
+  },
+  "meta_detail_crew_title": {
+    "other": "Equipo"
+  },
+  "meta_detail_languages": {
+    "one": "Idioma",
+    "other": "Idiomas"
+  },
+  "meta_detail_studios": {
+    "one": "Estudio",
+    "other": "Estudios"
+  },
+  "meta_detail_countries": {
+    "one": "País",
+    "other": "Países"
+  },
+  "meta_detail_subtitles": {
+    "other": "Subtítulos"
+  },
+  "meta_detail_captions": {
+    "other": "Subtítulos [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Episodios"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Contenido extra"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "También le puede interesar"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Los contenidos incluidos en este paquete"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} películas"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} temporadas"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} películas y temporadas"
+  },
+  "userwishlist_page_header": {
+    "other": "Mi Lista"
+  },
+  "userwishlist_slider_header": {
+    "other": "Mi Lista"
+  },
+  "userwishlist_empty_header": {
+    "other": "Su lista está vacía."
+  },
+  "userwishlist_empty_content": {
+    "other": "Llénala <a href=\"{{.HomeURL}}\">navegando</a> la programación."
+  },
+  "userwishlist_button_add": {
+    "other": "Agregar a mi lista"
+  },
+  "userwishlist_button_remove": {
+    "other": "Mi Lista"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Mi Lista"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Mi Lista"
+  },
+  "activatedevice_page_header": {
+    "other": "Activar dispositivo"
+  },
+  "activatedevice_page_content": {
+    "other": "Siga las instrucciones de su dispositivo para obtener un código PIN. El ordenador y el dispositivo tanto deben estar conectados a Internet para que pueda activarse."
+  },
+  "activatedevice_form_pin": {
+    "other": "Código PIN"
+  },
+  "activatedevice_form_submit": {
+    "other": "Activar"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "Código PIN no encontrado, por favor intente de nuevo."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "Código PIN no encontrado, por favor intente de nuevo."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Por favor inicie sesión antes de activar el dispositivo."
+  },
+  "activatedevice_page_activated": {
+    "other": "Gracias por la activación {{.DeviceName}}. Ahora podrá navegar en su biblioteca en su televisor o dispositivo."
+  },
+  "userdevices_page_header": {
+    "other": "Dispositivos"
+  },
   "userdevices_page_content": {
     "one": "Los dispositivos se agregarán automáticamente aquí cuando los use. Está limitado a un dispositivo.",
     "other": "Los dispositivos se agregarán automáticamente aquí cuando los uses. Estás limitado a {{.Count}} dispositivos."
   },
-  "userdevices_empty_content": { "other": "Actualmente tienes 0 dispositivos registrados." },
-  "userdevices_header_type": { "other": "Tipo de dispositivo" },
-  "userdevices_header_description": { "other": "Descripción" },
-  "userdevices_device_added": { "other": "Añadido el {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Eliminar" },
-  "userdevices_device_actions_cancel": { "other": "Cancelar" },
-  "userdevices_device_actions_confirm": { "other": "Sí, eliminat el dispositivo" },
-  "userdevices_device_deleted": { "other": "(Removido)" },
-
-  "playlist_page_header": { "other": "Lista de reproducción" },
-  "playlist_sign_in_warning": { "other": "Por favor inicie sesión para ver la televisión en directo."},
-  "playlist_share_title": { "other": "Lista de reproducción" },
-  "playlist_up_next_title": { "other": "Siguiente" },
-
-  "pricing_ownership_buy": { "other": "Comprar" },
-  "pricing_ownership_rent": { "other": "Alquilar" },
-
-  "classification_intro": { "other": "Clasificación: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "“Este sitio usa cookies para mejorar tu experiencia. Haciendo uso del sitio, usted acepta nuestra <a href=\"{{.CookiePolicyURL}}\">política de uso de cookies</a>." },
-  "cookie_banner_accept": { "other": "Acepto" },
-
-  "all_rights_reserved": { "other": "Todos los derechos reservados. Ninguna parte de este sitio puede ser reproducido sin nuestro permiso por escrito." },
-
-  "availability_not_available_in_country": { "other": "No disponible" },
-  "availability_coming_soon": {"other": "Próximamente"},
-  "availability_sold_out": { "other": "Agotada" },
-  "availability_available": {"other": "Disponible {{.ReleaseDate}}"},
-  "availability_available_till": {"other": "Disponible hasta {{.ExpiryDate}}"},
-  "availability_expires": { "other": "Caducó {{.Expiry}}" },
-  "availability_expired": { "other": "Caducada"},
-
-  "signup_terms": { "other": "Acepto todos <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a>." },
-
-  "combined_auth_terms": { "other": "Acepto todos <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a>." },
-  "validation_terms_required": { "other": "Es necesario aceptar los términos y condiciones para continuar." },
-
-  "shopping_card_change": { "other": "¿La tarjeta de crédito no es correcta? <a href=\"{{.SubscriptionsURL}}\">Haga clic aquí para actualizar su tarjeta.</a>" },
-  "shopping_info_rental_period_coming_soon": { "other": "a partir de la fecha y la hora de la publicación." },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Parece que estás teniendo problemas.</p><p>Restablezca su PIN o contáctenos para <a href=\"{{.HelpURL}}\" target=\"_blank\">ayuda</a>" },
-
-  "app_badge_title": { "other": "¡Descarga la aplicación para ver el contenido comprado!" },
-  "app_badge_ios": { "other": "Descargar en la App Store" },
-  "app_badge_android": { "other": "Consiguelo en google play" },
-
+  "userdevices_empty_content": {
+    "other": "Actualmente tienes 0 dispositivos registrados."
+  },
+  "userdevices_header_type": {
+    "other": "Tipo de dispositivo"
+  },
+  "userdevices_header_description": {
+    "other": "Descripción"
+  },
+  "userdevices_device_added": {
+    "other": "Añadido el {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Eliminar"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Cancelar"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Sí, eliminat el dispositivo"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Removido)"
+  },
+  "playlist_page_header": {
+    "other": "Lista de reproducción"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Por favor inicie sesión para ver la televisión en directo."
+  },
+  "playlist_share_title": {
+    "other": "Lista de reproducción"
+  },
+  "playlist_up_next_title": {
+    "other": "Siguiente"
+  },
+  "pricing_ownership_buy": {
+    "other": "Comprar"
+  },
+  "pricing_ownership_rent": {
+    "other": "Alquilar"
+  },
+  "classification_intro": {
+    "other": "Clasificación: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "“Este sitio usa cookies para mejorar tu experiencia. Haciendo uso del sitio, usted acepta nuestra <a href=\"{{.CookiePolicyURL}}\">política de uso de cookies</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Acepto"
+  },
+  "all_rights_reserved": {
+    "other": "Todos los derechos reservados. Ninguna parte de este sitio puede ser reproducido sin nuestro permiso por escrito."
+  },
+  "availability_not_available_in_country": {
+    "other": "No disponible"
+  },
+  "availability_coming_soon": {
+    "other": "Próximamente"
+  },
+  "availability_sold_out": {
+    "other": "Agotada"
+  },
+  "availability_available": {
+    "other": "Disponible {{.ReleaseDate}}"
+  },
+  "availability_available_till": {
+    "other": "Disponible hasta {{.ExpiryDate}}"
+  },
+  "availability_expires": {
+    "other": "Caducó {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Caducada"
+  },
+  "signup_terms": {
+    "other": "Acepto todos <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a>."
+  },
+  "combined_auth_terms": {
+    "other": "Acepto todos <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a>."
+  },
+  "validation_terms_required": {
+    "other": "Es necesario aceptar los términos y condiciones para continuar."
+  },
+  "shopping_card_change": {
+    "other": "¿La tarjeta de crédito no es correcta? <a href=\"{{.SubscriptionsURL}}\">Haga clic aquí para actualizar su tarjeta.</a>"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "a partir de la fecha y la hora de la publicación."
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Parece que estás teniendo problemas.</p><p>Restablezca su PIN o contáctenos para <a href=\"{{.HelpURL}}\" target=\"_blank\">ayuda</a>"
+  },
+  "app_badge_title": {
+    "other": "¡Descarga la aplicación para ver el contenido comprado!"
+  },
+  "app_badge_ios": {
+    "other": "Descargar en la App Store"
+  },
+  "app_badge_android": {
+    "other": "Consiguelo en google play"
+  },
   "shopping_price_title_plan": {
     "other": "Precio"
   },
@@ -479,116 +972,277 @@
   "donate_button_text": {
     "other": "Donar"
   },
-
-  "wcag_skip_links_header": { "other": "Enlaces de accesibilidad" },
-  "wcag_skip_links_content": { "other": "Saltar al contenido" },
-
-  "wcag_homepage_h1": { "other": "Página principal" },
-  "wcag_carousel_h2": { "other": "Carrusel" },
-  "wcag_collections_h2": { "other": "Colecciones" },
-
-  "wcag_aria_label_footer": { "other": "Pie de página" },
-  "wcag_aria_label_nav_main": { "other": "Principal" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Navegación de palanca"},
-  "wcag_aria_label_bundle_items": { "other": "Paquete de artículos" },
-  "wcag_aria_label_carousel": { "other": "Carrusel" },
-  "wcag_aria_label_page_collection": { "other": "Colección de páginas" },
-  "wcag_aria_label_collection_list": { "other": "Lista de colecciones" },
-  "wcag_aria_label_collection_slider": { "other": "Control deslizante de colección" },
-  "wcag_aria_label_wishlist": { "other": "Lista de deseos" },
-  "wcag_aria_label_facebook": { "other": "Compartir en Facebook" },
-  "wcag_aria_label_twitter": { "other": "Compartir en Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Compartir en LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Ver en Letterboxd" },
-  
-  "shopping_error_plan_already_owned": { "other": "Ya tienes este plan." },
-  "shopping_error_plan_expired": { "other": "Este plan ya no está disponible." },
-  "header_banner": { "other": "banner de encabezado" },
-
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "No tiene un PIN establecido, que se requiere para comprar, alquilar y mirar algunos títulos."},
-  "account_form_set_pin": { "other": "Establecer PIN" },
-  "account_form_pin_changed": { "other": "Actualizada" },
-  "account_form_change_pin": { "other": "Cambiar PIN" },
-
-  "user_set_pin_header": { "other": "Establezca su PIN" },
-  "user_set_pin_button": { "other": "Establecer PIN" },
-  "user_submit_pin_heading": { "other": "Introduzca su PIN para {{.Action}} este contenido restringido" },
-  "user_error_wrong_pin_retry": { "other": "Ups, ingresaste un PIN incorrecto" },
-  "user_submit_pin_button": { "other": "Meterse en" },
-  "user_reset_pin_button": { "other": "Restablecer PIN" },
-
-  "validation_pincode1_required": { "other": "Introduzca un código PIN válido." },
-  "validation_pincode2_required": { "other": "Introduzca un código PIN válido." },
-  "validation_pincode1_pattern": { "other": "Introduzca un código PIN válido." },
-  "validation_pincode2_pattern": { "other": "Introduzca un código PIN válido." },
-  "validation_pincode2_match": { "other": "El código PIN no coincide." },
-
-  "userdevices_delete_limits": { "other": "Puedes borrar {{.Limit}} dispositivo(s) de esta lista cada uno {{.Period}} días."},
-  "userdevices_delete_limit_reached": { "other": "Ha alcanzado este límite y no puede eliminar ningún dispositivo en este momento. Puede eliminar un dispositivo en {{.Days}} días." },
-  "shopping_card_new_subscription": { "other": "Esta tarjeta será guardada y cargada regularmente." },
-
-"changepincode_modal_header": { "other": "Cambia tu PIN" },
-"changepincode_modal_currentpassword": { "other": "tu contraseña actual" },
-"changepincode_modal_pincode1": { "other": "Su nuevo PIN de 4 dígitos" },
-"changepincode_modal_pincode2": { "other": "Confirma tu nuevo PIN de 4 dígitos" },
-"changepincode_modal_submit": { "other": "Establecer PIN" },
-"changepincode_modal_error_wrong_password": { "other": "Esa contraseña es incorrecta." },
-
-"user_set_pin_intro": { "other": "Necesitas un PIN para {{.Action}} contenido restringido"},
-"user_error_wrong_pin_reset": { "other": "Haga clic aquí para restablecer su PIN" },
-"user_error_too_many_pin_errors_help_page_link": { "other": "" },
-"shopping_error_age_restricted": { "other": "Este contenido tiene restricción de edad." },
-"shopping_error_close_button": { "other": "Bueno" }, 
-
-"usersubscriptions_subscription_expiry": { "other": "Caduca {{.Expiry}}" },
-"usersubscriptions_subscription_status_trialing": { "other": "Periodo de prueba" },
-"usersubscriptions_subscription_unsubscribe": { "other": "Cancelar mi suscripción" },
-"usersubscriptions_unsubscribe_modal_cancel": { "other": "Cancelar" },
-"usersubscriptions_unsubscribe_modal_confirm": { "other": "Sí, cancelar mi suscripción"},
-"usersubscriptions_unsubscribe_modal_title": { "other": "¿Cancelar suscripción?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "Esto cancelará la suscripción a la {{.Name}} plan. Aún podrá ver el contenido del plan hasta que caduque {{.Expiry}}." },
-
-"signin_form_error_ip_throttled": { "other": "Ha fallado al iniciar sesión demasiadas veces. Por favor, inténtelo de nuevo más tarde." },
-"signin_form_error_account_suspended": { "other": "Su cuenta ha sido suspendida temporalmente. Póngase en contacto con un administrador si cree que se trata de un error." },
-
-
-"users_gender_none": { "other": "No especificado" },
-"users_gender_female": { "other": "Mujer" },
-"users_gender_male": { "other": "Masculino" },
-"users_gender_diverse": { "other": "Diversa" },
-"users_gender_other": { "other": "Otra" },
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HD solamente" },
-  "pricing_quality_sd_only": { "other": "SD solamente" },
-
-  "shopping_card_save_card": { "other": "Guarda esta tarjeta para uso futuro" },
-  "shopping_card_button_change": { "other": "Mostrar todas las tarjetas guardadas" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} terminando en {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(caduca {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(caducada)" },
-  "shopping_card_use_other": { "other": "Usar una nueva tarjeta" },
-  "shopping_card_use_new_card": { "other": "Cambiar tarjeta" },
-  "shopping_card_update_reason_none": { "other": "Actualice su tarjeta de crédito. Las tarjetas aceptadas son Visa, Mastercard y American Express." },
-  "shopping_info_ownership_plan": { "other": "Suscripción" },
-  "shopping_action_credit": { "other": "añadir crédito" },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Cambiar tarjeta de credito" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Actualizar los datos de la tarjeta de crédito" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Actualizar" },
-
-  "availability_renting": { "other": "Alquiler" },
-  "availability_not_available": { "other": "No disponible" },
-  "availability_in_watch_window": { "other": "Disponible en ventana" },
-
-  "modal_cancel": { "other": "Cancelar" },
-  "play": { "other": "Reproducir" },
-
-  "combined_auth_signin_prompt": { "other": "Iniciar sesión" },
-  "combined_auth_signup_prompt": { "other": "Crear cuenta" },
-
-  "shopping_error_item_limit_exceeded": { "other": "Desafortunadamente, {{.Title}} se ha vendido." }
+  "wcag_skip_links_header": {
+    "other": "Enlaces de accesibilidad"
+  },
+  "wcag_skip_links_content": {
+    "other": "Saltar al contenido"
+  },
+  "wcag_homepage_h1": {
+    "other": "Página principal"
+  },
+  "wcag_carousel_h2": {
+    "other": "Carrusel"
+  },
+  "wcag_collections_h2": {
+    "other": "Colecciones"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Pie de página"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Principal"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Navegación de palanca"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Paquete de artículos"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Carrusel"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Colección de páginas"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Lista de colecciones"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Control deslizante de colección"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Lista de deseos"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Compartir en Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Compartir en Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Compartir en LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Ver en Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Ya tienes este plan."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Este plan ya no está disponible."
+  },
+  "header_banner": {
+    "other": "banner de encabezado"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "No tiene un PIN establecido, que se requiere para comprar, alquilar y mirar algunos títulos."
+  },
+  "account_form_set_pin": {
+    "other": "Establecer PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Actualizada"
+  },
+  "account_form_change_pin": {
+    "other": "Cambiar PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Establezca su PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Establecer PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Introduzca su PIN para {{.Action}} este contenido restringido"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Ups, ingresaste un PIN incorrecto"
+  },
+  "user_submit_pin_button": {
+    "other": "Meterse en"
+  },
+  "user_reset_pin_button": {
+    "other": "Restablecer PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "Introduzca un código PIN válido."
+  },
+  "validation_pincode2_required": {
+    "other": "Introduzca un código PIN válido."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Introduzca un código PIN válido."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Introduzca un código PIN válido."
+  },
+  "validation_pincode2_match": {
+    "other": "El código PIN no coincide."
+  },
+  "userdevices_delete_limits": {
+    "other": "Puedes borrar {{.Limit}} dispositivo(s) de esta lista cada uno {{.Period}} días."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Ha alcanzado este límite y no puede eliminar ningún dispositivo en este momento. Puede eliminar un dispositivo en {{.Days}} días."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Esta tarjeta será guardada y cargada regularmente."
+  },
+  "changepincode_modal_header": {
+    "other": "Cambia tu PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "tu contraseña actual"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Su nuevo PIN de 4 dígitos"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Confirma tu nuevo PIN de 4 dígitos"
+  },
+  "changepincode_modal_submit": {
+    "other": "Establecer PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Esa contraseña es incorrecta."
+  },
+  "user_set_pin_intro": {
+    "other": "Necesitas un PIN para {{.Action}} contenido restringido"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Haga clic aquí para restablecer su PIN"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Este contenido tiene restricción de edad."
+  },
+  "shopping_error_close_button": {
+    "other": "Bueno"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Caduca {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Periodo de prueba"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Cancelar mi suscripción"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Cancelar"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Sí, cancelar mi suscripción"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "¿Cancelar suscripción?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Esto cancelará la suscripción a la {{.Name}} plan. Aún podrá ver el contenido del plan hasta que caduque {{.Expiry}}."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Ha fallado al iniciar sesión demasiadas veces. Por favor, inténtelo de nuevo más tarde."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Su cuenta ha sido suspendida temporalmente. Póngase en contacto con un administrador si cree que se trata de un error."
+  },
+  "users_gender_none": {
+    "other": "No especificado"
+  },
+  "users_gender_female": {
+    "other": "Mujer"
+  },
+  "users_gender_male": {
+    "other": "Masculino"
+  },
+  "users_gender_diverse": {
+    "other": "Diversa"
+  },
+  "users_gender_other": {
+    "other": "Otra"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD solamente"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD solamente"
+  },
+  "shopping_card_save_card": {
+    "other": "Guarda esta tarjeta para uso futuro"
+  },
+  "shopping_card_button_change": {
+    "other": "Mostrar todas las tarjetas guardadas"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} terminando en {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(caduca {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(caducada)"
+  },
+  "shopping_card_use_other": {
+    "other": "Usar una nueva tarjeta"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Cambiar tarjeta"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Actualice su tarjeta de crédito. Las tarjetas aceptadas son Visa, Mastercard y American Express."
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Suscripción"
+  },
+  "shopping_action_credit": {
+    "other": "añadir crédito"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Cambiar tarjeta de credito"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Actualizar los datos de la tarjeta de crédito"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Actualizar"
+  },
+  "availability_renting": {
+    "other": "Alquiler"
+  },
+  "availability_not_available": {
+    "other": "No disponible"
+  },
+  "availability_in_watch_window": {
+    "other": "Disponible en ventana"
+  },
+  "modal_cancel": {
+    "other": "Cancelar"
+  },
+  "play": {
+    "other": "Reproducir"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Iniciar sesión"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Crear cuenta"
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Desafortunadamente, {{.Title}} se ha vendido."
+  }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Configuración" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.shift72.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "Français" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Configuración"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "Français"
+  },
   "episode_name": {
     "other": "Capítulo"
   },
-
   "season_name": {
     "other": "Temporada"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "una temporada",
     "other": "{{.Count}} temporadas"
   },
@@ -38,176 +55,435 @@
     "one": "1 Episodio",
     "other": "{{.Count}} Episodios"
   },
-
-  "date_day": { "other": "Día" },
-  "date_month": { "other": "Mes" },
-  "date_year": { "other": "Año" },
-
-  "404_page_header": { "other": "Esa página no existe..." },
-  "404_page_content": { "other": "<p>Lo sentimos, parece que la página que estás buscando no existe. </p><p>Podría haber sido movida o eliminada, o quizá hayas escrito algo mal.</p><p>Intenta volver a la página de inicio para encontrar lo que buscabas.</p><p><a href=\"{{.URL}}\">Regresar a la página de incio</a></p>" },
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Iniciar sesión" },
-  "nav_signup": { "other": "Crear cuenta" },
-  "nav_signed_in_as": { "other": "Sesión iniciada como" },
-  "nav_library": { "other": "Mi biblioteca" },
-  "nav_devices": { "other": "Mis dispositivos" },
-  "nav_wishlist": { "other": "Mi lista" },
-  "nav_account": { "other": "Mi Cuenta" },
-  "nav_signout": { "other": "Cerrar sesión" },
-  "play_trailer": { "other": "Trailer" },
-  "runtime_hours": { "other": "h" },
-  "runtime_minutes": { "other": "m" },
-
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "último {{.Date}}" },
-  "datetime_today": { "other": "hoy {{.Date}}" },
-  "datetime_tomorrow": { "other": "mañana {{.Date}}" },
-  "datetime_yesterday": { "other": "ayer {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Buscar" },
-  "search_control_submit": { "other": "Enviar busqueda" },
-
-  "play_button_watch": { "other" : "Reproducir"},
-  "play_button_resume": { "other" : "Continuar"},
-
-  "social_media_buttons_title": { "other": "Compartir" },
-  "social_media_buttons_facebook": { "other": "Compartir en Facebook" },
-  "social_media_buttons_twitter": { "other": "Compartir en Twitter" },
-  "social_media_buttons_linkedin": { "other": "Compartir en Linkedin" },
-  "social_media_buttons_email": { "other": "Compartir via correo electrónico" },
-  "social_media_buttons_email_subject": { "other": "Compartir enlace" },
-  "social_media_buttons_copied_link": { "other": "¡Link copiado al portapapeles!" },
-  "social_media_buttons_copy_link": { "other": "Copiar al portapapeles" },
-
-  "accept_invite_page_header": { "other": "Bienvenido " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Parece que ya ha canjeado esta invitación, debería  <a href=\"{{.SigninURL}}\">ingresar</a>. Si has olvidado tu contraseña, puedes también <a href=\"{{.ForgotPasswordURL}}\">reestablecer tu contraseña</a>." },
-  "acceptinvite_complete": { "other": "Gracias. Se ha creado su cuenta." },
-  "acceptinvite_form_submit": { "other": "Aceptar invitación" },
-  "acceptinvite_agreement": { "other": "Al seleccionar 'aceptar invitación' estás de acuerdo con nuestros <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a> y <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">política de privacidad</a>." },
-
-  "signup_page_header": { "other": "Crear nueva cuenta" },
-  "signup_form_name": { "other": "Nombre" },
-  "signup_form_email": { "other": "Correo" },
-  "signup_form_password": { "other": "Contraseña" },
-  "signup_form_password_confirmation": { "other": "Confirmar tu contraseña" },
-  "signup_form_gender": { "other": "Género" },
-  "signup_form_dob": { "other": "Fecha de nacimiento" },
-  "signup_form_submit": { "other": "Enviar" },
-
-  "signin_page_header": { "other": "Iniciar sesión" },
-  "signin_form_email": { "other": "Correo" },
-  "signin_form_password": { "other": "Contraseña" },
-  "signin_form_remember": { "other": "Recuérdame" },
-  "signin_form_submit": { "other": "Enviar" },
-  "signin_page_forgotpassword": { "other": "¿Has olvidado tu contraseña?" },
-  "signin_page_createnewaccount": { "other": "¿No tienes una cuenta? Crear nueva cuenta" },
-  "signup_page_alreadyhaveanaccount": { "other": "¿Ya tienes una cuenta? Iniciar sesión" },
-  "signup_form_error_email_already_in_use": { "other": "Esa dirección de correo electrónico ya está en uso." },
-  "signin_form_error_incorrect_credentials": { "other": "El usuario o contraseña es incorecto." },
-  "signup_form_error_forbidden": { "other": "Ha ocurido un error." },
-
-  "combined_auth_continue": { "other": "Seguir" },
-  "combined_auth_change": { "other": "cambiar" },
-  "combined_auth_signin": { "other": "Iniciar sesión" },
-  "combined_auth_signup": { "other": "Crear cuenta" },
-  "combined_auth_signin_password": { "other": "Por favor ingresa tu contraseña para iniciar sesión." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Esa contraseña es incorecta." },
-  "combined_auth_error_forbidden": { "other": "Ha ocurido un error." },
-  "combined_auth_error_too_many_requests": { "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde." },
-
-  "forgotpassword_page_header": { "other": "Reestablecer contraseña" },
-  "forgotpassword_form_email": { "other": "Correo" },
-  "forgotpassword_form_submit": { "other": "Reestablecer" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "No existe ninguna cuenta con ese correo." },
-  "forgotpassword_form_error_account_suspended": { "other": "Esta cuenta está suspendida." },
-  "forgotpassword_complete": { "other": "Gracias. Un correo para reestablecer la constraseña debería llegar a tu inbox pronto." },
-  "forgotpassword_form_error_forbidden": { "other": "Ha ocurrido un error." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde." },
-
-  "resetpassword_page_header": { "other": "Cambiar tu contraseña" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Parece que esta solicitud para reestablecer la constraseña no es válida, por favor completa el formato <a href=\"{{.URL}}\">Se te olvidó tu contraseña</a> otra vez." },
-  "resetpassword_form_password": { "other": "Nueva Contraseña" },
-  "resetpassword_form_password2": { "other": "Confirma tu nueva contraseña" },
-  "resetpassword_form_submit": { "other": "Cambiar" },
-  "resetpassword_complete": { "other": "Gracias. Tu contraseña ha cambiado y has iniciado sesión." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "La solicitud para reestablecer la contraseña es inválida. Por favor intenta más tarde." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "El token para reestablecer la contraseña está vencido. Por favor solicita uno nuevo." },
-  "resetpassword_form_error_too_many_requests": { "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde." },
-
-  "account_page_header": { "other": "Mi cuenta" },
-  "account_form_name": { "other": "Nombre" },
-  "account_form_email": { "other": "Correo" },
-  "account_form_password": { "other": "Contraseña" },
-  "account_form_change_password": { "other": "Cambiar" },
-  "account_form_gender": { "other": "Género" },
-  "account_form_dob": { "other": "Fecha de nacimiento" },
-  "account_form_submit": { "other": "Actualizar" },
-  "account_form_submitted": { "other": "Actualizado" },
-  "account_form_password_changed": { "other": "Actualizado" },
-  "account_form_error_incorrect_password": { "other": "Esa contraseña es incorrecta." },
-
-  "signup_form_optin": {"other": "Registrarse para nuestro boletín"},
-
-  "passwordconfirmation_modal_header": { "other": "Confirme su contraseña" },
-  "passwordconfirmation_modal_label": { "other": "Por favor ingresa tu contraseña para actualizar tus cambios" },
-  "passwordconfirmation_modal_confirm": { "other": "Confirmar" },
-
-  "changepassword_modal_header": { "other": "Cambiar tu contraseña" },
-  "changepassword_modal_currentpassword": { "other": "Tu contraseña actual" },
-  "changepassword_modal_password": { "other": "Tu contraseña nueva" },
-  "changepassword_modal_password2": { "other": "Confirmar tu contraseña nueva" },
-  "changepassword_modal_submit": { "other": "Actualizar" },
-  "changepassword_modal_error_incorrect_password": { "other": "Esa contraseña es incorecta." },
-
-  "userlibrary_page_header": { "other": "Mi biblioteca" },
-  "userlibrary_empty_header":  { "other": "Tu biblioteca esta vacía." },
-  "userlibrary_empty_content": { "other": "Llénala <a href=\"{{.HomeURL}}\">revisando</a> nuestra gran selección." },
-
-  "searchresults_page_header": { "other": "Resultados de la busqueada" },
-  "searchresults_load_more": { "other": "Cargar {{.Count }} más" },
+  "date_day": {
+    "other": "Día"
+  },
+  "date_month": {
+    "other": "Mes"
+  },
+  "date_year": {
+    "other": "Año"
+  },
+  "404_page_header": {
+    "other": "Esa página no existe..."
+  },
+  "404_page_content": {
+    "other": "<p>Lo sentimos, parece que la página que estás buscando no existe. </p><p>Podría haber sido movida o eliminada, o quizá hayas escrito algo mal.</p><p>Intenta volver a la página de inicio para encontrar lo que buscabas.</p><p><a href=\"{{.URL}}\">Regresar a la página de incio</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Iniciar sesión"
+  },
+  "nav_signup": {
+    "other": "Crear cuenta"
+  },
+  "nav_signed_in_as": {
+    "other": "Sesión iniciada como"
+  },
+  "nav_library": {
+    "other": "Mi biblioteca"
+  },
+  "nav_devices": {
+    "other": "Mis dispositivos"
+  },
+  "nav_wishlist": {
+    "other": "Mi lista"
+  },
+  "nav_account": {
+    "other": "Mi Cuenta"
+  },
+  "nav_signout": {
+    "other": "Cerrar sesión"
+  },
+  "play_trailer": {
+    "other": "Trailer"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "m"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "último {{.Date}}"
+  },
+  "datetime_today": {
+    "other": "hoy {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "mañana {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "ayer {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Buscar"
+  },
+  "search_control_submit": {
+    "other": "Enviar busqueda"
+  },
+  "play_button_watch": {
+    "other": "Reproducir"
+  },
+  "play_button_resume": {
+    "other": "Continuar"
+  },
+  "social_media_buttons_title": {
+    "other": "Compartir"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Compartir en Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Compartir en Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Compartir en Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Compartir via correo electrónico"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Compartir enlace"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "¡Link copiado al portapapeles!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Copiar al portapapeles"
+  },
+  "accept_invite_page_header": {
+    "other": "Bienvenido "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Parece que ya ha canjeado esta invitación, debería  <a href=\"{{.SigninURL}}\">ingresar</a>. Si has olvidado tu contraseña, puedes también <a href=\"{{.ForgotPasswordURL}}\">reestablecer tu contraseña</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Gracias. Se ha creado su cuenta."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Aceptar invitación"
+  },
+  "acceptinvite_agreement": {
+    "other": "Al seleccionar 'aceptar invitación' estás de acuerdo con nuestros <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a> y <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">política de privacidad</a>."
+  },
+  "signup_page_header": {
+    "other": "Crear nueva cuenta"
+  },
+  "signup_form_name": {
+    "other": "Nombre"
+  },
+  "signup_form_email": {
+    "other": "Correo"
+  },
+  "signup_form_password": {
+    "other": "Contraseña"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Confirmar tu contraseña"
+  },
+  "signup_form_gender": {
+    "other": "Género"
+  },
+  "signup_form_dob": {
+    "other": "Fecha de nacimiento"
+  },
+  "signup_form_submit": {
+    "other": "Enviar"
+  },
+  "signin_page_header": {
+    "other": "Iniciar sesión"
+  },
+  "signin_form_email": {
+    "other": "Correo"
+  },
+  "signin_form_password": {
+    "other": "Contraseña"
+  },
+  "signin_form_remember": {
+    "other": "Recuérdame"
+  },
+  "signin_form_submit": {
+    "other": "Enviar"
+  },
+  "signin_page_forgotpassword": {
+    "other": "¿Has olvidado tu contraseña?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "¿No tienes una cuenta? Crear nueva cuenta"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "¿Ya tienes una cuenta? Iniciar sesión"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Esa dirección de correo electrónico ya está en uso."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "El usuario o contraseña es incorecto."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Ha ocurido un error."
+  },
+  "combined_auth_continue": {
+    "other": "Seguir"
+  },
+  "combined_auth_change": {
+    "other": "cambiar"
+  },
+  "combined_auth_signin": {
+    "other": "Iniciar sesión"
+  },
+  "combined_auth_signup": {
+    "other": "Crear cuenta"
+  },
+  "combined_auth_signin_password": {
+    "other": "Por favor ingresa tu contraseña para iniciar sesión."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Esa contraseña es incorecta."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Ha ocurido un error."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde."
+  },
+  "forgotpassword_page_header": {
+    "other": "Reestablecer contraseña"
+  },
+  "forgotpassword_form_email": {
+    "other": "Correo"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Reestablecer"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "No existe ninguna cuenta con ese correo."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Esta cuenta está suspendida."
+  },
+  "forgotpassword_complete": {
+    "other": "Gracias. Un correo para reestablecer la constraseña debería llegar a tu inbox pronto."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Ha ocurrido un error."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde."
+  },
+  "resetpassword_page_header": {
+    "other": "Cambiar tu contraseña"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Parece que esta solicitud para reestablecer la constraseña no es válida, por favor completa el formato <a href=\"{{.URL}}\">Se te olvidó tu contraseña</a> otra vez."
+  },
+  "resetpassword_form_password": {
+    "other": "Nueva Contraseña"
+  },
+  "resetpassword_form_password2": {
+    "other": "Confirma tu nueva contraseña"
+  },
+  "resetpassword_form_submit": {
+    "other": "Cambiar"
+  },
+  "resetpassword_complete": {
+    "other": "Gracias. Tu contraseña ha cambiado y has iniciado sesión."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "La solicitud para reestablecer la contraseña es inválida. Por favor intenta más tarde."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "El token para reestablecer la contraseña está vencido. Por favor solicita uno nuevo."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Hay demasiadas solicitudes. Por favor inténtelo más tarde."
+  },
+  "account_page_header": {
+    "other": "Mi cuenta"
+  },
+  "account_form_name": {
+    "other": "Nombre"
+  },
+  "account_form_email": {
+    "other": "Correo"
+  },
+  "account_form_password": {
+    "other": "Contraseña"
+  },
+  "account_form_change_password": {
+    "other": "Cambiar"
+  },
+  "account_form_gender": {
+    "other": "Género"
+  },
+  "account_form_dob": {
+    "other": "Fecha de nacimiento"
+  },
+  "account_form_submit": {
+    "other": "Actualizar"
+  },
+  "account_form_submitted": {
+    "other": "Actualizado"
+  },
+  "account_form_password_changed": {
+    "other": "Actualizado"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Esa contraseña es incorrecta."
+  },
+  "signup_form_optin": {
+    "other": "Registrarse para nuestro boletín"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Confirme su contraseña"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Por favor ingresa tu contraseña para actualizar tus cambios"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Confirmar"
+  },
+  "changepassword_modal_header": {
+    "other": "Cambiar tu contraseña"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Tu contraseña actual"
+  },
+  "changepassword_modal_password": {
+    "other": "Tu contraseña nueva"
+  },
+  "changepassword_modal_password2": {
+    "other": "Confirmar tu contraseña nueva"
+  },
+  "changepassword_modal_submit": {
+    "other": "Actualizar"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Esa contraseña es incorecta."
+  },
+  "userlibrary_page_header": {
+    "other": "Mi biblioteca"
+  },
+  "userlibrary_empty_header": {
+    "other": "Tu biblioteca esta vacía."
+  },
+  "userlibrary_empty_content": {
+    "other": "Llénala <a href=\"{{.HomeURL}}\">revisando</a> nuestra gran selección."
+  },
+  "searchresults_page_header": {
+    "other": "Resultados de la busqueada"
+  },
+  "searchresults_load_more": {
+    "other": "Cargar {{.Count }} más"
+  },
   "searchresults_total": {
     "one": "Encontrado 1 resultado para \"{{.Query}}\".",
     "other": "Encontrado {{.Count}} resultados para \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "No hubo resultados para \"{{.Query}}\"." },
-  "searchresults_empty_content": { "other": "Intenta otra busqueada o <a href=\"{{.HomeURL}}\">revisar la programación</a> para encontrar lo que buscas." },
-
-  "validation_name_required": { "other": "Por favor ingresa tu nombre." },
-  "validation_email_required": { "other": "Por favor ingresa tu correo." },
-  "validation_email_email": { "other": "Por favor ingresa un correo válido." },
-  "validation_currentpassword_required": { "other": "Por favor ingresa tu contraseña actual." },
-  "validation_password_required": { "other": "Por favor ingresa una contraseña" },
-  "validation_password2_required": { "other": "Por favor confirma tu contraseña." },
-  "validation_password2_match": { "other": "No coinciden tus constraseñas." },
-  "validation_password_minlength": { "other": "Por favor ingresa al menos {{.Count}} caracteres." },
-  "validation_promocode_required": { "other": "Por favor ingresa un código promocional." },
-  "validation_pincode_required": { "other": "Por favor, introduzca un código PIN." },
-  "validation_gender_required": { "other": "Por favor selecciona el género más cercano con el que te identifiques." },
-  "validation_dob_required": { "other": "Por favor ingresa tu fecha de nacimiento." },
-  "validation_dob_date": { "other": "Por favor ingresa una fecha de nacimiento válida." },
-
-  "shopping_info_subtitle_hd": { "other": "HD Video sobre demanda." },
-  "shopping_info_subtitle_sd": { "other": "SD vídeo bajo demanda." },
-  "shopping_info_subtitle_wallet": { "other": "Los fondos de su cartera pueden ser utilizados para la compra o alquiler de cualquier contenido en ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "Revisa aquí los requerimientos del sistema." },
-  "shopping_info_ownership_buy": { "other": "Comprar" },
-  "shopping_info_ownership_rent": { "other": "Rentar" },
-
-  "shopping_info_sd_only": { "other": "Limitado a la reproducción SD solamente." },
-  "shopping_info_release_date_title": { "other": "Lanzamientos {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "La puedes rentar ahora, pero no puedes verla hasta entonces." },
-  "shopping_info_release_date_explanation_buy": { "other": "La puedes comprar ahora, pero no puedes verla hasta entonces." },
-
-  "shopping_info_available_until_date_title": { "other": "Disponible hasta el {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "No podrás ver el contenido después de esto." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "No podrás ver el contenido después de esto." },
-
-  "duration_hour": { "one": "1 hora", "other": "{{.Count}} horas" },
-  "duration_day": { "one": "1 día", "other": "{{.Count}} dias" },
-  "shopping_info_rental_period_duration": { "other": "Renta de {{.ValueUnit}} " },
-  "shopping_info_watch_window_duration": { "other": "Ventana de reproducción de {{.Count}} horas. " },
+  "searchresults_empty_header": {
+    "other": "No hubo resultados para \"{{.Query}}\"."
+  },
+  "searchresults_empty_content": {
+    "other": "Intenta otra busqueada o <a href=\"{{.HomeURL}}\">revisar la programación</a> para encontrar lo que buscas."
+  },
+  "validation_name_required": {
+    "other": "Por favor ingresa tu nombre."
+  },
+  "validation_email_required": {
+    "other": "Por favor ingresa tu correo."
+  },
+  "validation_email_email": {
+    "other": "Por favor ingresa un correo válido."
+  },
+  "validation_currentpassword_required": {
+    "other": "Por favor ingresa tu contraseña actual."
+  },
+  "validation_password_required": {
+    "other": "Por favor ingresa una contraseña"
+  },
+  "validation_password2_required": {
+    "other": "Por favor confirma tu contraseña."
+  },
+  "validation_password2_match": {
+    "other": "No coinciden tus constraseñas."
+  },
+  "validation_password_minlength": {
+    "other": "Por favor ingresa al menos {{.Count}} caracteres."
+  },
+  "validation_promocode_required": {
+    "other": "Por favor ingresa un código promocional."
+  },
+  "validation_pincode_required": {
+    "other": "Por favor, introduzca un código PIN."
+  },
+  "validation_gender_required": {
+    "other": "Por favor selecciona el género más cercano con el que te identifiques."
+  },
+  "validation_dob_required": {
+    "other": "Por favor ingresa tu fecha de nacimiento."
+  },
+  "validation_dob_date": {
+    "other": "Por favor ingresa una fecha de nacimiento válida."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Video sobre demanda."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD vídeo bajo demanda."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Los fondos de su cartera pueden ser utilizados para la compra o alquiler de cualquier contenido en ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Revisa aquí los requerimientos del sistema."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "Comprar"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "Rentar"
+  },
+  "shopping_info_sd_only": {
+    "other": "Limitado a la reproducción SD solamente."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Lanzamientos {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "La puedes rentar ahora, pero no puedes verla hasta entonces."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "La puedes comprar ahora, pero no puedes verla hasta entonces."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Disponible hasta el {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "No podrás ver el contenido después de esto."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "No podrás ver el contenido después de esto."
+  },
+  "duration_hour": {
+    "one": "1 hora",
+    "other": "{{.Count}} horas"
+  },
+  "duration_day": {
+    "one": "1 día",
+    "other": "{{.Count}} dias"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "Renta de {{.ValueUnit}} "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "Ventana de reproducción de {{.Count}} horas. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Una vez rentada, tu película estará disponible en tu cuenta durante {{.ValueUnit}}. ",
     "other": "Una vez rentada, tu película estará disponible en tu cuenta durante {{.ValueUnit}}. "
@@ -232,65 +508,151 @@
     "one": "Una vez que seleccionas reproducir en un capítulo, se inicia la ventana de reproducción y tienes hora para ver ese capítulo las veces que quieras.",
     "other": "Una vez que seleccionas reproducir en un capítulo, se inicia la ventana de reproducción y tienes {{.Count}} horas para ver ese capítulo las veces que quieras."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Primo" },
-
-  "shopping_enter_card_prompt": { "other": "Ingresa los datos de tu tarjeta de crédito para completar tu {{.Verb}}." },
-
-  "shopping_terms": { "other": "Al completar esta transacción, estoy de acuerdo con los <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">términos y condiciones</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} descuento aplicado." },
-  "shopping_discount_apply": { "other": "Aplicar" },
-  "shopping_discount_code": { "other": "Ingresar un código promocional." },
-  "shopping_discount_have_code": { "other": "Tengo un código promocional." },
-
-  "shopping_price_you_pay": { "other": "Pagas" },
-  "shopping_price_nothing": { "other": "Nada" },
-  "shopping_price_free": { "other": "Gratis" },
-
-  "shopping_auth_directions": { "other": "Se requiere una cuenta primero. Por favor ingresa tu correo." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} ya está en tu biblioteca." },
-
-  "shopping_error_missing_card": { "other": "Por favor ingresa los datos de tu tarjeta de crédito." },
-  "shopping_error_title": { "other": "Ocurrió un error" },
-  "shopping_error_incorrect_cvc": { "other": "Por favor ingresa un CVV válido." },
-  "shopping_error_invalid_cvc": { "other": "Por favor ingresa un CVV válido." },
-  "shopping_error_incorrect_number": { "other": "Por favor ingresa un número de tarjeta de crédito válido." },
-  "shopping_error_invalid_number": { "other": "Por favor ingresa un número de tarjeta de crédito válido." },
-  "shopping_error_card_declined": { "other": "Se ha declinado la tarjeta de crédito." },
-  "shopping_error_invalid_expiry_month": { "other": "Por favor ingresa una fecha de vencimiento válida." },
-  "shopping_error_invalid_expiry_year": { "other": "Por favor ingresa una fecha de vencimiento válida." },
-  "shopping_error_expired_card": { "other": "La tarjeta de crédito está vencida." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Tu {{.Ownership}} no se ha completado. Necesitas estar en el país en donde se emitió tu tarjeta de crédito. Por favor use otra tarjeta para realizar el pago." },
-  "shopping_error_proxy_detected": { "other": "Tu {{.Ownership}} no se ha completado. Hemos detectado que estás usando un servicio de proxy o unblocker. Por favor apague estos servicios e intenta de nuevo." },
-
-  "shopping_error_discount_worn_out": { "other": "Ese código promocional ya no puede ser utilizado." },
-  "shopping_error_discount_blank": { "other": "Por favor ingresa un código promocional." },
-  "shopping_error_discount_not_applied": { "other": "Por favor ingresa un código promocional válido." },
-  "shopping_error_discount_invalid": { "other": "Por favor ingresa un código promocional válido." },
-  "shopping_error_discount_disabled": { "other": "Por favor ingresa un código promocional válido." },
-  "shopping_error_discount_already_applied": { "other": "Ya se ha utlizado un código promocional para esta sesión." },
-  "shopping_error_discount_already_redeemed": { "other": "Ese código promocional ya se ha utlizado." },
-  "shopping_error_discount_used_previously": { "other": "Ese código promocional ya se ha utlizado." },
-  "shopping_error_discount_max_limit": { "other": "Ya no se puede usar ese códigio promocional." },
-  "shopping_error_discount_expired": { "other": "Ese código promocional está vencido." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Ese código promocional no se puede usar durante compras." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Ese código promocional no se puede usar durante rentas." },
-  "shopping_error_discount_invalid_item": { "other": "Ese código promocional no se puede usar con este artículo." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Ese código promocional no se puede usar en tu país." },
-  "shopping_error_discounts_not_allowed": { "other": "Ese código promocional no se puede usar." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Ese código promocional no se puede usar con paquetes." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Esa tarjeta de crédito está declinada. Por favor intenta más tarde." },
-
-  "shopping_complete_rental": { "other": "¡Éxito!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Primo"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Ingresa los datos de tu tarjeta de crédito para completar tu {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Al completar esta transacción, estoy de acuerdo con los <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">términos y condiciones</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} descuento aplicado."
+  },
+  "shopping_discount_apply": {
+    "other": "Aplicar"
+  },
+  "shopping_discount_code": {
+    "other": "Ingresar un código promocional."
+  },
+  "shopping_discount_have_code": {
+    "other": "Tengo un código promocional."
+  },
+  "shopping_price_you_pay": {
+    "other": "Pagas"
+  },
+  "shopping_price_nothing": {
+    "other": "Nada"
+  },
+  "shopping_price_free": {
+    "other": "Gratis"
+  },
+  "shopping_auth_directions": {
+    "other": "Se requiere una cuenta primero. Por favor ingresa tu correo."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} ya está en tu biblioteca."
+  },
+  "shopping_error_missing_card": {
+    "other": "Por favor ingresa los datos de tu tarjeta de crédito."
+  },
+  "shopping_error_title": {
+    "other": "Ocurrió un error"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Por favor ingresa un CVV válido."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Por favor ingresa un CVV válido."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Por favor ingresa un número de tarjeta de crédito válido."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Por favor ingresa un número de tarjeta de crédito válido."
+  },
+  "shopping_error_card_declined": {
+    "other": "Se ha declinado la tarjeta de crédito."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Por favor ingresa una fecha de vencimiento válida."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Por favor ingresa una fecha de vencimiento válida."
+  },
+  "shopping_error_expired_card": {
+    "other": "La tarjeta de crédito está vencida."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Tu {{.Ownership}} no se ha completado. Necesitas estar en el país en donde se emitió tu tarjeta de crédito. Por favor use otra tarjeta para realizar el pago."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Tu {{.Ownership}} no se ha completado. Hemos detectado que estás usando un servicio de proxy o unblocker. Por favor apague estos servicios e intenta de nuevo."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Ese código promocional ya no puede ser utilizado."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Por favor ingresa un código promocional."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Por favor ingresa un código promocional válido."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Por favor ingresa un código promocional válido."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Por favor ingresa un código promocional válido."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Ya se ha utlizado un código promocional para esta sesión."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Ese código promocional ya se ha utlizado."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Ese código promocional ya se ha utlizado."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Ya no se puede usar ese códigio promocional."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Ese código promocional está vencido."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Ese código promocional no se puede usar durante compras."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Ese código promocional no se puede usar durante rentas."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Ese código promocional no se puede usar con este artículo."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Ese código promocional no se puede usar en tu país."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Ese código promocional no se puede usar."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Ese código promocional no se puede usar con paquetes."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Esa tarjeta de crédito está declinada. Por favor intenta más tarde."
+  },
+  "shopping_complete_rental": {
+    "other": "¡Éxito!"
+  },
   "shopping_complete_rental_period": {
     "one": "Ahora puedes verla las veces que quieras durante el próximo día.",
     "other": "Ahora puedes verla las veces que quieras durante los próximos {{.Count}} días."
   },
-  "shopping_complete_purchase": { "other": "Gracias por comprar {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Gracias por comprar {{.Title}}, {{.CreditTotal}} se ha agregado a tu cuenta." },
-  "shopping_complete_purchase_coming_soon": { "other": "Puedes verla desde {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Se ha enviado un comprobante por correo." },
-  "shopping_complete_library_link": { "other": "Ir a tu biblioteca." },
+  "shopping_complete_purchase": {
+    "other": "Gracias por comprar {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Gracias por comprar {{.Title}}, {{.CreditTotal}} se ha agregado a tu cuenta."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Puedes verla desde {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Se ha enviado un comprobante por correo."
+  },
+  "shopping_complete_library_link": {
+    "other": "Ir a tu biblioteca."
+  },
   "shopping_complete_plan": {
     "other": "Su compra de {{ .Title }} fue exitosa."
   },
@@ -310,220 +672,517 @@
     "one": "Podrá ver desde {{.Date}} y su alquiler se mantendrá activo durante un día.",
     "other": "Podrías verla desde {{.Date}} y tu ventana de renta permanecerá activa durante {{.Count}} días."
   },
-
-  "shopping_action_rent": { "other": "Rentar" },
-  "shopping_action_buy": { "other": "Comprar" },
-
-  "meta_detail_cast_title": { "other": "Reparto" },
-  "meta_detail_crew_title": { "other": "Tripulación" },
-  "meta_detail_languages": { "one": "Idioma", "other": "Idiomas" },
-  "meta_detail_studios": { "one": "Productora", "other": "Productoras" },
-  "meta_detail_countries": { "one": "País", "other": "Países" },
-  "meta_detail_subtitles": { "other": "Subtítulos" },
-  "meta_detail_captions": { "other": "Subtítulos [CC]" },
-  "meta_detail_episodes_title": { "other": "Capítulos" },
-  "meta_detail_bonus_title": { "other": "Contenido adicional" },
-  "meta_detail_recommendations_title": { "other": "Te podría interesar" },
-  "meta_detail_bundle_items_title": { "other": "Contenido incluido en este paquete" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} películas" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} temporadas" },
-  "bundle_items_mixed": { "other": "{{.Count}} películas y temporadas" },
-  "userwishlist_page_header": { "other": "Mi lista" },
-  "userwishlist_slider_header": { "other": "Mi lista" },
-  "userwishlist_empty_header":  { "other": "Tu lista está vacia." },
-  "userwishlist_empty_content": { "other": "Llénala <a href=\"{{.HomeURL}}\">revisando</a> nuestra gran selección." },
-  "userwishlist_button_add": { "other": "Agregar a mi lista" },
-  "userwishlist_button_remove": { "other": "Mi lista" },
-  "userwishlist_button_add_compact": { "other": "Mi lista" },
-  "userwishlist_button_remove_compact": { "other": "Mi lista" },
-
-  "activatedevice_page_header": { "other": "Activar dispositivo" },
-  "activatedevice_page_content": { "other": "Siga las instrucciones de su dispositivo para obtener un código PIN. El ordenador y el dispositivo tanto deben estar conectados a Internet para que pueda activarse." },
-  "activatedevice_form_pin": { "other": "Código PIN" },
-  "activatedevice_form_submit": { "other": "Activar" },
-  "activatedevice_form_error_invalid_code": { "other": "Código PIN no encontrado, por favor intente de nuevo." },
-  "activatedevice_form_error_pin_not_found": { "other": "Código PIN no encontrado, por favor intente de nuevo." },
-  "activatedevice_signin_prompt": { "other": "Por favor inicie sesión antes de activar el dispositivo." },
-  "activatedevice_page_activated": { "other": "Gracias por la activación {{.DeviceName}}. Ahora podrá navegar en su biblioteca en su televisor o dispositivo." },
-
-  "userdevices_page_header": { "other": "Dispositivos" },
+  "shopping_action_rent": {
+    "other": "Rentar"
+  },
+  "shopping_action_buy": {
+    "other": "Comprar"
+  },
+  "meta_detail_cast_title": {
+    "other": "Reparto"
+  },
+  "meta_detail_crew_title": {
+    "other": "Tripulación"
+  },
+  "meta_detail_languages": {
+    "one": "Idioma",
+    "other": "Idiomas"
+  },
+  "meta_detail_studios": {
+    "one": "Productora",
+    "other": "Productoras"
+  },
+  "meta_detail_countries": {
+    "one": "País",
+    "other": "Países"
+  },
+  "meta_detail_subtitles": {
+    "other": "Subtítulos"
+  },
+  "meta_detail_captions": {
+    "other": "Subtítulos [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Capítulos"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Contenido adicional"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Te podría interesar"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Contenido incluido en este paquete"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} películas"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} temporadas"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} películas y temporadas"
+  },
+  "userwishlist_page_header": {
+    "other": "Mi lista"
+  },
+  "userwishlist_slider_header": {
+    "other": "Mi lista"
+  },
+  "userwishlist_empty_header": {
+    "other": "Tu lista está vacia."
+  },
+  "userwishlist_empty_content": {
+    "other": "Llénala <a href=\"{{.HomeURL}}\">revisando</a> nuestra gran selección."
+  },
+  "userwishlist_button_add": {
+    "other": "Agregar a mi lista"
+  },
+  "userwishlist_button_remove": {
+    "other": "Mi lista"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Mi lista"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Mi lista"
+  },
+  "activatedevice_page_header": {
+    "other": "Activar dispositivo"
+  },
+  "activatedevice_page_content": {
+    "other": "Siga las instrucciones de su dispositivo para obtener un código PIN. El ordenador y el dispositivo tanto deben estar conectados a Internet para que pueda activarse."
+  },
+  "activatedevice_form_pin": {
+    "other": "Código PIN"
+  },
+  "activatedevice_form_submit": {
+    "other": "Activar"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "Código PIN no encontrado, por favor intente de nuevo."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "Código PIN no encontrado, por favor intente de nuevo."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Por favor inicie sesión antes de activar el dispositivo."
+  },
+  "activatedevice_page_activated": {
+    "other": "Gracias por la activación {{.DeviceName}}. Ahora podrá navegar en su biblioteca en su televisor o dispositivo."
+  },
+  "userdevices_page_header": {
+    "other": "Dispositivos"
+  },
   "userdevices_page_content": {
     "one": "Se agregarán dispositivos aquí cuando los usas. Tienes un límite de solo un dispositivo.",
     "other": "Se agregarán dispositivos aquí cuando los uses. Tienes un límite de {{.Count}} dispositivos."
   },
-  "userdevices_empty_content": { "other": "Actualmente tienes 0 dispositvos registrados." },
-  "userdevices_header_type": { "other": "Tipo de dispositivo" },
-  "userdevices_header_description": { "other": "Descripción" },
-  "userdevices_device_added": { "other": "Agregado {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Borrar" },
-  "userdevices_device_actions_cancel": { "other": "Cancelar" },
-  "userdevices_device_actions_confirm": { "other": "Sí, borrar dispositivo" },
-  "userdevices_device_deleted": { "other": "(Borrado)" },
-
-  "playlist_page_header": { "other": "Lista de reproducción" },
-  "playlist_sign_in_warning": { "other": "Por favor inicie sesión para ver la televisión en directo."},
-  "playlist_share_title": { "other": "Lista de reproducción" },
-  "playlist_up_next_title": { "other": "Siguiente" },
-
-  "pricing_ownership_buy": { "other": "Comprar" },
-  "pricing_ownership_rent": { "other": "Rentar" },
-
-  "classification_intro": { "other": "Clasificación: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Este sitio usa cookies para mejorar tu experiencia. Al usar este sitio, aceptas nuestra política de cookies <a href=\"{{.CookiePolicyURL}}\">uso de cookies</a>." },
-  "cookie_banner_accept": { "other": "Acepto" },
-
-  "all_rights_reserved": { "other": "Todos los derechos reservados. Ninguna parte de este sitio puede reproducirse sin nuestro permiso escrito." },
-
-  "availability_not_available_in_country": { "other": "No disponible" },
-  "availability_coming_soon": {"other": "Próximamente"},
-  "availability_available": {"other": "Disponible {{.ReleaseDate}}"},
-  "availability_available_till": {"other": "Disponible hasta {{.ExpiryDate}}"},
-  "availability_renting": {"other": "En renta"},
-  "availability_in_watch_window": {"other": "Disponible"},
-  "availability_sold_out": {"other": "Agotada"},
-
-  "modal_cancel": {"other": "Cancelar"},
-
-  "play": {"other": "Reproducir"},
-
-  "users_gender_none": {"other": "No especificado"},
-  "users_gender_female": {"other": "Mujer"},
-  "users_gender_male": {"other": "Hombre"},
-  "users_gender_diverse": {"other": "Diverso"},
-  "users_gender_other": {"other": "Otro"},
-
-  "combined_auth_signin_prompt": {"other": "Iniciar sesión"},
-  "combined_auth_signup_prompt": {"other": "Registrarse"},
-  "combined_auth_terms": {"other": "Estoy de acuerdo con todos los <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a>."},
-  "signup_terms": {"other": "Estoy de acuerdo con todos los <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a>."},
-  "validation_terms_required": {"other": "Debes estar de acuerdo con los términos y condiciones."},
-  "shopping_info_rental_period_coming_soon": {"other": "desde la fecha y hora de lanzamiento."},
-  "shopping_error_item_limit_exceeded": {"other": "Lamentablemente, {{.Title}} está agotada."},
-
-  "shopping_card_change": { "other": "¿La tarjeta de crédito no es correcta? <a href=\"{{.SubscriptionsURL}}\">Haga clic aquí para actualizar su tarjeta.</a>" },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Parece que estás teniendo problemas.</p><p>Restablezca su PIN o contáctenos para <a href=\"{{.HelpURL}}\" target=\"_blank\">ayuda</a>" },
-
-  "app_badge_title": { "other": "¡Descarga la aplicación para ver el contenido comprado!" },
-  "app_badge_ios": { "other": "Descargar en la App Store" },
-  "app_badge_android": { "other": "Consiguelo en google play" },
-
+  "userdevices_empty_content": {
+    "other": "Actualmente tienes 0 dispositvos registrados."
+  },
+  "userdevices_header_type": {
+    "other": "Tipo de dispositivo"
+  },
+  "userdevices_header_description": {
+    "other": "Descripción"
+  },
+  "userdevices_device_added": {
+    "other": "Agregado {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Borrar"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Cancelar"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Sí, borrar dispositivo"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Borrado)"
+  },
+  "playlist_page_header": {
+    "other": "Lista de reproducción"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Por favor inicie sesión para ver la televisión en directo."
+  },
+  "playlist_share_title": {
+    "other": "Lista de reproducción"
+  },
+  "playlist_up_next_title": {
+    "other": "Siguiente"
+  },
+  "pricing_ownership_buy": {
+    "other": "Comprar"
+  },
+  "pricing_ownership_rent": {
+    "other": "Rentar"
+  },
+  "classification_intro": {
+    "other": "Clasificación: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Este sitio usa cookies para mejorar tu experiencia. Al usar este sitio, aceptas nuestra política de cookies <a href=\"{{.CookiePolicyURL}}\">uso de cookies</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Acepto"
+  },
+  "all_rights_reserved": {
+    "other": "Todos los derechos reservados. Ninguna parte de este sitio puede reproducirse sin nuestro permiso escrito."
+  },
+  "availability_not_available_in_country": {
+    "other": "No disponible"
+  },
+  "availability_coming_soon": {
+    "other": "Próximamente"
+  },
+  "availability_available": {
+    "other": "Disponible {{.ReleaseDate}}"
+  },
+  "availability_available_till": {
+    "other": "Disponible hasta {{.ExpiryDate}}"
+  },
+  "availability_renting": {
+    "other": "En renta"
+  },
+  "availability_in_watch_window": {
+    "other": "Disponible"
+  },
+  "availability_sold_out": {
+    "other": "Agotada"
+  },
+  "modal_cancel": {
+    "other": "Cancelar"
+  },
+  "play": {
+    "other": "Reproducir"
+  },
+  "users_gender_none": {
+    "other": "No especificado"
+  },
+  "users_gender_female": {
+    "other": "Mujer"
+  },
+  "users_gender_male": {
+    "other": "Hombre"
+  },
+  "users_gender_diverse": {
+    "other": "Diverso"
+  },
+  "users_gender_other": {
+    "other": "Otro"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Iniciar sesión"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Registrarse"
+  },
+  "combined_auth_terms": {
+    "other": "Estoy de acuerdo con todos los <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a>."
+  },
+  "signup_terms": {
+    "other": "Estoy de acuerdo con todos los <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">términos y condiciones</a>."
+  },
+  "validation_terms_required": {
+    "other": "Debes estar de acuerdo con los términos y condiciones."
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "desde la fecha y hora de lanzamiento."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Lamentablemente, {{.Title}} está agotada."
+  },
+  "shopping_card_change": {
+    "other": "¿La tarjeta de crédito no es correcta? <a href=\"{{.SubscriptionsURL}}\">Haga clic aquí para actualizar su tarjeta.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Parece que estás teniendo problemas.</p><p>Restablezca su PIN o contáctenos para <a href=\"{{.HelpURL}}\" target=\"_blank\">ayuda</a>"
+  },
+  "app_badge_title": {
+    "other": "¡Descarga la aplicación para ver el contenido comprado!"
+  },
+  "app_badge_ios": {
+    "other": "Descargar en la App Store"
+  },
+  "app_badge_android": {
+    "other": "Consiguelo en google play"
+  },
   "awards_in_competition": {
     "other": "En competición"
   },
-
-  "awards_winner": { "other": "Ganador" },
-  "donate_button_text": { "other": "Donar" },
-
-  "wcag_skip_links_header": { "other": "Enlaces de accesibilidad" },
-  "wcag_skip_links_content": { "other": "Saltar al contenido" },
-
-  "wcag_homepage_h1": { "other": "Página principal" },
-  "wcag_carousel_h2": { "other": "Carrusel" },
-  "wcag_collections_h2": { "other": "Colecciones" },
-
-  "wcag_aria_label_footer": { "other": "Pie de página" },
-  "wcag_aria_label_nav_main": { "other": "Principal" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Navegación de palanca" },
-  "wcag_aria_label_bundle_items": { "other": "Paquete de artículos" },
-  "wcag_aria_label_carousel": { "other": "Carrusel" },
-  "wcag_aria_label_page_collection": { "other": "Colección de páginas" },
-  "wcag_aria_label_collection_list": { "other": "Lista de colecciones" },
-  "wcag_aria_label_collection_slider": { "other": "Control deslizante de colección" },
-  "wcag_aria_label_wishlist": { "other": "Lista de deseos" },
-  "wcag_aria_label_facebook": { "other": "Compartir en Facebook" },
-  "wcag_aria_label_twitter": { "other": "Compartir en Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Compartir en LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Ver en Letterboxd" },
-  
-  "shopping_error_plan_already_owned": { "other": "Ya tienes este plan." },
-  "shopping_error_plan_expired": { "other": "Este plan ya no está disponible." },
-  "shopping_payment_method_header": { "other": "Métodos de pago" },
-  "shopping_payment_method_credit_card": { "other": "Tarjeta de crédito" },
-  "shopping_payment_method_giropay": { "other": "Giropay (Alemania)" },
-  "shopping_error_stripe_unknown_error": { "other": "Hubo un error con este pago. Por favor, intente más tarde." },
-  "shopping_error_payment_complete_failed": { "other": "Este pago fue rechazado. Cierre esta ventana e inténtelo de nuevo." },
-  "plan_label_owned": { "other": "" },
-
-  "header_banner": { "other": "banner de encabezado" },
-
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "No tiene un PIN establecido, que se requiere para comprar, alquilar y mirar algunos títulos."},
-  "account_form_set_pin": { "other": "Establecer PIN" },
-  "account_form_pin_changed": { "other": "Actualizada" },
-  "account_form_change_pin": { "other": "Cambiar PIN" },
-
-  "user_set_pin_header": { "other": "Establezca su PIN" },
-  "user_set_pin_button": { "other":  "Establecer PIN" },
-  "user_submit_pin_heading": { "other": "Introduzca su PIN para {{.Action}} este contenido restringido" },
-  "user_error_wrong_pin_retry": { "other": "Ups, ingresaste un PIN incorrecto" },
-  "user_submit_pin_button": { "other": "Meterse en" },
-  "user_reset_pin_button": { "other": "Restablecer PIN" },
-
-  "validation_pincode1_required": { "other": "Introduzca un código PIN válido." },
-  "validation_pincode2_required": { "other": "Introduzca un código PIN válido." },
-  "validation_pincode1_pattern": { "other": "Introduzca un código PIN válido." },
-  "validation_pincode2_pattern": { "other": "Introduzca un código PIN válido." },
-  "validation_pincode2_match": { "other": "El código PIN no coincide." },
-
-  "userdevices_delete_limits": { "other": "Puedes borrar {{.Limit}} dispositivo(s) de esta lista cada uno {{.Period}} días."},
-  "userdevices_delete_limit_reached": { "other": "Ha alcanzado este límite y no puede eliminar ningún dispositivo en este momento. Puede eliminar un dispositivo en {{.Days}} días." },
-  "shopping_card_new_subscription": { "other": "Esta tarjeta será guardada y cargada regularmente." },
-
-"changepincode_modal_header": { "other": "Cambia tu PIN" },
-"changepincode_modal_currentpassword": { "other": "tu contraseña actual" },
-"changepincode_modal_pincode1": { "other": "Su nuevo PIN de 4 dígitos" },
-"changepincode_modal_pincode2": { "other": "Confirma tu nuevo PIN de 4 dígitos" },
-"changepincode_modal_submit": { "other": "Establecer PIN" },
-"changepincode_modal_error_wrong_password": { "other": "Esa contraseña es incorrecta." },
-
-"user_set_pin_intro": { "other": "Necesitas un PIN para {{.Action}} contenido restringido"},
-"user_error_wrong_pin_reset": { "other": "Haga clic aquí para restablecer su PIN" },
-"user_error_too_many_pin_errors_help_page_link": { "other": "" },
-"shopping_error_age_restricted": { "other": "Este contenido tiene restricción de edad." },
-"shopping_error_close_button": { "other": "OK" }, 
-
-"usersubscriptions_subscription_expiry": { "other": "Caduca {{.Expiry}}" },
-"usersubscriptions_subscription_status_trialing": { "other": "Periodo de prueba" },
-"usersubscriptions_subscription_unsubscribe": { "other": "Cancelar mi suscripción" },
-"usersubscriptions_unsubscribe_modal_cancel": { "other": "Cancelar" },
-"usersubscriptions_unsubscribe_modal_confirm": { "other": "Sí, cancelar mi suscripción" },
-"usersubscriptions_unsubscribe_modal_title": { "other": "¿Cancelar suscripción?" },
-"usersubscriptions_unsubscribe_modal_body": { "other": "Esto cancelará la suscripción a la {{.Name}} plan. Aún podrá ver el contenido del plan hasta que caduque {{.Expiry}}." },
-
-"signin_form_error_ip_throttled": { "other": "Ha fallado al iniciar sesión demasiadas veces. Por favor, inténtelo de nuevo más tarde." },
-"signin_form_error_account_suspended": { "other": "Su cuenta ha sido suspendida temporalmente. Póngase en contacto con un administrador si cree que se trata de un error." },
-
-
-
-"pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HD solamente" },
-  "pricing_quality_sd_only": { "other": "SD solamente" },
-
-  "shopping_card_save_card": { "other": "Guarda esta tarjeta para uso futuro" },
-  "shopping_card_button_change": { "other": "Mostrar todas las tarjetas guardadas" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} terminando en {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(caduca {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(caducada)" },
-  "shopping_card_use_other": { "other": "Usar una nueva tarjeta" },
-  "shopping_card_use_new_card": { "other": "Cambiar tarjeta" },
-  "shopping_card_update_reason_none": { "other": "Actualice su tarjeta de crédito. Las tarjetas aceptadas son Visa, Mastercard y American Express." },
-  "shopping_info_ownership_plan": { "other": "Suscripción" },
-  "shopping_action_credit": { "other": "añadir crédito" },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Cambiar tarjeta de credito" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Actualizar los datos de la tarjeta de crédito" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Actualizar" },
-
-
-  "availability_not_available": { "other": "No disponible" },
-  "shopping_price_title_plan": { "other": "Precio" },
+  "awards_winner": {
+    "other": "Ganador"
+  },
+  "donate_button_text": {
+    "other": "Donar"
+  },
+  "wcag_skip_links_header": {
+    "other": "Enlaces de accesibilidad"
+  },
+  "wcag_skip_links_content": {
+    "other": "Saltar al contenido"
+  },
+  "wcag_homepage_h1": {
+    "other": "Página principal"
+  },
+  "wcag_carousel_h2": {
+    "other": "Carrusel"
+  },
+  "wcag_collections_h2": {
+    "other": "Colecciones"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Pie de página"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Principal"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Navegación de palanca"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Paquete de artículos"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Carrusel"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Colección de páginas"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Lista de colecciones"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Control deslizante de colección"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Lista de deseos"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Compartir en Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Compartir en Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Compartir en LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Ver en Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Ya tienes este plan."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Este plan ya no está disponible."
+  },
+  "shopping_payment_method_header": {
+    "other": "Métodos de pago"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Tarjeta de crédito"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay (Alemania)"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Hubo un error con este pago. Por favor, intente más tarde."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Este pago fue rechazado. Cierre esta ventana e inténtelo de nuevo."
+  },
+  "plan_label_owned": {
+    "other": ""
+  },
+  "header_banner": {
+    "other": "banner de encabezado"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "No tiene un PIN establecido, que se requiere para comprar, alquilar y mirar algunos títulos."
+  },
+  "account_form_set_pin": {
+    "other": "Establecer PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Actualizada"
+  },
+  "account_form_change_pin": {
+    "other": "Cambiar PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Establezca su PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Establecer PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Introduzca su PIN para {{.Action}} este contenido restringido"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Ups, ingresaste un PIN incorrecto"
+  },
+  "user_submit_pin_button": {
+    "other": "Meterse en"
+  },
+  "user_reset_pin_button": {
+    "other": "Restablecer PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "Introduzca un código PIN válido."
+  },
+  "validation_pincode2_required": {
+    "other": "Introduzca un código PIN válido."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Introduzca un código PIN válido."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Introduzca un código PIN válido."
+  },
+  "validation_pincode2_match": {
+    "other": "El código PIN no coincide."
+  },
+  "userdevices_delete_limits": {
+    "other": "Puedes borrar {{.Limit}} dispositivo(s) de esta lista cada uno {{.Period}} días."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Ha alcanzado este límite y no puede eliminar ningún dispositivo en este momento. Puede eliminar un dispositivo en {{.Days}} días."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Esta tarjeta será guardada y cargada regularmente."
+  },
+  "changepincode_modal_header": {
+    "other": "Cambia tu PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "tu contraseña actual"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Su nuevo PIN de 4 dígitos"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Confirma tu nuevo PIN de 4 dígitos"
+  },
+  "changepincode_modal_submit": {
+    "other": "Establecer PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Esa contraseña es incorrecta."
+  },
+  "user_set_pin_intro": {
+    "other": "Necesitas un PIN para {{.Action}} contenido restringido"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Haga clic aquí para restablecer su PIN"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Este contenido tiene restricción de edad."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Caduca {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Periodo de prueba"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Cancelar mi suscripción"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Cancelar"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Sí, cancelar mi suscripción"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "¿Cancelar suscripción?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Esto cancelará la suscripción a la {{.Name}} plan. Aún podrá ver el contenido del plan hasta que caduque {{.Expiry}}."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Ha fallado al iniciar sesión demasiadas veces. Por favor, inténtelo de nuevo más tarde."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Su cuenta ha sido suspendida temporalmente. Póngase en contacto con un administrador si cree que se trata de un error."
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD solamente"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD solamente"
+  },
+  "shopping_card_save_card": {
+    "other": "Guarda esta tarjeta para uso futuro"
+  },
+  "shopping_card_button_change": {
+    "other": "Mostrar todas las tarjetas guardadas"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} terminando en {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(caduca {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(caducada)"
+  },
+  "shopping_card_use_other": {
+    "other": "Usar una nueva tarjeta"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Cambiar tarjeta"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Actualice su tarjeta de crédito. Las tarjetas aceptadas son Visa, Mastercard y American Express."
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Suscripción"
+  },
+  "shopping_action_credit": {
+    "other": "añadir crédito"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Cambiar tarjeta de credito"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Actualizar los datos de la tarjeta de crédito"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Actualizar"
+  },
+  "availability_not_available": {
+    "other": "No disponible"
+  },
+  "shopping_price_title_plan": {
+    "other": "Precio"
+  },
   "shopping_price_plan_note": {
     "zero": "Cargado cada {{.Interval}}.",
     "one": "Se {{ .Interval }} cada intervalo después de que finaliza la prueba gratuita de 24 horas.",
@@ -533,14 +1192,18 @@
     "one": "{{.Interval}}",
     "other": "{{.Count}} {{.Interval}}s"
   },
-
-  "shopping_enter_card_prompt_plan": { "other": "Ingrese los detalles de su tarjeta de crédito a continuación para comenzar su suscripción." },
-
-  "shopping_action_plan": { "other": "Completo" },
-
-  "shopping_complete_subscription": { "other": "La compra de su suscripción se realizó correctamente. Ahora estás suscrito a {{ .Title }}." },
-  "shopping_complete_subscription_browse": { "other": "No dude en <a href=\"/\">navegar por</a> el sitio o <a href=\"/search.html\">buscar</a> algo específico." },
-
+  "shopping_enter_card_prompt_plan": {
+    "other": "Ingrese los detalles de su tarjeta de crédito a continuación para comenzar su suscripción."
+  },
+  "shopping_action_plan": {
+    "other": "Completo"
+  },
+  "shopping_complete_subscription": {
+    "other": "La compra de su suscripción se realizó correctamente. Ahora estás suscrito a {{ .Title }}."
+  },
+  "shopping_complete_subscription_browse": {
+    "other": "No dude en <a href=\"/\">navegar por</a> el sitio o <a href=\"/search.html\">buscar</a> algo específico."
+  },
   "shopping_info_plan_offer": {
     "one": "Se renueva automáticamente cada {{.Interval}}",
     "other": "Se renueva automáticamente cada {{.Count}} {{.Interval}}s"
@@ -549,19 +1212,37 @@
     "one": "Renueva automáticamente cada {{ .Interval }}",
     "other": "Renueva automáticamente cada {{ .Count }} {{ .Interval }}"
   },
-
-  "availability_expires": { "other": "Caducó {{.Expiry}}" },
-  "availability_expired": { "other": "Caducada"},
-
-  "plans_page_header": { "other": "Planes Disponibles" },
-
-  "plan_expiry_date" : { "other": "Cierre de ventas: "},
-  "plan_read_more"   : { "other": "Saber más" },
-  
-  "plan_page_read_more": { "other": "Lee mas" },
-  "plan_page_header_text": { "other": "Disfruta {{.Name}}" },
-  "page_plan_explore_intro": { "other": "O" },
-  "page_plan_explore_link": { "other": "Explore otros pases" },
-  "plan_showcase_page_ownership_button_buy": { "other": "Compra ahora" },
-  "plan_free_link_text": { "other": "Registrate gratis" }
+  "availability_expires": {
+    "other": "Caducó {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Caducada"
+  },
+  "plans_page_header": {
+    "other": "Planes Disponibles"
+  },
+  "plan_expiry_date": {
+    "other": "Cierre de ventas: "
+  },
+  "plan_read_more": {
+    "other": "Saber más"
+  },
+  "plan_page_read_more": {
+    "other": "Lee mas"
+  },
+  "plan_page_header_text": {
+    "other": "Disfruta {{.Name}}"
+  },
+  "page_plan_explore_intro": {
+    "other": "O"
+  },
+  "page_plan_explore_link": {
+    "other": "Explore otros pases"
+  },
+  "plan_showcase_page_ownership_button_buy": {
+    "other": "Compra ahora"
+  },
+  "plan_free_link_text": {
+    "other": "Registrate gratis"
+  }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1,188 +1,457 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Asetukset" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.shift72.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Asetukset"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
   "episode_name": {
     "other": "Jakso"
   },
-
   "season_name": {
     "other": "Kausi"
   },
-
-  "date_day": { "other": "Päivä" },
-  "date_month": { "other": "Kuukausi" },
-  "date_year": { "other": "Vuosi" },
-
-  "404_page_header": { "other": "Sivua ei ole olemassa" },
-  "404_page_content": { "other": "<p> Valitettavasti hakemaasi sivua ei ole olemassa.</p><p>Sivu on voitu siirtää tai poistaa, tai osoiterivillä on virhe.</p><p>Palaa etusivulle löytääksesi hakemasi.</p><p><a href=\"/\">Takaisin etusivulle</a></p>" },
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Kirjaudu" },
-  "nav_signup": { "other": "Luo tili" },
-  "nav_signed_in_as": { "other": "Kirjautunut:" },
-  "nav_library": { "other": "Kirjastoni" },
-  "nav_devices": { "other": "Laitteeni" },
-  "nav_wishlist": { "other": "Listani" },
-  "nav_account": { "other": "Tilini" },
-  "nav_signout": { "other": "Kirjaudu ulos" },  
-  "play_trailer": { "other": "Traileri" },
-  "runtime_hours": { "other": "t" },
-  "runtime_minutes": { "other": "min" },
-
-  "datetime_today": { "other": "tänään {{.Date}}" },
-  "datetime_tomorrow": { "other": "huomenna {{.Date}}" },
-  "datetime_yesterday": { "other": "eilen {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "viimeinen {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Haku" },
-  "search_control_submit": { "other": "Hae" },
-
-  "play_button_watch": { "other" : "Toista"},
-  "play_button_resume": { "other" : "Jatka"},
-
-  "social_media_buttons_title": { "other": "Jaa" },
-  "social_media_buttons_facebook": { "other": "Jaa Facebookissa" },
-  "social_media_buttons_twitter": { "other": "Jaa Twitterissä" },
-  "social_media_buttons_linkedin": { "other": "Jaa Linkedinissä" },
-  "social_media_buttons_email": { "other": "Jaa sähköpostilla" },
-  "social_media_buttons_email_subject": { "other": "Linkin jakaminen" },
-  "social_media_buttons_copied_link": { "other": "Linkki kopioitu leikepöydälle!" },
-  "social_media_buttons_copy_link": { "other": "Kopioi leikepöydälle" },
-
-  "accept_invite_page_header": { "other": "Tervetuloa " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Vaikuttaa siltä, että olet jo käyttänyt tämän kutsun. Kokeile <a href=\"signin.html\">kirjautua sisään</a> palveluun. Jos olet unohtanut salasanasi, voit <a href=\"forgotpassword.html\">tilata uuden salasanan</a>." },
-  "acceptinvite_complete": { "other": "Kiitos. Tilisi on luotu." },
-  "acceptinvite_form_submit": { "other": "Hyväksy kutsu" },
-  "acceptinvite_agreement": { "other": "Hyväksymällä kutsun vahvistat lukeneesi ja ymmärtäneesi palvelun <a href=\"/page/terms-and-conditions/\" target=\"_blank\">käyttöehdot</a> ja <a href=\"/page/privacy/\" target=\"_blank\">tietosuojaselosteen</a>." },
-
-  "signup_page_header": { "other": "Luo uusi tili" },
-  "signup_form_name": { "other": "Nimi" },
-  "signup_form_email": { "other": "Sähköpostiosoite" },
-  "signup_form_password": { "other": "Salasana" },
-  "signup_form_password_confirmation": { "other": "Vahvista salasana" },
-  "signup_form_gender": { "other": "Sukupuoli" },
-  "signup_form_dob": { "other": "Syntymäaika" },
-  "signup_form_submit": { "other": "Lähetä" },
-
-  "signin_page_header": { "other": "Kirjaudu" },
-  "signin_form_email": { "other": "Sähköpostiosoite" },
-  "signin_form_password": { "other": "Salasana" },
-  "signin_form_remember": { "other": "Muista minut" },
-  "signin_form_submit": { "other": "Lähetä" },
-  "signin_page_forgotpassword": { "other": "Unohtuiko salasana?" },
-  "signin_page_createnewaccount": { "other": "Eikö sinulla ole tiliä? Luo uusi tili" },
-  "signup_page_alreadyhaveanaccount": { "other": "Onko sinulla jo tili? Kirjaudu sisään" },
-  "signup_form_error_email_already_in_use": { "other": "Sähköpostiosoite on jo käytössä." },
-  "signin_form_error_incorrect_credentials": { "other": "Virheellinen käyttäjätunnus tai salasana." },
-  "signin_form_error_ip_throttled": { "other": "Et ole kirjautunut sisään liian monta kertaa. Yritä uudelleen myöhemmin." },
-
-  "signup_form_error_forbidden": { "other": "Tapahtui virhe." },
-
-  "combined_auth_continue": { "other": "Jatka" },
-  "combined_auth_change": { "other": "vaihda" },
-  "combined_auth_signin": { "other": "Kirjaudu" },
-  "combined_auth_signup": { "other": "Luo tili" },
-  "combined_auth_signin_password": { "other": "Syötä salasanasi kirjautuaksesi tilillesi." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Salasana on virheellinen." },
-  "combined_auth_error_forbidden": { "other": "Tapahtui virhe." },
-  "combined_auth_error_too_many_requests": { "other": "Liikaa pyyntöjä, yritä myöhemmin uudelleen." },
-
-  "forgotpassword_page_header": { "other": "Tilaa uusi salasana" },
-  "forgotpassword_form_email": { "other": "Sähköpostiosoite" },
-  "forgotpassword_form_submit": { "other": "Tilaa uusi" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Tätä sähköpostiosoitetta vastaavaa tiliä ei ole olemassa." },
-  "forgotpassword_form_error_account_suspended": { "other": "Tämä tili on jäädytetty." },
-  "forgotpassword_complete": { "other": "Kiitos. Saat pian sähköpostiisi linkin salasanasi vaihtamiseksi." },
-  "forgotpassword_form_error_forbidden": { "other": "Tapahtui virhe." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Liikaa pyyntöjä, yritä myöhemmin uudelleen." },
-
-  "resetpassword_page_header": { "other": "Vaihda salasana" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Vaikuttaa siltä, ​​että tämä salasanan palautuspyyntö on virheellinen. Täytä <a href=\"{{.URL}}\">Salasananvaihtolomake</a> uudelleen." },
-  "resetpassword_form_password": { "other": "Uusi salasana" },
-  "resetpassword_form_password2": { "other": "Vahvista salasana" },
-  "resetpassword_form_submit": { "other": "Vaihda" },
-  "resetpassword_complete": { "other": "Kiitos. Salasanasi on vaihdettu ja sinut on kirjattu sisään." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Salasanan vaihtopyyntö on virheellinen. Yritä myöhemmin uudelleen." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Salasananvaihtopyyntö on vanhentunut. Pyydä uusi." },
-  "resetpassword_form_error_too_many_requests": { "other": "Liikaa pyyntöjä, yritä myöhemmin uudelleen." },
-
-  "account_page_header": { "other": "Tilini" },
-  "account_form_name": { "other": "Nimi" },
-  "account_form_email": { "other": "Sähköpostiosoite" },
-  "account_form_password": { "other": "Salasana" },
-  "account_form_change_password": { "other": "Vaihda" },
-  "account_form_gender": { "other": "Sukupuoli" },
-  "account_form_dob": { "other": "Syntymäaika" },
-  "account_form_submit": { "other": "Päivitä" },
-  "account_form_submitted": { "other": "Päivitetty" },
-  "account_form_password_changed": { "other": "Päivitetty" },
-  "account_form_error_incorrect_password": { "other": "Salasana on virheellinen." },
-
-  "signup_form_optin": {"other": "Tilaa Festival Scopen ilmainen uutiskirje"},
-
-  "passwordconfirmation_modal_header": { "other": "Vahvista salasana" },
-  "passwordconfirmation_modal_label": { "other": "Kirjoita salasanasi vahvistaaksesi tekemäsi muutokset." },
-  "passwordconfirmation_modal_confirm": { "other": "Vahvista" },
-
-  "changepassword_modal_header": { "other": "Vaihda salasana" },
-  "changepassword_modal_currentpassword": { "other": "Nykyinen salasana" },
-  "changepassword_modal_password": { "other": "Uusi salasana" },
-  "changepassword_modal_password2": { "other": "Vahvista uusi salasana" },
-  "changepassword_modal_submit": { "other": "Päivitä" },
-  "changepassword_modal_error_incorrect_password": { "other": "Salasana on virheellinen." },
-
-  "userlibrary_page_header": { "other": "Kirjastoni" },
-  "userlibrary_empty_header":  { "other": "Kirjastosi on tyhjä." },
-  "userlibrary_empty_content": { "other": "Täydennä kirjastoasi <a href=\"/\">selaamalla</a> valikoimaamme." },
-
-  "searchresults_page_header": { "other": "Hakutulokset" },
-  "searchresults_load_more": { "other": "Näytä {{.Count}} lisää" },
+  "date_day": {
+    "other": "Päivä"
+  },
+  "date_month": {
+    "other": "Kuukausi"
+  },
+  "date_year": {
+    "other": "Vuosi"
+  },
+  "404_page_header": {
+    "other": "Sivua ei ole olemassa"
+  },
+  "404_page_content": {
+    "other": "<p> Valitettavasti hakemaasi sivua ei ole olemassa.</p><p>Sivu on voitu siirtää tai poistaa, tai osoiterivillä on virhe.</p><p>Palaa etusivulle löytääksesi hakemasi.</p><p><a href=\"/\">Takaisin etusivulle</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Kirjaudu"
+  },
+  "nav_signup": {
+    "other": "Luo tili"
+  },
+  "nav_signed_in_as": {
+    "other": "Kirjautunut:"
+  },
+  "nav_library": {
+    "other": "Kirjastoni"
+  },
+  "nav_devices": {
+    "other": "Laitteeni"
+  },
+  "nav_wishlist": {
+    "other": "Listani"
+  },
+  "nav_account": {
+    "other": "Tilini"
+  },
+  "nav_signout": {
+    "other": "Kirjaudu ulos"
+  },
+  "play_trailer": {
+    "other": "Traileri"
+  },
+  "runtime_hours": {
+    "other": "t"
+  },
+  "runtime_minutes": {
+    "other": "min"
+  },
+  "datetime_today": {
+    "other": "tänään {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "huomenna {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "eilen {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "viimeinen {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Haku"
+  },
+  "search_control_submit": {
+    "other": "Hae"
+  },
+  "play_button_watch": {
+    "other": "Toista"
+  },
+  "play_button_resume": {
+    "other": "Jatka"
+  },
+  "social_media_buttons_title": {
+    "other": "Jaa"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Jaa Facebookissa"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Jaa Twitterissä"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Jaa Linkedinissä"
+  },
+  "social_media_buttons_email": {
+    "other": "Jaa sähköpostilla"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Linkin jakaminen"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Linkki kopioitu leikepöydälle!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Kopioi leikepöydälle"
+  },
+  "accept_invite_page_header": {
+    "other": "Tervetuloa "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Vaikuttaa siltä, että olet jo käyttänyt tämän kutsun. Kokeile <a href=\"signin.html\">kirjautua sisään</a> palveluun. Jos olet unohtanut salasanasi, voit <a href=\"forgotpassword.html\">tilata uuden salasanan</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Kiitos. Tilisi on luotu."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Hyväksy kutsu"
+  },
+  "acceptinvite_agreement": {
+    "other": "Hyväksymällä kutsun vahvistat lukeneesi ja ymmärtäneesi palvelun <a href=\"/page/terms-and-conditions/\" target=\"_blank\">käyttöehdot</a> ja <a href=\"/page/privacy/\" target=\"_blank\">tietosuojaselosteen</a>."
+  },
+  "signup_page_header": {
+    "other": "Luo uusi tili"
+  },
+  "signup_form_name": {
+    "other": "Nimi"
+  },
+  "signup_form_email": {
+    "other": "Sähköpostiosoite"
+  },
+  "signup_form_password": {
+    "other": "Salasana"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Vahvista salasana"
+  },
+  "signup_form_gender": {
+    "other": "Sukupuoli"
+  },
+  "signup_form_dob": {
+    "other": "Syntymäaika"
+  },
+  "signup_form_submit": {
+    "other": "Lähetä"
+  },
+  "signin_page_header": {
+    "other": "Kirjaudu"
+  },
+  "signin_form_email": {
+    "other": "Sähköpostiosoite"
+  },
+  "signin_form_password": {
+    "other": "Salasana"
+  },
+  "signin_form_remember": {
+    "other": "Muista minut"
+  },
+  "signin_form_submit": {
+    "other": "Lähetä"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Unohtuiko salasana?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Eikö sinulla ole tiliä? Luo uusi tili"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Onko sinulla jo tili? Kirjaudu sisään"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Sähköpostiosoite on jo käytössä."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Virheellinen käyttäjätunnus tai salasana."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Et ole kirjautunut sisään liian monta kertaa. Yritä uudelleen myöhemmin."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Tapahtui virhe."
+  },
+  "combined_auth_continue": {
+    "other": "Jatka"
+  },
+  "combined_auth_change": {
+    "other": "vaihda"
+  },
+  "combined_auth_signin": {
+    "other": "Kirjaudu"
+  },
+  "combined_auth_signup": {
+    "other": "Luo tili"
+  },
+  "combined_auth_signin_password": {
+    "other": "Syötä salasanasi kirjautuaksesi tilillesi."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Salasana on virheellinen."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Tapahtui virhe."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Liikaa pyyntöjä, yritä myöhemmin uudelleen."
+  },
+  "forgotpassword_page_header": {
+    "other": "Tilaa uusi salasana"
+  },
+  "forgotpassword_form_email": {
+    "other": "Sähköpostiosoite"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Tilaa uusi"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Tätä sähköpostiosoitetta vastaavaa tiliä ei ole olemassa."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Tämä tili on jäädytetty."
+  },
+  "forgotpassword_complete": {
+    "other": "Kiitos. Saat pian sähköpostiisi linkin salasanasi vaihtamiseksi."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Tapahtui virhe."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Liikaa pyyntöjä, yritä myöhemmin uudelleen."
+  },
+  "resetpassword_page_header": {
+    "other": "Vaihda salasana"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Vaikuttaa siltä, ​​että tämä salasanan palautuspyyntö on virheellinen. Täytä <a href=\"{{.URL}}\">Salasananvaihtolomake</a> uudelleen."
+  },
+  "resetpassword_form_password": {
+    "other": "Uusi salasana"
+  },
+  "resetpassword_form_password2": {
+    "other": "Vahvista salasana"
+  },
+  "resetpassword_form_submit": {
+    "other": "Vaihda"
+  },
+  "resetpassword_complete": {
+    "other": "Kiitos. Salasanasi on vaihdettu ja sinut on kirjattu sisään."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Salasanan vaihtopyyntö on virheellinen. Yritä myöhemmin uudelleen."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Salasananvaihtopyyntö on vanhentunut. Pyydä uusi."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Liikaa pyyntöjä, yritä myöhemmin uudelleen."
+  },
+  "account_page_header": {
+    "other": "Tilini"
+  },
+  "account_form_name": {
+    "other": "Nimi"
+  },
+  "account_form_email": {
+    "other": "Sähköpostiosoite"
+  },
+  "account_form_password": {
+    "other": "Salasana"
+  },
+  "account_form_change_password": {
+    "other": "Vaihda"
+  },
+  "account_form_gender": {
+    "other": "Sukupuoli"
+  },
+  "account_form_dob": {
+    "other": "Syntymäaika"
+  },
+  "account_form_submit": {
+    "other": "Päivitä"
+  },
+  "account_form_submitted": {
+    "other": "Päivitetty"
+  },
+  "account_form_password_changed": {
+    "other": "Päivitetty"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Salasana on virheellinen."
+  },
+  "signup_form_optin": {
+    "other": "Tilaa Festival Scopen ilmainen uutiskirje"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Vahvista salasana"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Kirjoita salasanasi vahvistaaksesi tekemäsi muutokset."
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Vahvista"
+  },
+  "changepassword_modal_header": {
+    "other": "Vaihda salasana"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Nykyinen salasana"
+  },
+  "changepassword_modal_password": {
+    "other": "Uusi salasana"
+  },
+  "changepassword_modal_password2": {
+    "other": "Vahvista uusi salasana"
+  },
+  "changepassword_modal_submit": {
+    "other": "Päivitä"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Salasana on virheellinen."
+  },
+  "userlibrary_page_header": {
+    "other": "Kirjastoni"
+  },
+  "userlibrary_empty_header": {
+    "other": "Kirjastosi on tyhjä."
+  },
+  "userlibrary_empty_content": {
+    "other": "Täydennä kirjastoasi <a href=\"/\">selaamalla</a> valikoimaamme."
+  },
+  "searchresults_page_header": {
+    "other": "Hakutulokset"
+  },
+  "searchresults_load_more": {
+    "other": "Näytä {{.Count}} lisää"
+  },
   "searchresults_total": {
     "one": "Hakuehdolla \"{{.Query}}\" löytyi 1 tulos.",
     "other": "Hakuehdolla \"{{.Query}}\" löytyi {{.Count}} tulosta."
   },
-  "searchresults_empty_header":  { "other": "Hakuehdolla \"{{.Query}}\" ei löytynyt tuloksia." },
-  "searchresults_empty_content": { "other": "Kokeile toista hakusanaa tai <a href=\"{{.HomeURL}}\">selaa sisältöjämme</a> löytääksesi etsimäsi." },
-
-  "validation_name_required": { "other": "Kirjoita nimesi." },
-  "validation_email_required": { "other": "Kirjoita sähköpostiosoitteesi." },
-  "validation_email_email": { "other": "Kirjoita voimassaoleva sähköpostiosoite." },
-  "validation_currentpassword_required": { "other": "Kirjoita vaatimusten mukainen salasana." },
-  "validation_password_required": { "other": "Kirjoita salasana." },
-  "validation_password2_required": { "other": "Vahvista salasanasi." },
-  "validation_password2_match": { "other": "Salasanasi eivät täsmää." },
-  "validation_password_minlength": { "other": "Salasanassa on oltava vähintään {{.Count}} merkkiä." },
-  "validation_promocode_required": { "other": "Syötä tarjouskoodi." },
-  "validation_gender_required": { "other": "Valitse sukupuoli, johon eniten identifioidut." },
-  "validation_dob_required": { "other": "Kirjoita syntymäaikasi." },
-  "validation_dob_date": { "other": "Kirjoita kelvollinen syntymäaika." },
-
-  "shopping_info_subtitle_help": { "other": "Katso järjestelmävaatimukset täältä." },
-  "shopping_info_ownership_buy": { "other": "osto" },
-  "shopping_info_ownership_rent": { "other": "vuokraus" },
-
-  "shopping_info_release_date_title": { "other": "Julkaistaan {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Voit vuokrata tuotteen nyt, mutta se on katsottavissa vasta julkaisupäivänä." },
-  "shopping_info_release_date_explanation_buy": { "other": "Voit ostaa tuotteen nyt, mutta se on katsottavissa vasta julkaisupäivänä." },
-
-  "shopping_info_available_until_date_title": { "other": "Saatavissa {{.Date}} saakka. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Sen jälkeen sisältöä ei voi enää katsoa." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Sen jälkeen sisältöä ei voi enää katsoa." },
-
-  "duration_hour": { "one": "1 tunti", "other": "{{.Count}} tuntia" },
-  "duration_day": { "one": "1 päivä", "other": "{{.Count}} päivää" },
-  "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} vuokra " },
-  "shopping_info_watch_window_duration": { "other": "{{.Count}} tunnin katseluoikeus. " },
+  "searchresults_empty_header": {
+    "other": "Hakuehdolla \"{{.Query}}\" ei löytynyt tuloksia."
+  },
+  "searchresults_empty_content": {
+    "other": "Kokeile toista hakusanaa tai <a href=\"{{.HomeURL}}\">selaa sisältöjämme</a> löytääksesi etsimäsi."
+  },
+  "validation_name_required": {
+    "other": "Kirjoita nimesi."
+  },
+  "validation_email_required": {
+    "other": "Kirjoita sähköpostiosoitteesi."
+  },
+  "validation_email_email": {
+    "other": "Kirjoita voimassaoleva sähköpostiosoite."
+  },
+  "validation_currentpassword_required": {
+    "other": "Kirjoita vaatimusten mukainen salasana."
+  },
+  "validation_password_required": {
+    "other": "Kirjoita salasana."
+  },
+  "validation_password2_required": {
+    "other": "Vahvista salasanasi."
+  },
+  "validation_password2_match": {
+    "other": "Salasanasi eivät täsmää."
+  },
+  "validation_password_minlength": {
+    "other": "Salasanassa on oltava vähintään {{.Count}} merkkiä."
+  },
+  "validation_promocode_required": {
+    "other": "Syötä tarjouskoodi."
+  },
+  "validation_gender_required": {
+    "other": "Valitse sukupuoli, johon eniten identifioidut."
+  },
+  "validation_dob_required": {
+    "other": "Kirjoita syntymäaikasi."
+  },
+  "validation_dob_date": {
+    "other": "Kirjoita kelvollinen syntymäaika."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Katso järjestelmävaatimukset täältä."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "osto"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "vuokraus"
+  },
+  "shopping_info_release_date_title": {
+    "other": "Julkaistaan {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Voit vuokrata tuotteen nyt, mutta se on katsottavissa vasta julkaisupäivänä."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Voit ostaa tuotteen nyt, mutta se on katsottavissa vasta julkaisupäivänä."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Saatavissa {{.Date}} saakka. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Sen jälkeen sisältöä ei voi enää katsoa."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Sen jälkeen sisältöä ei voi enää katsoa."
+  },
+  "duration_hour": {
+    "one": "1 tunti",
+    "other": "{{.Count}} tuntia"
+  },
+  "duration_day": {
+    "one": "1 päivä",
+    "other": "{{.Count}} päivää"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} vuokra "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} tunnin katseluoikeus. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Vuokraamasi elokuva on katsottavissa tililläsi {{.ValueUnit}} ajan. ",
     "other": "Vuokraamasi elokuva on katsottavissa tililläsi {{.ValueUnit}} ajan. "
@@ -207,68 +476,151 @@
     "one": "Kun aloitat tietyn jakson toiston, sinulla on tunti aikaa katsoa jaksoa niin monta kertaa kuin haluat.",
     "other": "Kun aloitat tietyn jakson toiston, sinulla on {{.Count}} tuntia aikaa katsoa jaksoa niin monta kertaa kuin haluat."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Bonus" },
-
-  "shopping_enter_card_prompt": { "other": "Syötä luottokorttitietosi alle ja {{.Verb}} suoritetaan loppuun." },
-
-  "shopping_terms": { "other": "Suorittamalla tapahtuman loppuun hyväksyn palvelun <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">käyttöehdot</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} alennus käytössä." },
-  "shopping_discount_apply": { "other": "Käytä tarjouskoodi" },
-  "shopping_discount_code": { "other": "Syötä tarjouskoodi." },
-  "shopping_discount_have_code": { "other": "Minulla on tarjouskoodi." },
-
-  "shopping_price_you_pay": { "other": "Hinta" },
-  "shopping_price_nothing": { "other": "Ei mitään" },
-  "shopping_price_free": { "other": "Ilmainen" },
-
-  "shopping_auth_directions": { "other": "Ostoon tarvitaan tili. Syötä sähköpostiosoitteesi." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} on jo kirjastossasi." },
-
-  "shopping_error_missing_card": { "other": "Syötä luottokorttitietosi." },
-  "shopping_error_title": { "other": "Tapahtui virhe" },
-  "shopping_error_incorrect_cvc": { "other": "Syötä kelvollinen CVV-tunnus." },
-  "shopping_error_invalid_cvc": { "other": "Syötä kelvollinen CVV-tunnus." },
-  "shopping_error_incorrect_number": { "other": "Syötä voimassa olevan luottokortin numero." },
-  "shopping_error_invalid_number": { "other": "Syötä voimassa olevan luottokortin numero." },
-  "shopping_error_card_declined": { "other": "Korttimaksutapahtuma hylätty." },
-  "shopping_error_invalid_expiry_month": { "other": "Syötä kelvollinen viimeinen voimassaolopäivä." },
-  "shopping_error_invalid_expiry_year": { "other": "Syötä kelvollinen viimeinen voimassaolopäivä." },
-  "shopping_error_expired_card": { "other": "Kortti on vanhentunut." },
-  "shopping_error_creditcard_country_mismatch": { "other": "{{.Ownership}} epäonnistui. Sinun on oltava siinä maassa, jossa luottokorttisi myönnettiin. Käytä maksamiseen toista korttia." },
-  "shopping_error_proxy_detected": { "other": "{{.Ownership}} epäonnistui. Havaitsimme sinun käyttävän estonpoistajaa tai välityspalvelinta. Kokeile poistaa nämä palvelut käytöstä ja yritä uudelleen." },
-
-  "shopping_error_discount_blank": { "other": "Syötä tarjouskoodi." },
-  "shopping_error_discount_not_applied": { "other": "Syötä kelvollinen tarjouskoodi." },
-  "shopping_error_discount_invalid": { "other": "Syötä kelvollinen tarjouskoodi." },
-  "shopping_error_discount_disabled": { "other": "Syötä kelvollinen tarjouskoodi." },
-  "shopping_error_discount_already_applied": { "other": "Tähän ostotapahtumaan on jo käytetty tarjouskoodia." },
-  "shopping_error_discount_already_redeemed": { "other": "Tarjouskoodi on jo käytetty." },
-  "shopping_error_discount_used_previously": { "other": "Tarjouskoodi on jo käytetty." },
-  "shopping_error_discount_max_limit": { "other": "Tarjouskoodia ei voi enää käyttää." },
-  "shopping_error_discount_expired": { "other": "Tarjouskoodi on vanhentunut." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Tarjouskoodia ei voi käyttää tuotteiden ostamiseen." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Tarjouskoodia ei voi käyttää tuotteiden vuokraamiseen." },
-  "shopping_error_discount_invalid_item": { "other": "Tarjouskoodia ei voi käyttää tähän tuotteeseen." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Tarjouskoodia ei voi käyttää maassasi." },
-  "shopping_error_discounts_not_allowed": { "other": "Tarjouskoodia ei voi käyttää." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Tarjouskoodia ei voi käyttää paketteihin." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Kortti hylätty. Ole hyvä ja yritä uudestaan." },
-
-  "shopping_complete_rental": { "other": "Tapahtuma hyväksytty" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Bonus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Syötä luottokorttitietosi alle ja {{.Verb}} suoritetaan loppuun."
+  },
+  "shopping_terms": {
+    "other": "Suorittamalla tapahtuman loppuun hyväksyn palvelun <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">käyttöehdot</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} alennus käytössä."
+  },
+  "shopping_discount_apply": {
+    "other": "Käytä tarjouskoodi"
+  },
+  "shopping_discount_code": {
+    "other": "Syötä tarjouskoodi."
+  },
+  "shopping_discount_have_code": {
+    "other": "Minulla on tarjouskoodi."
+  },
+  "shopping_price_you_pay": {
+    "other": "Hinta"
+  },
+  "shopping_price_nothing": {
+    "other": "Ei mitään"
+  },
+  "shopping_price_free": {
+    "other": "Ilmainen"
+  },
+  "shopping_auth_directions": {
+    "other": "Ostoon tarvitaan tili. Syötä sähköpostiosoitteesi."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} on jo kirjastossasi."
+  },
+  "shopping_error_missing_card": {
+    "other": "Syötä luottokorttitietosi."
+  },
+  "shopping_error_title": {
+    "other": "Tapahtui virhe"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Syötä kelvollinen CVV-tunnus."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Syötä kelvollinen CVV-tunnus."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Syötä voimassa olevan luottokortin numero."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Syötä voimassa olevan luottokortin numero."
+  },
+  "shopping_error_card_declined": {
+    "other": "Korttimaksutapahtuma hylätty."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Syötä kelvollinen viimeinen voimassaolopäivä."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Syötä kelvollinen viimeinen voimassaolopäivä."
+  },
+  "shopping_error_expired_card": {
+    "other": "Kortti on vanhentunut."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "{{.Ownership}} epäonnistui. Sinun on oltava siinä maassa, jossa luottokorttisi myönnettiin. Käytä maksamiseen toista korttia."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "{{.Ownership}} epäonnistui. Havaitsimme sinun käyttävän estonpoistajaa tai välityspalvelinta. Kokeile poistaa nämä palvelut käytöstä ja yritä uudelleen."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Syötä tarjouskoodi."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Syötä kelvollinen tarjouskoodi."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Syötä kelvollinen tarjouskoodi."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Syötä kelvollinen tarjouskoodi."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Tähän ostotapahtumaan on jo käytetty tarjouskoodia."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Tarjouskoodi on jo käytetty."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Tarjouskoodi on jo käytetty."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Tarjouskoodia ei voi enää käyttää."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Tarjouskoodi on vanhentunut."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Tarjouskoodia ei voi käyttää tuotteiden ostamiseen."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Tarjouskoodia ei voi käyttää tuotteiden vuokraamiseen."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Tarjouskoodia ei voi käyttää tähän tuotteeseen."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Tarjouskoodia ei voi käyttää maassasi."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Tarjouskoodia ei voi käyttää."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Tarjouskoodia ei voi käyttää paketteihin."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Kortti hylätty. Ole hyvä ja yritä uudestaan."
+  },
+  "shopping_complete_rental": {
+    "other": "Tapahtuma hyväksytty"
+  },
   "shopping_complete_rental_period": {
     "one": "Voit nyt katsoa elokuvan niin monta kertaa kuin haluat seuraavan päivän aikana.",
     "other": "Voit nyt katsoa elokuvan niin monta kertaa kuin haluat seuraavien {{.Count}} päivän aikana."
   },
-  "shopping_complete_purchase": { "other": "Kiitos tuotteen {{.Title}} ostamisesta." },
-  "shopping_complete_credit_purchase": { "other": "Kiitos tuotteen {{.Title}} ostamisesta. {{.CreditTotal}} on lisätty tilillesi." },
-  "shopping_complete_purchase_coming_soon": { "other": "Voit katsoa elokuvaa {{.Date}} alkaen." },
-  "shopping_complete_receipt": { "other": "Kuitti on lähetetty sähköpostiisi." },
-  "shopping_complete_library_link": { "other": "Selaa kirjastoasi" },
+  "shopping_complete_purchase": {
+    "other": "Kiitos tuotteen {{.Title}} ostamisesta."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Kiitos tuotteen {{.Title}} ostamisesta. {{.CreditTotal}} on lisätty tilillesi."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Voit katsoa elokuvaa {{.Date}} alkaen."
+  },
+  "shopping_complete_receipt": {
+    "other": "Kuitti on lähetetty sähköpostiisi."
+  },
+  "shopping_complete_library_link": {
+    "other": "Selaa kirjastoasi"
+  },
   "shopping_complete_plan": {
     "other": "{{ .Title }} onnistui."
   },
-
   "shopping_complete_rental_watch_window_start": {
     "one": "Voit aloittaa katsomisen seuraavan päivän aikana.",
     "other": "Voit aloittaa katsomisen seuraavan {{.Count}} päivän aikana."
@@ -285,93 +637,211 @@
     "one": "Voit katsoa elokuvaa {{.Date}} alkaen, ja vuokrauksesi pysyy aktiivisena yhden päivän ajan.",
     "other": "Voit katsoa elokuvaa {{. .Date}} alkaen, ja vuokrauksesi pysyy aktiivisena {{.Count}} päivän ajan."
   },
-
-  "shopping_action_rent": { "other": "Vuokraa" },
-  "shopping_action_buy": { "other": "Osta" },
-
-  "meta_detail_cast_title": { "other": "Esiintyjät" },
-  "meta_detail_crew_title": { "other": "Tekijät" },
-  "meta_detail_languages": { "one": "Kieli", "other": "Kielet" },
-  "meta_detail_studios": { "one": "Tuotantoyhtiö", "other": "Tuotantoyhtiöt" },
-  "meta_detail_countries": { "one": "Maa", "other": "Maat" },
-  "meta_detail_subtitles": { "other": "Tekstitys" },
-  "meta_detail_captions": { "other": "Tekstitys [CC]" },
-  "meta_detail_episodes_title": { "other": "Jaksot" },
-  "meta_detail_bonus_title": { "other": "Bonusmateriaali" },
-  "meta_detail_recommendations_title": { "other": "Saatat pitää myös:" },
-  "meta_detail_bundle_items_title": { "other": "Tämän paketin sisältämät tuotteet" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} elokuvaa" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} kautta" },
-  "bundle_items_mixed": { "other": "{{.Count}} elokuvaa ja kautta" },
-
-  "userwishlist_page_header": { "other": "Listani" },
-  "userwishlist_slider_header": { "other": "Listani" },
-  "userwishlist_empty_header":  { "other": "Listasi on tyhjä." },
-  "userwishlist_empty_content": { "other": "Täydennä listaasi <a href=\"{{.HomeURL}}\">selaamalla</a> valikoimaamme." },
-  "userwishlist_button_add": { "other": "Lisää listaani" },
-  "userwishlist_button_remove": { "other": "Listani" },
-  "userwishlist_button_add_compact": { "other": "Listani" },
-  "userwishlist_button_remove_compact": { "other": "Listani" },
-
-  "userdevices_page_header": { "other": "Laitteeni" },
+  "shopping_action_rent": {
+    "other": "Vuokraa"
+  },
+  "shopping_action_buy": {
+    "other": "Osta"
+  },
+  "meta_detail_cast_title": {
+    "other": "Esiintyjät"
+  },
+  "meta_detail_crew_title": {
+    "other": "Tekijät"
+  },
+  "meta_detail_languages": {
+    "one": "Kieli",
+    "other": "Kielet"
+  },
+  "meta_detail_studios": {
+    "one": "Tuotantoyhtiö",
+    "other": "Tuotantoyhtiöt"
+  },
+  "meta_detail_countries": {
+    "one": "Maa",
+    "other": "Maat"
+  },
+  "meta_detail_subtitles": {
+    "other": "Tekstitys"
+  },
+  "meta_detail_captions": {
+    "other": "Tekstitys [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Jaksot"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Bonusmateriaali"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Saatat pitää myös:"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Tämän paketin sisältämät tuotteet"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} elokuvaa"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} kautta"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} elokuvaa ja kautta"
+  },
+  "userwishlist_page_header": {
+    "other": "Listani"
+  },
+  "userwishlist_slider_header": {
+    "other": "Listani"
+  },
+  "userwishlist_empty_header": {
+    "other": "Listasi on tyhjä."
+  },
+  "userwishlist_empty_content": {
+    "other": "Täydennä listaasi <a href=\"{{.HomeURL}}\">selaamalla</a> valikoimaamme."
+  },
+  "userwishlist_button_add": {
+    "other": "Lisää listaani"
+  },
+  "userwishlist_button_remove": {
+    "other": "Listani"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Listani"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Listani"
+  },
+  "userdevices_page_header": {
+    "other": "Laitteeni"
+  },
   "userdevices_page_content": {
     "one": "Käyttämäsi laitteet lisätään tähän automaattisesti. Käyttöoikeus on rajattu yhteen laitteeseen.",
     "other": "Käyttämäsi laitteet lisätään tähän automaattisesti. Käyttöoikeus on rajattu {{.Count}} laitteeseen."
   },
-  "userdevices_empty_content": { "other": "Tällä hetkellä käytössäsi on 0 rekisteröityä laitetta." },
-  "userdevices_header_type": { "other": "Laitetyyppi" },
-  "userdevices_header_description": { "other": "Kuvaus" },
-  "userdevices_device_added": { "other": "Lisätty {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Poista" },
-  "userdevices_device_actions_cancel": { "other": "Peru" },
-  "userdevices_device_actions_confirm": { "other": "Kyllä, poista laite" },
-  "userdevices_device_deleted": { "other": "(Poistettu)" },
-
-  "availability_coming_soon": { "other": "Tulossa" },
-  "availability_renting": { "other": "Vuokrattavissa" },
-  "availability_not_available": { "other": "Ei saatavissa" },
-  "availability_in_watch_window": { "other": "Saatavissa" },
-  "availability_sold_out": { "other": "Loppuunmyyty" },
-  "availability_available_till": { "other": "Saatavissa {{.ExpiryDate}} asti" },
-  "availability_not_available_in_country": { "other": "Ei saatavissa" },
-  "availability_available": { "other": "Katsottavissa {{.ReleaseDate}}" },
-  "availability_expires": { "other": "Poistuu {{.Expiry}}" },
-  "availability_expired": { "other": "Ei katsottavissa"},
-
-  "modal_cancel": { "other": "Peru" },
-
-  "play": { "other": "Toista" },
-
-  "pricing_ownership_buy": { "other": "Osta" },
-  "pricing_ownership_rent": { "other": "Vuokraa" },
-
-  "classification_intro": { "other": "Luokitus: " },
-
-  "cookie_banner_message": { "other": "Sivusto käyttää evästeitä parantaakseen käyttökokemustasi. Jatkamalla sivuston käyttöä hyväksyt <a href=\"/page/cookie-policy/\">käyttöehtomme</a>." },
-  "cookie_banner_accept": { "other": "Hyväksyä" },
-  "all_rights_reserved": { "other": "Kaikki oikeudet pidätetään. Sivustoa tai sen osia ei saa käyttää uudelleen ilman kirjallista lupaamme." },
-
-  "users_gender_none": { "other": "Ei määritelty" },
-  "users_gender_female": { "other": "Nainen" },
-  "users_gender_male": { "other": "Mies" },
-  "users_gender_diverse": { "other": "Ei-binäärinen" },
-  "users_gender_other": { "other": "Muu" },
-
-  "shopping_info_rental_period_coming_soon": { "other": "julkaisupäivästä ja -ajasta." },
-
-  "combined_auth_signin_prompt": { "other": "Kirjaudu" },
-  "combined_auth_signup_prompt": { "other": "Rekisteröidy" },
-  "combined_auth_terms": { "other": "Hyväksyn palvelun <a href=\"/page/terms-and-conditions/\" target=\"_blank\">käyttöehdot</a>." },
-  "signup_terms": { "other": "Hyväksyn palvelun <a href=\"/page/terms-and-conditions/\" target=\"_blank\">käyttöehdot</a>." },
-  "validation_terms_required": { "other": "Sinun on hyväksyttävä käyttöehdot." },
-
-  "shopping_error_item_limit_exceeded": { "other": "Valitettavasti {{.Title}} on loppuunmyyty." },
-
-  "app_badge_title": { "other": "Lataa sovellus nähdäksesi ostamasi sisällön!" },
-  "app_badge_ios": { "other": "Lataa App Storesta" },
-  "app_badge_android": { "other": "Hanki se Google Playsta" },
-
+  "userdevices_empty_content": {
+    "other": "Tällä hetkellä käytössäsi on 0 rekisteröityä laitetta."
+  },
+  "userdevices_header_type": {
+    "other": "Laitetyyppi"
+  },
+  "userdevices_header_description": {
+    "other": "Kuvaus"
+  },
+  "userdevices_device_added": {
+    "other": "Lisätty {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Poista"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Peru"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Kyllä, poista laite"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Poistettu)"
+  },
+  "availability_coming_soon": {
+    "other": "Tulossa"
+  },
+  "availability_renting": {
+    "other": "Vuokrattavissa"
+  },
+  "availability_not_available": {
+    "other": "Ei saatavissa"
+  },
+  "availability_in_watch_window": {
+    "other": "Saatavissa"
+  },
+  "availability_sold_out": {
+    "other": "Loppuunmyyty"
+  },
+  "availability_available_till": {
+    "other": "Saatavissa {{.ExpiryDate}} asti"
+  },
+  "availability_not_available_in_country": {
+    "other": "Ei saatavissa"
+  },
+  "availability_available": {
+    "other": "Katsottavissa {{.ReleaseDate}}"
+  },
+  "availability_expires": {
+    "other": "Poistuu {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Ei katsottavissa"
+  },
+  "modal_cancel": {
+    "other": "Peru"
+  },
+  "play": {
+    "other": "Toista"
+  },
+  "pricing_ownership_buy": {
+    "other": "Osta"
+  },
+  "pricing_ownership_rent": {
+    "other": "Vuokraa"
+  },
+  "classification_intro": {
+    "other": "Luokitus: "
+  },
+  "cookie_banner_message": {
+    "other": "Sivusto käyttää evästeitä parantaakseen käyttökokemustasi. Jatkamalla sivuston käyttöä hyväksyt <a href=\"/page/cookie-policy/\">käyttöehtomme</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Hyväksyä"
+  },
+  "all_rights_reserved": {
+    "other": "Kaikki oikeudet pidätetään. Sivustoa tai sen osia ei saa käyttää uudelleen ilman kirjallista lupaamme."
+  },
+  "users_gender_none": {
+    "other": "Ei määritelty"
+  },
+  "users_gender_female": {
+    "other": "Nainen"
+  },
+  "users_gender_male": {
+    "other": "Mies"
+  },
+  "users_gender_diverse": {
+    "other": "Ei-binäärinen"
+  },
+  "users_gender_other": {
+    "other": "Muu"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "julkaisupäivästä ja -ajasta."
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Kirjaudu"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Rekisteröidy"
+  },
+  "combined_auth_terms": {
+    "other": "Hyväksyn palvelun <a href=\"/page/terms-and-conditions/\" target=\"_blank\">käyttöehdot</a>."
+  },
+  "signup_terms": {
+    "other": "Hyväksyn palvelun <a href=\"/page/terms-and-conditions/\" target=\"_blank\">käyttöehdot</a>."
+  },
+  "validation_terms_required": {
+    "other": "Sinun on hyväksyttävä käyttöehdot."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Valitettavasti {{.Title}} on loppuunmyyty."
+  },
+  "app_badge_title": {
+    "other": "Lataa sovellus nähdäksesi ostamasi sisällön!"
+  },
+  "app_badge_ios": {
+    "other": "Lataa App Storesta"
+  },
+  "app_badge_android": {
+    "other": "Hanki se Google Playsta"
+  },
   "shopping_price_title_plan": {
     "other": "Hinta"
   },
@@ -443,112 +913,257 @@
   "donate_button_text": {
     "other": "Lahjoittaa"
   },
-
-  "wcag_skip_links_header": { "other": "Esteettömyyslinkit" },
-  "wcag_skip_links_content": { "other": "Siirry sisältöön" },
-
-  "wcag_homepage_h1": { "other": "Kotisivu" },
-  "wcag_carousel_h2": { "other": "Karuselli" },
-  "wcag_collections_h2": { "other": "kokoelma" },
-
-  "wcag_aria_label_footer": { "other": "Alatunniste" },
-  "wcag_aria_label_nav_main": { "other": "Tärkein" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Navigointi päälle/pois" },
-  "wcag_aria_label_bundle_items": { "other": "Niputa kohteita" },
-  "wcag_aria_label_carousel": { "other": "Karuselli" },
-  "wcag_aria_label_page_collection": { "other": "Sivujen kokoelma" },
-  "wcag_aria_label_collection_list": { "other": "Kokoelmaluettelo" },
-  "wcag_aria_label_collection_slider": { "other": "Kokoelman liukusäädin" },
-  "wcag_aria_label_wishlist": { "other": "Toivelista" },
-  "wcag_aria_label_facebook": { "other": "Jaa Facebookissa" },
-  "wcag_aria_label_twitter": { "other": "Jaa Twitterissä" },
-  "wcag_aria_label_linkedin": { "other": "Jaa LinkedInissä" },
-  "wcag_aria_label_letterboxd": { "other": "Katso Letterboxd" },
-  
-  "shopping_error_plan_already_owned": { "other": "Sinulla on jo tämä suunnitelma." },
-  "shopping_error_plan_expired": { "other": "Tämä suunnitelma ei ole enää saatavilla." },
-  "shopping_payment_method_header": { "other": "Maksutavat" },
-  "shopping_payment_method_credit_card": { "other": "Luottokortti" },
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  "shopping_error_stripe_unknown_error": { "other": "Jotain meni pieleen tässä maksussa. Yritä uudelleen myöhemmin." },
-  "shopping_error_payment_complete_failed": { "other": "Maksu hylätty. Sulje tämä ikkuna ja yritä uudelleen." },
-
-  "header_banner": { "other": "otsikkobanneri" },
-
-  "account_form_pin_code": { "other": "Pin-koodi" },
-  "account_form_pin_code_not_set": { "other": "Luo PIN-koodi nähdäksesi tämän sisällön"},
-  "account_form_set_pin": { "other": "Aseta PIN-koodi" },
-  "account_form_pin_changed": { "other": "Päivitetty" },
-  "account_form_change_pin": { "other": "Vaihda PIN" },
-
-  "user_set_pin_header": { "other": "Aseta PIN-koodi" },
-  "user_set_pin_button": { "other": "Aseta PIN" },
-  "user_submit_pin_heading": { "other": "Kirjoita PIN-koodisi {{.Action}} tälle rajoitetulle sisällölle" },
-  "user_error_wrong_pin_retry": { "other": "Hups, annoit väärän PIN-koodin" },
-  "user_submit_pin_button": { "other": "Mennä" },
-  "user_reset_pin_button": { "other": "Palauta PIN" },
-
-  "validation_pincode1_required": { "other": "Anna kelvollinen PIN-koodi." },
-  "validation_pincode2_required": { "other": "Anna kelvollinen PIN-koodi." },
-  "validation_pincode1_pattern": { "other": "Anna kelvollinen PIN-koodi." },
-  "validation_pincode2_pattern": { "other": "Anna kelvollinen PIN-koodi." },
-  "validation_pincode2_match": { "other": "PIN-koodi ei täsmää." },
-
-  "userdevices_delete_limits": { "other": "Voit poistaa {{.Limit}} laite(t) tästä luettelosta {{.Period}} päivässä."},
-  "userdevices_delete_limit_reached": { "other": "Olet saavuttanut tämän rajan, etkä voi poistaa laitteita juuri nyt. Voit poistaa laitteesi {{.Days}} päivässä." },
-  "shopping_card_new_subscription": { "other": "Tämä kortti tallennetaan ja sitä veloitetaan säännöllisesti" },
-
-"changepincode_modal_header": { "other": "Vaihda PIN-koodisi" },
-"changepincode_modal_currentpassword": { "other": "Nykyinen salasanasi" },
-"changepincode_modal_pincode1": { "other": "Uusi 4-numeroinen PIN-koodisi" },
-"changepincode_modal_pincode2": { "other": "Vahvista uusi 4-numeroinen PIN-koodisi" },
-"changepincode_modal_submit": { "other": "Aseta PIN-koodi" },
-"changepincode_modal_error_wrong_password": { "other": "Salasana on väärä." },
-
-"user_set_pin_intro": { "other": "Tarvitset PIN-koodin {{.Action}} ikärajoitettu sisältö"},
-"user_error_wrong_pin_reset": { "other": "Napsauta tätä nollataksesi PIN-koodisi" },
-"user_error_too_many_pin_errors_help_page_link": { "other": "" },
-"shopping_error_age_restricted": { "other": "Tämä sisältö on ikärajoitettu." },
-"shopping_error_close_button": { "other": "OK" }, 
-
-"usersubscriptions_subscription_expiry": { "other": "Vanhenee {{.Expiry}}" },
-"usersubscriptions_subscription_status_trialing": { "other": "Testijakso" },
-"usersubscriptions_subscription_unsubscribe": { "other": "Peruuta tilaukseni" },
-"usersubscriptions_unsubscribe_modal_cancel": { "other": "Peruuttaa" },
-"usersubscriptions_unsubscribe_modal_confirm": { "other": "Kyllä, peruuta tilaukseni" },
-"usersubscriptions_unsubscribe_modal_title": { "other": "Peruuta tilaus?" },
-"usersubscriptions_unsubscribe_modal_body": { "other": "Tämä peruuttaa {{.Name}}-tilauksen. Voit silti tarkastella suunnitelman sisältöä sen voimassaolon päättymiseen asti {{.Expiry}}." },
-
-"signin_form_error_account_suspended": { "other": "Tilisi on väliaikaisesti jäädytetty. Ota yhteyttä järjestelmänvalvojaan, jos uskot tämän olevan virhe." },
-
-
-
-
-"pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "Vain HD" },
-  "pricing_quality_sd_only": { "other": "Vain SD" },
-
-  "shopping_card_save_card": { "other": "Säilytä tämä kortti tulevaa tarvetta varten" },
-  "shopping_card_button_change": { "other": "Näytä kaikki tallennetut kortit" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} päättyy {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(päättyy {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(vanhentunut)" },
-  "shopping_card_use_other": { "other": "Käytä uutta korttia" },
-  "shopping_card_use_new_card": { "other": "Vaihda kortti" },
-  "shopping_card_update_reason_none": { "other": "Päivitä luottokorttisi. Tuetut kortit ovat Visa, Mastercard ja American Express." },
-  "shopping_info_ownership_plan": { "other": "Tilaus" },
-  "shopping_action_credit": { "other": "Täytä" },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Vaihda luottokorttisi" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Päivitä luottokorttitietosi" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Päivittää" },
-
-  "seasons":{
+  "wcag_skip_links_header": {
+    "other": "Esteettömyyslinkit"
+  },
+  "wcag_skip_links_content": {
+    "other": "Siirry sisältöön"
+  },
+  "wcag_homepage_h1": {
+    "other": "Kotisivu"
+  },
+  "wcag_carousel_h2": {
+    "other": "Karuselli"
+  },
+  "wcag_collections_h2": {
+    "other": "kokoelma"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Alatunniste"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Tärkein"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Navigointi päälle/pois"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Niputa kohteita"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Karuselli"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Sivujen kokoelma"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Kokoelmaluettelo"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Kokoelman liukusäädin"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Toivelista"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Jaa Facebookissa"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Jaa Twitterissä"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Jaa LinkedInissä"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Katso Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Sinulla on jo tämä suunnitelma."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Tämä suunnitelma ei ole enää saatavilla."
+  },
+  "shopping_payment_method_header": {
+    "other": "Maksutavat"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Luottokortti"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Jotain meni pieleen tässä maksussa. Yritä uudelleen myöhemmin."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Maksu hylätty. Sulje tämä ikkuna ja yritä uudelleen."
+  },
+  "header_banner": {
+    "other": "otsikkobanneri"
+  },
+  "account_form_pin_code": {
+    "other": "Pin-koodi"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Luo PIN-koodi nähdäksesi tämän sisällön"
+  },
+  "account_form_set_pin": {
+    "other": "Aseta PIN-koodi"
+  },
+  "account_form_pin_changed": {
+    "other": "Päivitetty"
+  },
+  "account_form_change_pin": {
+    "other": "Vaihda PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Aseta PIN-koodi"
+  },
+  "user_set_pin_button": {
+    "other": "Aseta PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Kirjoita PIN-koodisi {{.Action}} tälle rajoitetulle sisällölle"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Hups, annoit väärän PIN-koodin"
+  },
+  "user_submit_pin_button": {
+    "other": "Mennä"
+  },
+  "user_reset_pin_button": {
+    "other": "Palauta PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "Anna kelvollinen PIN-koodi."
+  },
+  "validation_pincode2_required": {
+    "other": "Anna kelvollinen PIN-koodi."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Anna kelvollinen PIN-koodi."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Anna kelvollinen PIN-koodi."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN-koodi ei täsmää."
+  },
+  "userdevices_delete_limits": {
+    "other": "Voit poistaa {{.Limit}} laite(t) tästä luettelosta {{.Period}} päivässä."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Olet saavuttanut tämän rajan, etkä voi poistaa laitteita juuri nyt. Voit poistaa laitteesi {{.Days}} päivässä."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Tämä kortti tallennetaan ja sitä veloitetaan säännöllisesti"
+  },
+  "changepincode_modal_header": {
+    "other": "Vaihda PIN-koodisi"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Nykyinen salasanasi"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Uusi 4-numeroinen PIN-koodisi"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Vahvista uusi 4-numeroinen PIN-koodisi"
+  },
+  "changepincode_modal_submit": {
+    "other": "Aseta PIN-koodi"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Salasana on väärä."
+  },
+  "user_set_pin_intro": {
+    "other": "Tarvitset PIN-koodin {{.Action}} ikärajoitettu sisältö"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Napsauta tätä nollataksesi PIN-koodisi"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Tämä sisältö on ikärajoitettu."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Vanhenee {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Testijakso"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Peruuta tilaukseni"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Peruuttaa"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Kyllä, peruuta tilaukseni"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Peruuta tilaus?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Tämä peruuttaa {{.Name}}-tilauksen. Voit silti tarkastella suunnitelman sisältöä sen voimassaolon päättymiseen asti {{.Expiry}}."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Tilisi on väliaikaisesti jäädytetty. Ota yhteyttä järjestelmänvalvojaan, jos uskot tämän olevan virhe."
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "Vain HD"
+  },
+  "pricing_quality_sd_only": {
+    "other": "Vain SD"
+  },
+  "shopping_card_save_card": {
+    "other": "Säilytä tämä kortti tulevaa tarvetta varten"
+  },
+  "shopping_card_button_change": {
+    "other": "Näytä kaikki tallennetut kortit"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} päättyy {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(päättyy {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(vanhentunut)"
+  },
+  "shopping_card_use_other": {
+    "other": "Käytä uutta korttia"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Vaihda kortti"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Päivitä luottokorttisi. Tuetut kortit ovat Visa, Mastercard ja American Express."
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Tilaus"
+  },
+  "shopping_action_credit": {
+    "other": "Täytä"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Vaihda luottokorttisi"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Päivitä luottokorttitietosi"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Päivittää"
+  },
+  "seasons": {
     "one": "yksi kausi",
     "other": "{{.Count}} vuodenajat"
-  },"tvseason": {
+  },
+  "tvseason": {
     "other": "{{.ShowInfo.Title}} Kausi {{.Season.SeasonNumber}}"
   },
   "tvseason_html": {
@@ -564,32 +1179,70 @@
     "one": "1 Jakso",
     "other": "{{.Count}} Jaksot"
   },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Sinulla näyttää olevan ongelmia.</p><p>Nollaa PIN-koodi tai ota meihin yhteyttä saadaksesi apua <a href=\"{{.HelpURL}}\" target=\"_blank\">apua</a>" },
-  "validation_pincode_required": { "other": "Anna PIN-koodi." },
-
-  "shopping_info_subtitle_hd": { "other": "HD Video on Demand." },
-  "shopping_info_subtitle_sd": { "other": "SD Video on Demand." },
-  "shopping_info_subtitle_wallet": { "other": "Walletissasi olevia varoja voidaan käyttää minkä tahansa sisällön ostamiseen tai vuokraamiseen ScreenPlus." },
- 
-  "shopping_info_sd_only": { "other": "Rajoitettu vain SD-toistoon." },
-  "shopping_error_discount_worn_out": { "other": "Tätä tarjouskoodia ei voi enää käyttää." },
-
-  "activatedevice_page_header": { "other": "Aktivoi laite" },
-  "activatedevice_page_content": { "other": "Hanki PIN-koodi noudattamalla laitteesi ohjeita. Sekä tietokoneesi että laitteesi on oltava yhteydessä Internetiin aktivoimista varten." },
-  "activatedevice_form_pin": { "other": "Pin-koodi" },
-  "activatedevice_form_submit": { "other": "Aktivoida" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN-koodia ei löydy, yritä uudelleen." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN-koodia ei löydy, yritä uudelleen." },
-  "activatedevice_signin_prompt": { "other": "Kirjaudu sisään ennen laitteesi aktivoimista." },
-  "activatedevice_page_activated": { "other": "Kiitos aktivoinnistasi {{.DeviceName}}. Sinun pitäisi nyt pystyä selaamaan kirjastoasi televisiollasi tai laitteellasi." },
-
-  "playlist_page_header": { "other": "Soittolista" },
-  "playlist_sign_in_warning": { "other": "Kirjaudu sisään katsoaksesi live-TV:tä."},
-  "playlist_share_title": { "other": "Soittolista" },
-  "playlist_up_next_title": { "other": "Seuraava" },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-  "shopping_card_change": { "other": "Luottokortti ei ole oikea?? <a href=\"{{.SubscriptionsURL}}\">Napsauta tätä päivittääksesi korttisi</a>" }
-
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Sinulla näyttää olevan ongelmia.</p><p>Nollaa PIN-koodi tai ota meihin yhteyttä saadaksesi apua <a href=\"{{.HelpURL}}\" target=\"_blank\">apua</a>"
+  },
+  "validation_pincode_required": {
+    "other": "Anna PIN-koodi."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Video on Demand."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video on Demand."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Walletissasi olevia varoja voidaan käyttää minkä tahansa sisällön ostamiseen tai vuokraamiseen ScreenPlus."
+  },
+  "shopping_info_sd_only": {
+    "other": "Rajoitettu vain SD-toistoon."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Tätä tarjouskoodia ei voi enää käyttää."
+  },
+  "activatedevice_page_header": {
+    "other": "Aktivoi laite"
+  },
+  "activatedevice_page_content": {
+    "other": "Hanki PIN-koodi noudattamalla laitteesi ohjeita. Sekä tietokoneesi että laitteesi on oltava yhteydessä Internetiin aktivoimista varten."
+  },
+  "activatedevice_form_pin": {
+    "other": "Pin-koodi"
+  },
+  "activatedevice_form_submit": {
+    "other": "Aktivoida"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN-koodia ei löydy, yritä uudelleen."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN-koodia ei löydy, yritä uudelleen."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Kirjaudu sisään ennen laitteesi aktivoimista."
+  },
+  "activatedevice_page_activated": {
+    "other": "Kiitos aktivoinnistasi {{.DeviceName}}. Sinun pitäisi nyt pystyä selaamaan kirjastoasi televisiollasi tai laitteellasi."
+  },
+  "playlist_page_header": {
+    "other": "Soittolista"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Kirjaudu sisään katsoaksesi live-TV:tä."
+  },
+  "playlist_share_title": {
+    "other": "Soittolista"
+  },
+  "playlist_up_next_title": {
+    "other": "Seuraava"
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "shopping_card_change": {
+    "other": "Luottokortti ei ole oikea?? <a href=\"{{.SubscriptionsURL}}\">Napsauta tätä päivittääksesi korttisi</a>"
+  }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1,25 +1,44 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Paramètres" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "ScreenPlus" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "Anglais" },
-  "fr": { "other": "Français" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Paramètres"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "ScreenPlus"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "Anglais"
+  },
+  "fr": {
+    "other": "Français"
+  },
   "episode_name": {
     "other": "Épisode"
   },
-
   "season_name": {
     "other": "Saison"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "un saison",
     "other": "{{.Count}} saisons"
   },
@@ -39,187 +58,459 @@
     "one": "1 Épisode",
     "other": "{{.Count}} Épisodes"
   },
-
-  "date_day": { "other": "Jour" },
-  "date_month": { "other": "Mois" },
-  "date_year": { "other": "Année" },
-
-  "404_page_header": { "other": "Cette page n'existe pas..." },
-  "404_page_content": { "other": "<p>Désolée, la page que vous essayez de consulter n'existe pas.</p><p>Il se peut qu'elle ait été déplacée ou supprimée, ou peut-être il y a une erreur de saisie.</p><p>Veuillez retourner à la page d'accueil pour essayer de retrouver ce que vous cherchiez.</p><p><a href=\"{{.URL}}\">Retour à la page d'accueil</a></p>" },
-
-  "nav_signin": { "other": "Se connecter" },
-  "nav_signup": { "other": "Créer un compte" },
-  "nav_signed_in_as": { "other": "Connecté en tant que" },
-  "nav_library": { "other": "Ma bibliothèque" },
-  "nav_devices": { "other": "Mes appareils" },
-  "nav_wishlist": { "other": "Ma liste" },
-  "nav_account": { "other": "Mon compte" },
-  "nav_signout": { "other": "Déconnexion" },
-  "play_trailer": { "other": "Bande annonce" },
-  "runtime_hours": { "other": "h" },
-  "runtime_minutes": { "other": "m" },
-
-  "datetime_today": { "other": "aujourd'hui {{.Date}}" },
-  "datetime_tomorrow": { "other": "demain {{.Date}}" },
-  "datetime_yesterday": { "other": "hier {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "{{.Date}}" },
-
-  "search_control_placeholder": { "other": "Rechercher" },
-
-  "play_button_watch": { "other" : "Voir le film"},
-  "play_button_resume": { "other" : "Continuer"},
-
-  "social_media_buttons_title": { "other": "Partager" },
-  "social_media_buttons_facebook": { "other": "Partager sur Facebook" },
-  "social_media_buttons_twitter": { "other": "Partager sur Twitter" },
-  "social_media_buttons_linkedin": { "other": "Partager sur Linkedin" },
-  "social_media_buttons_email": { "other": "Partager par e-mail" },
-  "social_media_buttons_email_subject": { "other": "Lien de partage" },
-  "social_media_buttons_copied_link": { "other": "Lien copié dans le presse-papiers !" },
-  "social_media_buttons_copy_link": { "other": "Copier dans le presse-papier" },
-
-  "accept_invite_page_header": { "other": "Bienvenue " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Il semble que vous ayez déjà utilisé ce lien, vous devriez essayer de <a href=\"{{.SigninURL}}\">vous connecter</a>. Si vous avez oublié votre mot de passe, vous pouvez aussi <a href=\"{{.ForgotPasswordURL}}\">réinitialiser votre mot de passe</a>." },
-  "acceptinvite_complete": { "other": "Merci, votre compte a bien été créé." },
-  "acceptinvite_form_submit": { "other": "Accepter l'invitation" },
-  "acceptinvite_agreement": { "other": "En cliquant sur \"Accepter l'invitation\", vous reconnaissez avoir lu et accepté les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termes &amp; conditions</a> et <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">notre politique de confidentialité</a>." },
-
-  "signup_page_header": { "other": "Créer un compte" },
-  "signup_form_name": { "other": "Nom" },
-  "signup_form_email": { "other": "Adresse électronique" },
-  "signup_form_password": { "other": "Mot de passe" },
-  "signup_form_password_confirmation": { "other": "Confirmer votre mot de passe" },
-  "signup_form_gender": { "other": "Genre" },
-  "signup_form_dob": { "other": "Date de naissance" },
-  "signup_form_submit": { "other": "Valider" },
-
-  "signin_page_header": { "other": "Se connecter" },
-  "signin_form_email": { "other": "Adresse électronique" },
-  "signin_form_password": { "other": "Mot de passe" },
-  "signin_form_remember": { "other": "Se souvenir de moi" },
-  "signin_form_submit": { "other": "Valider" },
-  "signin_page_forgotpassword": { "other": "Mot de passe oublié?" },
-  "signin_page_createnewaccount": { "other": "Créer un nouveau compte" },
-  "signup_page_alreadyhaveanaccount": { "other": "Vous avez déjà un compte? Se connecter ici" },
-  "signup_form_error_email_already_in_use": { "other": "Cette adresse email est déjà utilisée." },
-  "signin_form_error_incorrect_credentials": { "other": "Le pseudo ou mot de passe est incorect." },
-  "signup_form_error_forbidden": { "other": "Une erreur est survenue." },
-
-  "combined_auth_continue": { "other": "Continuer" },
-  "combined_auth_change": { "other": "changement" },
-  "combined_auth_signin": { "other": "Se connecter" },
-  "combined_auth_signup": { "other": "Créer un compte" },
-  "combined_auth_signin_password": { "other": "Veuillez entrer un mot de passe." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Le mot de passe est incorrect." },
-  "combined_auth_error_forbidden": { "other": "Une erreur est survenue." },
-  "combined_auth_error_too_many_requests": { "other": "Il y a trop de demandes. S'il-vous-plait réessayez plus tard." },
-
-  "forgotpassword_page_header": { "other": "Récupérer votre mot de passe" },
-  "forgotpassword_form_email": { "other": "Adresse électronique" },
-  "forgotpassword_form_submit": { "other": "Valider" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Aucun compte existant ne correspond à cette adresse email." },
-  "forgotpassword_form_error_account_suspended": { "other": "Ce compte est suspendu." },
-  "forgotpassword_complete": { "other": "Merci. Vous allez recevoir rapidement un email de réinitialisation du mot de passe dans votre boîte de réception." },
-  "forgotpassword_form_error_forbidden": { "other": "Une erreur est survenue." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Il y a trop de demandes. S'il-vous-plait réessayez plus tard." },
-
-  "resetpassword_page_header": { "other": "Changez votre mot de passe" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Il semble que cette demande de réinitialisation du mot de passe ne soit pas valide, merci de remplir à nouveau le formulaire de <a href=\"{{.URL}}\">Réinitialisation du Mot de passe</a>." },
-  "resetpassword_form_password": { "other": "Nouveau mot de passe" },
-  "resetpassword_form_password2": { "other": "Confirmer votre mot de passe" },
-  "resetpassword_form_submit": { "other": "Modifier" },
-  "resetpassword_complete": { "other": "Merci, votre mot de passe a bien été modifié. Vous êtes maintenant connecté." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "La demande de réinitialisation est invalide. Veuillez réessayer ultérieurement." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Le lien de réinitialisation du mot de passe a expiré. Veuillez en demander un nouveau." },
-  "resetpassword_form_error_too_many_requests": { "other": "Il y a trop de demandes. S'il-vous-plait réessayez plus tard." },
-
-  "account_page_header": { "other": "Mon compte" },
-  "account_form_name": { "other": "Nom" },
-  "account_form_email": { "other": "Adresse électronique" },
-  "account_form_password": { "other": "Mot de passe" },
-  "account_form_change_password": { "other": "Modifier" },
-  "account_form_gender": { "other": "Genre" },
-  "account_form_dob": { "other": "Date de naissance" },
-  "account_form_submit": { "other": "Mettre à jour" },
-  "account_form_submitted": { "other": "Mis à jour" },
-  "account_form_password_changed": { "other": "Mis à jour" },
-  "account_form_error_incorrect_password": { "other": "Le mot de passe est incorrect." },
-
-  "signup_form_optin": {"other": "Inscrivez-vous à notre newsletter"},
-
-  "passwordconfirmation_modal_header": { "other": "Confirmer votre mot de passe" },
-  "passwordconfirmation_modal_label": { "other": "Confirmer votre mot de passe" },
-  "passwordconfirmation_modal_confirm": { "other": "Confirmer" },
-
-  "changepassword_modal_header": { "other": "Changez votre mot de passe" },
-  "changepassword_modal_currentpassword": { "other": "Mot de passe actuel" },
-  "changepassword_modal_password": { "other": "Nouveau mot de passe" },
-  "changepassword_modal_password2": { "other": "Confirmez votre nouveau mot de passe" },
-  "changepassword_modal_submit": { "other": "Mise à jour" },
-  "changepassword_modal_error_incorrect_password": { "other": "Le mot de passe est incorrect." },
-
-  "userlibrary_page_header": { "other": "Ma bibliothèque" },
-  "userlibrary_empty_header":  { "other": "Votre bibliothèque est vide." },
-  "userlibrary_empty_content": { "other": "Remplissez-le en <a href=\"{{.HomeURL}}\">naviguant</a> sur notre grande sélection." },
-
-  "searchresults_page_header": { "other": "Résultats de recherche" },
-  "searchresults_load_more": { "other": "Afficher {{.Count}} de plus" },
+  "date_day": {
+    "other": "Jour"
+  },
+  "date_month": {
+    "other": "Mois"
+  },
+  "date_year": {
+    "other": "Année"
+  },
+  "404_page_header": {
+    "other": "Cette page n'existe pas..."
+  },
+  "404_page_content": {
+    "other": "<p>Désolée, la page que vous essayez de consulter n'existe pas.</p><p>Il se peut qu'elle ait été déplacée ou supprimée, ou peut-être il y a une erreur de saisie.</p><p>Veuillez retourner à la page d'accueil pour essayer de retrouver ce que vous cherchiez.</p><p><a href=\"{{.URL}}\">Retour à la page d'accueil</a></p>"
+  },
+  "nav_signin": {
+    "other": "Se connecter"
+  },
+  "nav_signup": {
+    "other": "Créer un compte"
+  },
+  "nav_signed_in_as": {
+    "other": "Connecté en tant que"
+  },
+  "nav_library": {
+    "other": "Ma bibliothèque"
+  },
+  "nav_devices": {
+    "other": "Mes appareils"
+  },
+  "nav_wishlist": {
+    "other": "Ma liste"
+  },
+  "nav_account": {
+    "other": "Mon compte"
+  },
+  "nav_signout": {
+    "other": "Déconnexion"
+  },
+  "play_trailer": {
+    "other": "Bande annonce"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "m"
+  },
+  "datetime_today": {
+    "other": "aujourd'hui {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "demain {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "hier {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "{{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Rechercher"
+  },
+  "play_button_watch": {
+    "other": "Voir le film"
+  },
+  "play_button_resume": {
+    "other": "Continuer"
+  },
+  "social_media_buttons_title": {
+    "other": "Partager"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Partager sur Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Partager sur Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Partager sur Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Partager par e-mail"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Lien de partage"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Lien copié dans le presse-papiers !"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Copier dans le presse-papier"
+  },
+  "accept_invite_page_header": {
+    "other": "Bienvenue "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Il semble que vous ayez déjà utilisé ce lien, vous devriez essayer de <a href=\"{{.SigninURL}}\">vous connecter</a>. Si vous avez oublié votre mot de passe, vous pouvez aussi <a href=\"{{.ForgotPasswordURL}}\">réinitialiser votre mot de passe</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Merci, votre compte a bien été créé."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Accepter l'invitation"
+  },
+  "acceptinvite_agreement": {
+    "other": "En cliquant sur \"Accepter l'invitation\", vous reconnaissez avoir lu et accepté les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termes &amp; conditions</a> et <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">notre politique de confidentialité</a>."
+  },
+  "signup_page_header": {
+    "other": "Créer un compte"
+  },
+  "signup_form_name": {
+    "other": "Nom"
+  },
+  "signup_form_email": {
+    "other": "Adresse électronique"
+  },
+  "signup_form_password": {
+    "other": "Mot de passe"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Confirmer votre mot de passe"
+  },
+  "signup_form_gender": {
+    "other": "Genre"
+  },
+  "signup_form_dob": {
+    "other": "Date de naissance"
+  },
+  "signup_form_submit": {
+    "other": "Valider"
+  },
+  "signin_page_header": {
+    "other": "Se connecter"
+  },
+  "signin_form_email": {
+    "other": "Adresse électronique"
+  },
+  "signin_form_password": {
+    "other": "Mot de passe"
+  },
+  "signin_form_remember": {
+    "other": "Se souvenir de moi"
+  },
+  "signin_form_submit": {
+    "other": "Valider"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Mot de passe oublié?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Créer un nouveau compte"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Vous avez déjà un compte? Se connecter ici"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Cette adresse email est déjà utilisée."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Le pseudo ou mot de passe est incorect."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Une erreur est survenue."
+  },
+  "combined_auth_continue": {
+    "other": "Continuer"
+  },
+  "combined_auth_change": {
+    "other": "changement"
+  },
+  "combined_auth_signin": {
+    "other": "Se connecter"
+  },
+  "combined_auth_signup": {
+    "other": "Créer un compte"
+  },
+  "combined_auth_signin_password": {
+    "other": "Veuillez entrer un mot de passe."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Le mot de passe est incorrect."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Une erreur est survenue."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Il y a trop de demandes. S'il-vous-plait réessayez plus tard."
+  },
+  "forgotpassword_page_header": {
+    "other": "Récupérer votre mot de passe"
+  },
+  "forgotpassword_form_email": {
+    "other": "Adresse électronique"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Valider"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Aucun compte existant ne correspond à cette adresse email."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Ce compte est suspendu."
+  },
+  "forgotpassword_complete": {
+    "other": "Merci. Vous allez recevoir rapidement un email de réinitialisation du mot de passe dans votre boîte de réception."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Une erreur est survenue."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Il y a trop de demandes. S'il-vous-plait réessayez plus tard."
+  },
+  "resetpassword_page_header": {
+    "other": "Changez votre mot de passe"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Il semble que cette demande de réinitialisation du mot de passe ne soit pas valide, merci de remplir à nouveau le formulaire de <a href=\"{{.URL}}\">Réinitialisation du Mot de passe</a>."
+  },
+  "resetpassword_form_password": {
+    "other": "Nouveau mot de passe"
+  },
+  "resetpassword_form_password2": {
+    "other": "Confirmer votre mot de passe"
+  },
+  "resetpassword_form_submit": {
+    "other": "Modifier"
+  },
+  "resetpassword_complete": {
+    "other": "Merci, votre mot de passe a bien été modifié. Vous êtes maintenant connecté."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "La demande de réinitialisation est invalide. Veuillez réessayer ultérieurement."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Le lien de réinitialisation du mot de passe a expiré. Veuillez en demander un nouveau."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Il y a trop de demandes. S'il-vous-plait réessayez plus tard."
+  },
+  "account_page_header": {
+    "other": "Mon compte"
+  },
+  "account_form_name": {
+    "other": "Nom"
+  },
+  "account_form_email": {
+    "other": "Adresse électronique"
+  },
+  "account_form_password": {
+    "other": "Mot de passe"
+  },
+  "account_form_change_password": {
+    "other": "Modifier"
+  },
+  "account_form_gender": {
+    "other": "Genre"
+  },
+  "account_form_dob": {
+    "other": "Date de naissance"
+  },
+  "account_form_submit": {
+    "other": "Mettre à jour"
+  },
+  "account_form_submitted": {
+    "other": "Mis à jour"
+  },
+  "account_form_password_changed": {
+    "other": "Mis à jour"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Le mot de passe est incorrect."
+  },
+  "signup_form_optin": {
+    "other": "Inscrivez-vous à notre newsletter"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Confirmer votre mot de passe"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Confirmer votre mot de passe"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Confirmer"
+  },
+  "changepassword_modal_header": {
+    "other": "Changez votre mot de passe"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Mot de passe actuel"
+  },
+  "changepassword_modal_password": {
+    "other": "Nouveau mot de passe"
+  },
+  "changepassword_modal_password2": {
+    "other": "Confirmez votre nouveau mot de passe"
+  },
+  "changepassword_modal_submit": {
+    "other": "Mise à jour"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Le mot de passe est incorrect."
+  },
+  "userlibrary_page_header": {
+    "other": "Ma bibliothèque"
+  },
+  "userlibrary_empty_header": {
+    "other": "Votre bibliothèque est vide."
+  },
+  "userlibrary_empty_content": {
+    "other": "Remplissez-le en <a href=\"{{.HomeURL}}\">naviguant</a> sur notre grande sélection."
+  },
+  "searchresults_page_header": {
+    "other": "Résultats de recherche"
+  },
+  "searchresults_load_more": {
+    "other": "Afficher {{.Count}} de plus"
+  },
   "searchresults_total": {
     "one": "1 résultat trouvé pour \"{{.Query}}\".",
     "other": "{{.Count}} résultats trouvés pour \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "Aucun résultat trouvé pour \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Veuillez faire une nouvelle recherche ou <a href=\"{{.HomeURL}}\">parcourir notre contenu</a> pour trouver ce que vous cherchez." },
-
-  "validation_name_required": { "other": "S'il vous plaît entrez votre nom." },
-  "validation_email_required": { "other": "S'il vous plaît entrer votre adresse e-mail." },
-  "validation_email_email": { "other": "S'il vous plaît, mettez une adresse email valide." },
-  "validation_currentpassword_required": { "other": "S'il vous plaît entrez votre mot de passe actuel." },
-  "validation_password_required": { "other": "Veuillez entrer un mot de passe." },
-  "validation_password2_required": { "other": "S'il vous plaît confirmer votre mot de passe." },
-  "validation_password2_match": { "other": "Vos mots de passe ne correspondent pas." },
-  "validation_password_minlength": { "other": "S'il vous plaît entrer au moins {{.Count}} caractères." },
-  "validation_promocode_required": { "other": "Veuillez saisir un code promo." },
-  "validation_pincode_required": { "other": "Veuillez saisir un code PIN." },
-  "validation_gender_required": { "other": "Veuillez sélectionner le genre auquel vous vous identifiez le plus." },
-  "validation_dob_required": { "other": "Veuillez saisir votre date de naissance." },
-  "validation_dob_date": { "other": "Veuillez saisir une date de naissance valide." },
-
-  "availability_not_available_in_country": { "other": "Non disponible" },
-  "availability_coming_soon": { "other": "Bientôt disponible" },
-  "availability_available_till": { "other": "Disponible jusqu’au {{.ExpiryDate}}" },
-  "availability_available": { "other": "Disponible {{.ReleaseDate}}" },
-  "availability_sold_out": { "other": "Épuisé" },
-  "availability_expires": { "other": "Expire {{.Expiry}}" },
-  "availability_expired": { "other": "Expiré"},
-
-  "modal_cancel": { "other": "Annuler" },
-
-  "validation_terms_required": { "other": "Veuillez lire et accepter nos termes et conditions." },
-
-  "shopping_info_subtitle_hd": { "other": "Vidéo HD à la demande." },
-  "shopping_info_subtitle_sd": { "other": "Vidéo SD à la demande." },
-  "shopping_info_subtitle_wallet": { "other": "Les fonds de votre portefeuille peuvent être utilisés pour l'achat ou la location de tout contenu sur ScreenPlu." },
-  "shopping_info_subtitle_help": { "other": "Voir ici pour la configuration système requise." },
-  "shopping_info_ownership_buy": { "other": "achat" },
-  "shopping_info_ownership_rent": { "other": "location" },
-
-  "shopping_info_sd_only": { "other": "Limité à la lecture SD uniquement." },
-  "shopping_info_release_date_title": { "other": "Disponible {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Vous pouvez acheter votre billet maintenant, mais vous ne pourrez pas le regarder jusque-là." },
-  "shopping_info_release_date_explanation_buy": { "other": "Vous pouvez l'acheter maintenant, mais vous ne pourrez pas le regarder jusque-là." },
-
-  "shopping_info_available_until_date_title": { "other": "Disponible jusqu’au {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Vous ne pourrez plus voir le contenu après cela." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Vous ne pourrez plus voir le contenu après cela." },
-
-  "shopping_info_rental_period_coming_soon": { "other": "Bientôt disponible" },
-
-  "duration_hour": { "one": "1 heure", "other": "{{.Count}} heures" },
-  "duration_day": { "one": "1 jour", "other": "{{.Count}} jours" },
-  "shopping_info_rental_period_duration": { "other": "Location pour {{.ValueUnit}} " },
-  "shopping_info_watch_window_duration": { "other": "Fenêtre de lecture est de {{.Count}} heures. " },
+  "searchresults_empty_header": {
+    "other": "Aucun résultat trouvé pour \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Veuillez faire une nouvelle recherche ou <a href=\"{{.HomeURL}}\">parcourir notre contenu</a> pour trouver ce que vous cherchez."
+  },
+  "validation_name_required": {
+    "other": "S'il vous plaît entrez votre nom."
+  },
+  "validation_email_required": {
+    "other": "S'il vous plaît entrer votre adresse e-mail."
+  },
+  "validation_email_email": {
+    "other": "S'il vous plaît, mettez une adresse email valide."
+  },
+  "validation_currentpassword_required": {
+    "other": "S'il vous plaît entrez votre mot de passe actuel."
+  },
+  "validation_password_required": {
+    "other": "Veuillez entrer un mot de passe."
+  },
+  "validation_password2_required": {
+    "other": "S'il vous plaît confirmer votre mot de passe."
+  },
+  "validation_password2_match": {
+    "other": "Vos mots de passe ne correspondent pas."
+  },
+  "validation_password_minlength": {
+    "other": "S'il vous plaît entrer au moins {{.Count}} caractères."
+  },
+  "validation_promocode_required": {
+    "other": "Veuillez saisir un code promo."
+  },
+  "validation_pincode_required": {
+    "other": "Veuillez saisir un code PIN."
+  },
+  "validation_gender_required": {
+    "other": "Veuillez sélectionner le genre auquel vous vous identifiez le plus."
+  },
+  "validation_dob_required": {
+    "other": "Veuillez saisir votre date de naissance."
+  },
+  "validation_dob_date": {
+    "other": "Veuillez saisir une date de naissance valide."
+  },
+  "availability_not_available_in_country": {
+    "other": "Non disponible"
+  },
+  "availability_coming_soon": {
+    "other": "Bientôt disponible"
+  },
+  "availability_available_till": {
+    "other": "Disponible jusqu’au {{.ExpiryDate}}"
+  },
+  "availability_available": {
+    "other": "Disponible {{.ReleaseDate}}"
+  },
+  "availability_sold_out": {
+    "other": "Épuisé"
+  },
+  "availability_expires": {
+    "other": "Expire {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Expiré"
+  },
+  "modal_cancel": {
+    "other": "Annuler"
+  },
+  "validation_terms_required": {
+    "other": "Veuillez lire et accepter nos termes et conditions."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "Vidéo HD à la demande."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "Vidéo SD à la demande."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Les fonds de votre portefeuille peuvent être utilisés pour l'achat ou la location de tout contenu sur ScreenPlu."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Voir ici pour la configuration système requise."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "achat"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "location"
+  },
+  "shopping_info_sd_only": {
+    "other": "Limité à la lecture SD uniquement."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Disponible {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Vous pouvez acheter votre billet maintenant, mais vous ne pourrez pas le regarder jusque-là."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Vous pouvez l'acheter maintenant, mais vous ne pourrez pas le regarder jusque-là."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Disponible jusqu’au {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Vous ne pourrez plus voir le contenu après cela."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Vous ne pourrez plus voir le contenu après cela."
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "Bientôt disponible"
+  },
+  "duration_hour": {
+    "one": "1 heure",
+    "other": "{{.Count}} heures"
+  },
+  "duration_day": {
+    "one": "1 jour",
+    "other": "{{.Count}} jours"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "Location pour {{.ValueUnit}} "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "Fenêtre de lecture est de {{.Count}} heures. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Une fois loué, votre film sera disponible sur votre compte pendant {{.ValueUnit}}. ",
     "other": "Une fois loué, votre film sera disponible sur votre compte pendant {{.ValueUnit}}. "
@@ -244,63 +535,145 @@
     "one": "Une fois que vous lancez la lecture d'un épisode, la fenêtre de lecture commence et vous avez une heure pour regarder l'épisode autant de vois que vous le souhaitez.",
     "other": "Une fois que vous lancez la lecture d'un épisode, la fenêtre de lecture commence et vous avez {{.Count}} heures pour regarder l'épisode autant de vois que vous le souhaitez."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Prime" },
-
-  "shopping_enter_card_prompt": { "other": "Veuillez saisir les détails de votre carte bancaire ci-dessous pour compléter votre {{.Verb}}." },
-
-  "shopping_terms": { "other": "En validant cette transaction, j'accepte les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">conditions d'utilisation</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} remise appliquée." },
-  "shopping_discount_apply": { "other": "Confirmer" },
-  "shopping_discount_code": { "other": "Rentrer votre code promo." },
-  "shopping_discount_have_code": { "other": "J'ai un code promo." },
-
-  "shopping_price_you_pay": { "other": "Vous payez" },
-  "shopping_price_nothing": { "other": "Rien" },
-  "shopping_price_free": { "other": "Gratuit" },
-
-  "shopping_auth_directions": { "other": "Vous devez d'abord créer un compte. Veuillez saisir votre adresse email." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} est déjà dans votre bibliothèque." },
-
-  "shopping_error_missing_card": { "other": "Veuillez saisir les détails de votre carte bancaire." },
-  "shopping_error_title": { "other": "Une erreur est survenue" },
-  "shopping_error_incorrect_cvc": { "other": "Veuillez saisir un code CVV valide." },
-  "shopping_error_invalid_cvc": { "other": "Veuillez saisir un code CVV valide." },
-  "shopping_error_incorrect_number": { "other": "Veuillez saisir un numéro de carte bancaire valide." },
-  "shopping_error_invalid_number": { "other": "Veuillez saisir un numéro de carte bancaire valide." },
-  "shopping_error_card_declined": { "other": "La carte de crédit a été refusée." },
-  "shopping_error_invalid_expiry_month": { "other": "La carte de crédit a été refusée." },
-  "shopping_error_invalid_expiry_year": { "other": "La carte de crédit a été refusée." },
-  "shopping_error_expired_card": { "other": "La carte de crédit a été refusée" },
-  "shopping_error_creditcard_country_mismatch": { "other": "Votre {{.Ownership}} n'a pas été complété. Vous devez être dans le pays où votre carte bancaire a été émise. Veuillez utiliser une autre carte pour effectuer le paiement." },
-  "shopping_error_proxy_detected": { "other": "Votre {{.Ownership}} n'a pas été complété. Nous avons détecté l'utilisation d'un bloqueur ou d'un proxy. Veuillez désactiver l'un de ces services et réessayer à nouveau." },
-
-  "shopping_error_discount_worn_out": { "other": "Ce code promo ne peut plus être utilisé." },
-  "shopping_error_discount_blank": { "other": "Merci de saisir un code promo valide." },
-  "shopping_error_discount_invalid": { "other": "Merci de saisir un code promo valide." },
-  "shopping_error_discount_disabled": { "other": "Merci de saisir un code promo valide." },
-  "shopping_error_discount_already_applied": { "other": "Un code promo a déjà été utilisé pour cette session." },
-  "shopping_error_discount_used_previously": { "other": "Ce code promo a déjà été utilisé." },
-  "shopping_error_discount_max_limit": { "other": "Ce code promo ne peut plus être utilisé." },
-  "shopping_error_discount_expired": { "other": "Ce code promo est expiré." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Ce code promo ne peut pas être utilisé lors de l'achat." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Ce code promo ne peut pas être utilisé lors de la location." },
-  "shopping_error_discount_invalid_item": { "other": "Ce code promo ne peut pas être utilisé avec cet article." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Ce code promo ne peut pas être utilisé dans votre pays." },
-  "shopping_error_discounts_not_allowed": { "other": "Ce code promo ne peut pas être utilisé." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Ce code promo ne peut pas être utilisé sur les forfaits." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "La carte bancaire a été refusée. Veuillez réessayer." },
-
-  "shopping_complete_rental": { "other": "Réussi!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Prime"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Veuillez saisir les détails de votre carte bancaire ci-dessous pour compléter votre {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "En validant cette transaction, j'accepte les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">conditions d'utilisation</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} remise appliquée."
+  },
+  "shopping_discount_apply": {
+    "other": "Confirmer"
+  },
+  "shopping_discount_code": {
+    "other": "Rentrer votre code promo."
+  },
+  "shopping_discount_have_code": {
+    "other": "J'ai un code promo."
+  },
+  "shopping_price_you_pay": {
+    "other": "Vous payez"
+  },
+  "shopping_price_nothing": {
+    "other": "Rien"
+  },
+  "shopping_price_free": {
+    "other": "Gratuit"
+  },
+  "shopping_auth_directions": {
+    "other": "Vous devez d'abord créer un compte. Veuillez saisir votre adresse email."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} est déjà dans votre bibliothèque."
+  },
+  "shopping_error_missing_card": {
+    "other": "Veuillez saisir les détails de votre carte bancaire."
+  },
+  "shopping_error_title": {
+    "other": "Une erreur est survenue"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Veuillez saisir un code CVV valide."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Veuillez saisir un code CVV valide."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Veuillez saisir un numéro de carte bancaire valide."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Veuillez saisir un numéro de carte bancaire valide."
+  },
+  "shopping_error_card_declined": {
+    "other": "La carte de crédit a été refusée."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "La carte de crédit a été refusée."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "La carte de crédit a été refusée."
+  },
+  "shopping_error_expired_card": {
+    "other": "La carte de crédit a été refusée"
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Votre {{.Ownership}} n'a pas été complété. Vous devez être dans le pays où votre carte bancaire a été émise. Veuillez utiliser une autre carte pour effectuer le paiement."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Votre {{.Ownership}} n'a pas été complété. Nous avons détecté l'utilisation d'un bloqueur ou d'un proxy. Veuillez désactiver l'un de ces services et réessayer à nouveau."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Ce code promo ne peut plus être utilisé."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Merci de saisir un code promo valide."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Merci de saisir un code promo valide."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Merci de saisir un code promo valide."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Un code promo a déjà été utilisé pour cette session."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Ce code promo a déjà été utilisé."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Ce code promo ne peut plus être utilisé."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Ce code promo est expiré."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Ce code promo ne peut pas être utilisé lors de l'achat."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Ce code promo ne peut pas être utilisé lors de la location."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Ce code promo ne peut pas être utilisé avec cet article."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Ce code promo ne peut pas être utilisé dans votre pays."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Ce code promo ne peut pas être utilisé."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Ce code promo ne peut pas être utilisé sur les forfaits."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "La carte bancaire a été refusée. Veuillez réessayer."
+  },
+  "shopping_complete_rental": {
+    "other": "Réussi!"
+  },
   "shopping_complete_rental_period": {
     "one": "Vous pouvez maintenant le regarder autant que vous le souhaitez jusqu'à demain.",
     "other": "Vous pouvez maintenant le regarder autant que vous le souhaitez au cours des {{.Count}} prochains jours."
   },
-  "shopping_complete_purchase": { "other": "Merci d'avoir acheté {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Merci d'avoir acheté {{.Title}}, {{.CreditTotal}} a été ajouté à votre compte." },
-  "shopping_complete_purchase_coming_soon": { "other": "Vous pourrez commencer le visionnage à partir du {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Un reçu vous a été envoyé par email." },
-  "shopping_complete_library_link": { "other": "Voir votre bibliothèque" },
+  "shopping_complete_purchase": {
+    "other": "Merci d'avoir acheté {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Merci d'avoir acheté {{.Title}}, {{.CreditTotal}} a été ajouté à votre compte."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Vous pourrez commencer le visionnage à partir du {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Un reçu vous a été envoyé par email."
+  },
+  "shopping_complete_library_link": {
+    "other": "Voir votre bibliothèque"
+  },
   "shopping_complete_plan": {
     "other": "Votre achat de {{ .Title }} a réussi."
   },
@@ -320,93 +693,208 @@
     "one": "Vous pourrez le regarder à partir du {{.Date}} et votre location restera active pendant une journée.",
     "other": "Vous pourrez le regarder à partir du {{.Date}} et votre location restera active pendant {{.Count}} jours."
   },
-
-  "shopping_action_rent": { "other": "Location" },
-  "shopping_action_buy": { "other": "Acheter" },
-
-  "shopping_payment_method_header": { "other": "Méthodes de paiement" },
-  "shopping_payment_method_credit_card": { "other": "Carte de crédit" },
-  "shopping_payment_method_giropay": { "other": "Giropay (Allemagne)" },
-  
-  "shopping_error_stripe_unknown_error": { "other": "Il y a eu une erreur avec ce paiement. Veuillez réessayer plus tard." },
-  "shopping_error_payment_complete_failed": { "other": "Ce paiement a été rejeté. Fermez cette fenêtre et réessayez." },
-
-  "meta_detail_cast_title": { "other": "Casting" },
-  "meta_detail_crew_title": { "other": "Équipe" },
-  "meta_detail_languages": { "one": "Langue", "other": "Langues" },
-  "meta_detail_studios": { "one": "Studio", "other": "Studios" },
-  "meta_detail_countries": { "one": "Pays", "other": "Pays" },
-  "meta_detail_subtitles": { "other": "Sous-titres" },
-  "meta_detail_captions": { "other": "Sous-titres [CC]" },
-  "meta_detail_episodes_title": { "other": "Épisodes" },
-  "meta_detail_bonus_title": { "other": "Contenu Bonus" },
-  "meta_detail_recommendations_title": { "other": "Vous pourriez également apprécier" },
-  "meta_detail_bundle_items_title": { "other": "Contenus inclus dans le forfait" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} films" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} séries" },
-  "bundle_items_mixed": { "other": "{{.Count}} films et séries" },
-  "userwishlist_page_header": { "other": "Ma liste" },
-  "userwishlist_slider_header": { "other": "Ma liste" },
-  "userwishlist_empty_header":  { "other": "Votre liste est vide." },
-  "userwishlist_empty_content": { "other": "Remplissez-le en naviguant sur notre <a href=\"{{.HomeURL}}\">grande sélection</a>." },
-  "userwishlist_button_add": { "other": "Ajouter à ma liste" },
-  "userwishlist_button_remove": { "other": "Ma liste" },
-  "userwishlist_button_add_compact": { "other": "Ma liste" },
-  "userwishlist_button_remove_compact": { "other": "Ma liste" },
-
-  "activatedevice_page_header": { "other": "Appareil activé" },
-  "activatedevice_page_content": { "other": "Suivez les instructions sur votre appareil pour obtenir un code PIN. Votre ordinateur et l'appareil doivent tous deux être connectés à Internet pour être activés." },
-  "activatedevice_form_pin": { "other": "Code PIN" },
-  "activatedevice_form_submit": { "other": "Activé" },
-  "activatedevice_form_error_invalid_code": { "other": "Code PIN introuvable, veuillez réessayer." },
-  "activatedevice_form_error_pin_not_found": { "other": "Code PIN introuvable, veuillez réessayer." },
-  "activatedevice_signin_prompt": { "other": "Veuillez vous connecter avant d'activer votre appareil." },
-  "activatedevice_page_activated": { "other": "Merci d'avoir activé {{.DeviceName}}. Vous pouvez maintenant parcourir votre bibliothèque sur votre téléviseur ou votre appareil." },
-
-  "userdevices_page_header": { "other": "Dispositifs" },
+  "shopping_action_rent": {
+    "other": "Location"
+  },
+  "shopping_action_buy": {
+    "other": "Acheter"
+  },
+  "shopping_payment_method_header": {
+    "other": "Méthodes de paiement"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Carte de crédit"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay (Allemagne)"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Il y a eu une erreur avec ce paiement. Veuillez réessayer plus tard."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Ce paiement a été rejeté. Fermez cette fenêtre et réessayez."
+  },
+  "meta_detail_cast_title": {
+    "other": "Casting"
+  },
+  "meta_detail_crew_title": {
+    "other": "Équipe"
+  },
+  "meta_detail_languages": {
+    "one": "Langue",
+    "other": "Langues"
+  },
+  "meta_detail_studios": {
+    "one": "Studio",
+    "other": "Studios"
+  },
+  "meta_detail_countries": {
+    "one": "Pays",
+    "other": "Pays"
+  },
+  "meta_detail_subtitles": {
+    "other": "Sous-titres"
+  },
+  "meta_detail_captions": {
+    "other": "Sous-titres [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Épisodes"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Contenu Bonus"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Vous pourriez également apprécier"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Contenus inclus dans le forfait"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} films"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} séries"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} films et séries"
+  },
+  "userwishlist_page_header": {
+    "other": "Ma liste"
+  },
+  "userwishlist_slider_header": {
+    "other": "Ma liste"
+  },
+  "userwishlist_empty_header": {
+    "other": "Votre liste est vide."
+  },
+  "userwishlist_empty_content": {
+    "other": "Remplissez-le en naviguant sur notre <a href=\"{{.HomeURL}}\">grande sélection</a>."
+  },
+  "userwishlist_button_add": {
+    "other": "Ajouter à ma liste"
+  },
+  "userwishlist_button_remove": {
+    "other": "Ma liste"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Ma liste"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Ma liste"
+  },
+  "activatedevice_page_header": {
+    "other": "Appareil activé"
+  },
+  "activatedevice_page_content": {
+    "other": "Suivez les instructions sur votre appareil pour obtenir un code PIN. Votre ordinateur et l'appareil doivent tous deux être connectés à Internet pour être activés."
+  },
+  "activatedevice_form_pin": {
+    "other": "Code PIN"
+  },
+  "activatedevice_form_submit": {
+    "other": "Activé"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "Code PIN introuvable, veuillez réessayer."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "Code PIN introuvable, veuillez réessayer."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Veuillez vous connecter avant d'activer votre appareil."
+  },
+  "activatedevice_page_activated": {
+    "other": "Merci d'avoir activé {{.DeviceName}}. Vous pouvez maintenant parcourir votre bibliothèque sur votre téléviseur ou votre appareil."
+  },
+  "userdevices_page_header": {
+    "other": "Dispositifs"
+  },
   "userdevices_page_content": {
     "one": "Les appareils seront automatiquement ajoutés ici lorsque vous les utilisez. Vous êtes limité à un appareil.",
     "other": "Les appareils seront automatiquement ajoutés ici lorsque vous les utilisez. Vous êtes limité à {{.Count}} appareils."
   },
-  "userdevices_empty_content": { "other": "Vous avez actuellement 0 appareils enregistrés." },
-  "userdevices_header_type": { "other": "Type d'appareil" },
-  "userdevices_header_description": { "other": "Description" },
-  "userdevices_device_added": { "other": "Ajoutée {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Retirer" },
-  "userdevices_device_actions_cancel": { "other": "Annuler" },
-  "userdevices_device_actions_confirm": { "other": "Oui, retirer cet appareil" },
-  "userdevices_device_deleted": { "other": "(Supprimé)" },
-
-  "playlist_page_header": { "other": "Playlist" },
-  "playlist_sign_in_warning": { "other": "Veuillez vous connecter pour regarder la télévision en direct."},
-  "playlist_share_title": { "other": "Playlist" },
-  "playlist_up_next_title": { "other": "Suivant" },
-
-  "pricing_ownership_buy": { "other": "Achat" },
-  "pricing_ownership_rent": { "other": "Location" },
-
-  "classification_intro": { "other": "Notation: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Ce site utilise des cookies dans le but d'améliorer votre expérience. En utilisant ce site, vous acceptez notre <a href=\"{{.CookiePolicyURL}}\">politique d'utilisation des cookies</a>." },
-  "cookie_banner_accept": { "other": "J'accepte" },
-
-  "all_rights_reserved": { "other": "Tous les droits sont réservés. Aucune partie de ce site ne peut être reproduite sans notre autorisation écrite." },
-
-  "signup_terms": { "other": "J'accepte tous les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termes et conditions</a>." },
-
-  "combined_auth_terms": { "other": "J'accepte tous les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termes et conditions</a>." },
-
-  "shopping_card_change": { "other": "Mauvaise carte de crédit ? <a href=\"{{.SubscriptionsURL}}\">Cliquez ici pour mettre à jour votre carte de crédit.</a>" },
-
-  "user_error_too_many_pin_errors": { "other": "<p>On dirait que tu es en difficulté.</p><p>Réinitialisez votre code PIN ou contactez-nous pour <a href=\"{{.HelpURL}}\" target=\"_blank\">obtenir de l'aide</a>" },
-
-  "app_badge_title": { "other": "Téléchargez l'application pour voir votre contenu acheté !" },
-  "app_badge_ios": { "other": "Télécharger sur l'App Store" },
-  "app_badge_android": { "other": "Obtenez le sur Google Play" },
-
+  "userdevices_empty_content": {
+    "other": "Vous avez actuellement 0 appareils enregistrés."
+  },
+  "userdevices_header_type": {
+    "other": "Type d'appareil"
+  },
+  "userdevices_header_description": {
+    "other": "Description"
+  },
+  "userdevices_device_added": {
+    "other": "Ajoutée {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Retirer"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Annuler"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Oui, retirer cet appareil"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Supprimé)"
+  },
+  "playlist_page_header": {
+    "other": "Playlist"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Veuillez vous connecter pour regarder la télévision en direct."
+  },
+  "playlist_share_title": {
+    "other": "Playlist"
+  },
+  "playlist_up_next_title": {
+    "other": "Suivant"
+  },
+  "pricing_ownership_buy": {
+    "other": "Achat"
+  },
+  "pricing_ownership_rent": {
+    "other": "Location"
+  },
+  "classification_intro": {
+    "other": "Notation: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Ce site utilise des cookies dans le but d'améliorer votre expérience. En utilisant ce site, vous acceptez notre <a href=\"{{.CookiePolicyURL}}\">politique d'utilisation des cookies</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "J'accepte"
+  },
+  "all_rights_reserved": {
+    "other": "Tous les droits sont réservés. Aucune partie de ce site ne peut être reproduite sans notre autorisation écrite."
+  },
+  "signup_terms": {
+    "other": "J'accepte tous les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termes et conditions</a>."
+  },
+  "combined_auth_terms": {
+    "other": "J'accepte tous les <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termes et conditions</a>."
+  },
+  "shopping_card_change": {
+    "other": "Mauvaise carte de crédit ? <a href=\"{{.SubscriptionsURL}}\">Cliquez ici pour mettre à jour votre carte de crédit.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>On dirait que tu es en difficulté.</p><p>Réinitialisez votre code PIN ou contactez-nous pour <a href=\"{{.HelpURL}}\" target=\"_blank\">obtenir de l'aide</a>"
+  },
+  "app_badge_title": {
+    "other": "Téléchargez l'application pour voir votre contenu acheté !"
+  },
+  "app_badge_ios": {
+    "other": "Télécharger sur l'App Store"
+  },
+  "app_badge_android": {
+    "other": "Obtenez le sur Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Prix"
   },
@@ -478,121 +966,283 @@
   "donate_button_text": {
     "other": "Faire un don"
   },
-
-  "wcag_skip_links_header": { "other": "Liens d'accessibilité" },
-  "wcag_skip_links_content": { "other": "Aller au contenu" },
-
-
-  "wcag_homepage_h1": { "other": "Page d'accueil" },
-  "wcag_carousel_h2": { "other": "Carrousel" },
-  "wcag_collections_h2": { "other": "Collections" },
-
-  "wcag_aria_label_footer": { "other": "Bas de page" },
-  "wcag_aria_label_nav_main": { "other": "Principale" },
-  "wcag_aria_label_nav_sub": { "other": "Sous" },
-  "wcag_aria_label_toggle_nav": { "other": "Basculer la navigation" },
-  "wcag_aria_label_bundle_items": { "other": "Articles groupés" },
-  "wcag_aria_label_carousel": { "other": "Carrousel" },
-  "wcag_aria_label_page_collection": { "other": "Collecte de pages" },
-  "wcag_aria_label_collection_list": { "other": "Liste de collecte" },
-  "wcag_aria_label_collection_slider": { "other": "Curseur de collecte" },
-  "wcag_aria_label_wishlist": { "other": "Liste de souhaits" },
-  "wcag_aria_label_facebook": { "other": "Partager sur Facebook" },
-  "wcag_aria_label_twitter": { "other": "Partager sur Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Partager sur LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Voir sur Letterboxd" },
-
-  "header_banner": { "other": "bannière d'en-tête" },
-
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "Vous n'avez pas de code PIN, qui est requis pour acheter, louer et regarder certains titres."},
-  "account_form_set_pin": { "other": "Définir le code PIN" },
-  "account_form_pin_changed": { "other": "Modifié" },
-  "account_form_change_pin": { "other": "Changer le PIN" },
-
-  "user_set_pin_header": { "other": "Définissez votre PIN" },
-  "user_set_pin_button": { "other": "Définir le code PIN" },
-  "user_submit_pin_heading": { "other": "Entrez votre code PIN pour {{.Action}} ce contenu restreint" },
-  "user_error_wrong_pin_retry": { "other": "Oups, vous avez saisi un code PIN incorrect" },
-  "user_submit_pin_button": { "other": "Entrer" },
-  "user_reset_pin_button": { "other": "Réinitialiser le code PIN" },
-
-  "validation_pincode1_required": { "other": "Veuillez saisir un code PIN valide." },
-  "validation_pincode2_required": { "other": "Veuillez saisir un code PIN valide." },
-  "validation_pincode1_pattern": { "other": "Veuillez saisir un code PIN valide." },
-  "validation_pincode2_pattern": { "other": "Veuillez saisir un code PIN valide." },
-  "validation_pincode2_match": { "other": "Le code PIN ne correspond pas." },
-
-  "userdevices_delete_limits": { "other": "Vous pouvez supprimer {{.Limit}} appareil(s) dans cette liste tous {{.Period}} jour(s)."},
-  "userdevices_delete_limit_reached": { "other": "Vous avez atteint cette limite et ne pouvez supprimer aucun appareil pour le moment. Vous pouvez supprimer un appareil dans {{.Days}} journées." },
-  "shopping_card_new_subscription": { "other": "Cette carte sera enregistrée et débitée régulièrement" },
-
-"changepincode_modal_header": { "other": "Changer le code pin" },
-"changepincode_modal_currentpassword": { "other": "Votre mot de passe actuel" },
-"changepincode_modal_pincode1": { "other": "Votre nouveau NIP à 4 chiffres" },
-"changepincode_modal_pincode2": { "other": "Confirmez votre nouveau code PIN à 4 chiffres" },
-"changepincode_modal_submit": { "other": "Définir le NIP" },
-"changepincode_modal_error_wrong_password": { "other": "Ce mot de passe est incorrect." },
-
-"user_set_pin_intro": { "other": "Vous avez besoin d'un code PIN pour accéder au contenu restreint de {{.Action}}"},
-"user_error_wrong_pin_reset": { "other": "Cliquez ici pour réinitialiser votre code PIN" },
-"user_error_too_many_pin_errors_help_page_link": { "other": "" },
-"shopping_error_age_restricted": { "other": "Ce contenu est soumis à une limite d'âge." },
-"shopping_error_close_button": { "other": "D'accord" }, 
-
-"usersubscriptions_subscription_expiry": { "other": "Expire le {{.Expiry}}" },
-"usersubscriptions_subscription_status_trialing": { "other": "Période d'essai" },
-"usersubscriptions_subscription_unsubscribe": { "other": "Annuler mon abonnement" },
-"usersubscriptions_unsubscribe_modal_cancel": { "other": "Annuler" },
-"usersubscriptions_unsubscribe_modal_confirm": { "other": "Oui, résilier mon abonnement" },
-"usersubscriptions_unsubscribe_modal_title": { "other": "Se désabonner?" },
-"usersubscriptions_unsubscribe_modal_body": { "other": "Cela annulera l'abonnement au package {{.Name}}. Vous pourrez toujours regarder le contenu du paquet jusqu'à son expiration {{.Expiry}}. " },
-
-"signin_form_error_ip_throttled": { "other": "Vous n'avez pas réussi à vous connecter trop de fois. Veuillez réessayer plus tard." },
-"signin_form_error_account_suspended": { "other": "Votre compte a été suspendu temporairement. Veuillez contacter un administrateur si vous pensez qu'il s'agit d'une erreur." },
-
-
-"users_gender_none": { "other": "Non précisé" },
-"users_gender_female": { "other": "Femme" },
-"users_gender_male": { "other": "Mâle" },
-"users_gender_diverse": { "other": "Diverse" },
-"users_gender_other": { "other": "Autre" },
-
-"pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HD uniquement" },
-  "pricing_quality_sd_only": { "other": "SD uniquement" },
-
-  "shopping_card_save_card": { "other": "Enregistrez cette carte de crédit pour une utilisation future" },
-  "shopping_card_button_change": { "other": "Afficher toutes les cartes de crédit enregistrées" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} se terminant en {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(expire le {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(expiré)" },
-  "shopping_card_use_other": { "other": "Utiliser une nouvelle carte" },
-  "shopping_card_use_new_card": { "other": "Modifier les informations de la carte" },
-  "shopping_card_update_reason_none": { "other": "Mettez à jour votre carte de crédit. Les cartes acceptées sont Visa, Mastercard et American Express." },
-  "shopping_info_ownership_plan": { "other": "Abonnement" },
-  "shopping_action_credit": { "other": "Ajouter un crédit" },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Changer de carte de crédit" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Mettre à jour les détails de la carte de crédit" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Mettre à jour" },
-
-  "availability_renting": { "other": "Location" },
-  "availability_not_available": { "other": "Not Indisponible" },
-  "availability_in_watch_window": { "other": "Disponible en vitrine" },
-
-  "play": { "other": "Voir" },
-
-  "combined_auth_signin_prompt": { "other": "Connexion" },
-  "combined_auth_signup_prompt": { "other": "Créer un compte" },
-
-  "shopping_error_item_limit_exceeded": { "other": "Malheureusement, {{.Title}} est épuisé." },
-
-  "search_control_submit": { "other": "Soumettre la recherche" },
-  "shopping_error_discount_not_applied": { "other": "Veuillez entrer un code promotionnel valide." },
-  "shopping_error_discount_already_redeemed": { "other": "Ce code promo a déjà été utilisé." },
-  "shopping_error_plan_already_owned": { "other": "Vous avez déjà ce plan." },
-  "shopping_error_plan_expired": { "other": "Ce forfait n'est plus disponible." }
-
+  "wcag_skip_links_header": {
+    "other": "Liens d'accessibilité"
+  },
+  "wcag_skip_links_content": {
+    "other": "Aller au contenu"
+  },
+  "wcag_homepage_h1": {
+    "other": "Page d'accueil"
+  },
+  "wcag_carousel_h2": {
+    "other": "Carrousel"
+  },
+  "wcag_collections_h2": {
+    "other": "Collections"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Bas de page"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Principale"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sous"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Basculer la navigation"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Articles groupés"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Carrousel"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Collecte de pages"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Liste de collecte"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Curseur de collecte"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Liste de souhaits"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Partager sur Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Partager sur Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Partager sur LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Voir sur Letterboxd"
+  },
+  "header_banner": {
+    "other": "bannière d'en-tête"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Vous n'avez pas de code PIN, qui est requis pour acheter, louer et regarder certains titres."
+  },
+  "account_form_set_pin": {
+    "other": "Définir le code PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Modifié"
+  },
+  "account_form_change_pin": {
+    "other": "Changer le PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Définissez votre PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Définir le code PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Entrez votre code PIN pour {{.Action}} ce contenu restreint"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Oups, vous avez saisi un code PIN incorrect"
+  },
+  "user_submit_pin_button": {
+    "other": "Entrer"
+  },
+  "user_reset_pin_button": {
+    "other": "Réinitialiser le code PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "Veuillez saisir un code PIN valide."
+  },
+  "validation_pincode2_required": {
+    "other": "Veuillez saisir un code PIN valide."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Veuillez saisir un code PIN valide."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Veuillez saisir un code PIN valide."
+  },
+  "validation_pincode2_match": {
+    "other": "Le code PIN ne correspond pas."
+  },
+  "userdevices_delete_limits": {
+    "other": "Vous pouvez supprimer {{.Limit}} appareil(s) dans cette liste tous {{.Period}} jour(s)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Vous avez atteint cette limite et ne pouvez supprimer aucun appareil pour le moment. Vous pouvez supprimer un appareil dans {{.Days}} journées."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Cette carte sera enregistrée et débitée régulièrement"
+  },
+  "changepincode_modal_header": {
+    "other": "Changer le code pin"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Votre mot de passe actuel"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Votre nouveau NIP à 4 chiffres"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Confirmez votre nouveau code PIN à 4 chiffres"
+  },
+  "changepincode_modal_submit": {
+    "other": "Définir le NIP"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Ce mot de passe est incorrect."
+  },
+  "user_set_pin_intro": {
+    "other": "Vous avez besoin d'un code PIN pour accéder au contenu restreint de {{.Action}}"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Cliquez ici pour réinitialiser votre code PIN"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Ce contenu est soumis à une limite d'âge."
+  },
+  "shopping_error_close_button": {
+    "other": "D'accord"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Expire le {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Période d'essai"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Annuler mon abonnement"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Annuler"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Oui, résilier mon abonnement"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Se désabonner?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Cela annulera l'abonnement au package {{.Name}}. Vous pourrez toujours regarder le contenu du paquet jusqu'à son expiration {{.Expiry}}. "
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Vous n'avez pas réussi à vous connecter trop de fois. Veuillez réessayer plus tard."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Votre compte a été suspendu temporairement. Veuillez contacter un administrateur si vous pensez qu'il s'agit d'une erreur."
+  },
+  "users_gender_none": {
+    "other": "Non précisé"
+  },
+  "users_gender_female": {
+    "other": "Femme"
+  },
+  "users_gender_male": {
+    "other": "Mâle"
+  },
+  "users_gender_diverse": {
+    "other": "Diverse"
+  },
+  "users_gender_other": {
+    "other": "Autre"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD uniquement"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD uniquement"
+  },
+  "shopping_card_save_card": {
+    "other": "Enregistrez cette carte de crédit pour une utilisation future"
+  },
+  "shopping_card_button_change": {
+    "other": "Afficher toutes les cartes de crédit enregistrées"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} se terminant en {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(expire le {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(expiré)"
+  },
+  "shopping_card_use_other": {
+    "other": "Utiliser une nouvelle carte"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Modifier les informations de la carte"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Mettez à jour votre carte de crédit. Les cartes acceptées sont Visa, Mastercard et American Express."
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Abonnement"
+  },
+  "shopping_action_credit": {
+    "other": "Ajouter un crédit"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Changer de carte de crédit"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Mettre à jour les détails de la carte de crédit"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Mettre à jour"
+  },
+  "availability_renting": {
+    "other": "Location"
+  },
+  "availability_not_available": {
+    "other": "Not Indisponible"
+  },
+  "availability_in_watch_window": {
+    "other": "Disponible en vitrine"
+  },
+  "play": {
+    "other": "Voir"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Connexion"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Créer un compte"
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Malheureusement, {{.Title}} est épuisé."
+  },
+  "search_control_submit": {
+    "other": "Soumettre la recherche"
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Veuillez entrer un code promotionnel valide."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Ce code promo a déjà été utilisé."
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Vous avez déjà ce plan."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Ce forfait n'est plus disponible."
+  }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1,427 +1,1084 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Settings" },
-  "powered_by": { "other": "Sadržaj omogućio" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "u suradnji s" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
-  "episode_name": { "other": "Epizoda" },
-
-  "season_name": { "other": "Sezona" },
-
-  "seasons": { "other": "{{.Count}} sezona" },
-  "tvseason": { "other": "{{.ShowInfo.Title}} Serija {{.Season.SeasonNumber}}" },
-  "tvseason_html": { "other": "{{.ShowInfo.Title}} <span>Serija {{.Season.SeasonNumber}}</span>" },
-  "tvepisode": { "other": "{{.Episode.Title}}" },
-  "tvseason_number": { "other": "Serija {{.Season.SeasonNumber}}" },
-  "episode_count": { "other": "{{.Count}} Epizoda" },
-
-  "date_day": { "other": "Dan" },
-  "date_month": { "other": "Mjesec" },
-  "date_year": { "other": "Godina" },
-
-  "404_page_header": { "other": "Tražena stranica nije dostupna..." },
-  "404_page_content": { "other": "<p>Žao nam je, ali stranica koju tražite nije dostupna.</p><p>Stranica je možda premještena ili izbrisana, ili je unesena pogrešna adresa stranice.</p><p>Pokušajte se vratiti na početnu stranicu i ponovno pronaći traženi sadržaj.</p><p><a href=\"{{.URL}}\">Povratak na početnu stranicu</a></p>" },
-
-
-  "nav_signin": { "other": "Prijava" },
-  "nav_signup": { "other": "Izradi korisnički račun" },
-  "nav_signed_in_as": { "other": "Prijavljen kao" },
-  "nav_library": { "other": "Moja zbirka" },
-  "nav_devices": { "other": "Moji uređaji" },
-  "nav_wishlist": { "other": "Moj popis" },
-  "nav_account": { "other": "Moj račun" },
-  "nav_signout": { "other": "Odjava" },
-  "play_trailer": { "other": "Prikolica" },
-  "header_banner": { "other": "ABC Cinemas – 21. filmski festival, 1. – 6. lipnja 2021" },
-  "runtime_hours": { "other": "h" },
-  "runtime_minutes": { "other": "min" },
-
-  "datetime_today": { "other": "danas {{.Date}}" },
-  "datetime_tomorrow": { "other": "sutra {{.Date}}" },
-  "datetime_yesterday": { "other": "jučer {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "posljednje {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Pretraživanje" },
-  "search_control_submit": { "other": "Potvrdi pretraživanje" },
-
-  "play_button_watch": { "other": "Pokreni sadržaj" },
-  "play_button_resume": { "other": "Nastavi" },
-
-  "social_media_buttons_title": { "other": "Podijeli" },
-  "social_media_buttons_facebook": { "other": "Podijeli na Facebooku" },
-  "social_media_buttons_twitter": { "other": "Podijelite na Twitteru" },
-  "social_media_buttons_linkedin": { "other": "Podijelite na Linkedinu" },
-  "social_media_buttons_email": { "other": "Podijelite putem e-pošte" },
-  "social_media_buttons_email_subject": { "other": "Dijeljenje veze" },
-  "social_media_buttons_copied_link": { "other": "Veza je kopirana u međuspremnik!" },
-  "social_media_buttons_copy_link": { "other": "Kopirati u međuspremnikKopirati u međuspremnik" },
-
-  "accept_invite_page_header": { "other": "Dobrodošli " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Ovaj pozivni kod je već iskorišten i potrebna je ponovna <a href=\"{{.SigninURL}}\">prijava</a>. Ako ste zaboravili lozinku, možete je <a href=\"{{.ForgotPasswordURL}}\">resetirati</a>." },
-  "acceptinvite_complete": { "other": "Hvala vam. Izradili ste korisnički račun." },
-  "acceptinvite_form_submit": { "other": "Prihvati pozivnicu" },
-  "acceptinvite_agreement": { "other": "Pritiskom na dugme \"Prihvati pozivnicu\" potvrđujete da ste pročitali i razumjeli <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">uvjete korištenja</a> i <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">pravila o zaštiti privatnosti</a>." },
-  
-  "signup_page_header": { "other": "Izradi novi korisnički račun" },
-  "signup_form_name": { "other": "Ime" },
-  "signup_form_email": { "other": "Email adresa" },
-  "signup_form_password": { "other": "Lozinka" },
-  "signup_form_password_confirmation": { "other": "Potvrdi lozinku" },
-  "signup_form_gender": { "other": "Spol" },
-  "signup_form_dob": { "other": "Datum rođenja" },
-  "signup_form_submit": { "other": "Potvrdi" },
-
-  "signin_page_header": { "other": "Prijava" },
-  "signin_form_email": { "other": "Email adresa" },
-  "signin_form_password": { "other": "Lozinka" },
-  "signin_form_remember": { "other": "Zapamti me" },
-  "signin_form_submit": { "other": "Potvrdi" },
-  "signin_page_forgotpassword": { "other": "Zaboravili ste lozinku?" },
-  "signin_page_createnewaccount": { "other": "Nemate korisnički račun? Izradi novi korisnički račun" },
-  "signup_page_alreadyhaveanaccount": { "other": "Imate korisnički račun? Prijavite se" },
-  "signup_form_error_email_already_in_use": { "other": "Email adresa je povezana s drugim korisničkim računom." },
-  "signin_form_error_incorrect_credentials": { "other": "Pogrešno korisničko ime ili lozinka." },
-  "signin_form_error_ip_throttled": { "other": "Premašili ste broj pokušaja prijave. Pokušajte ponovno kasnije." },
-  "signin_form_error_account_suspended": { "other": "Korisnički račun je privremeno blokiran. Obratite se administratoru ako smatrate da je riječ o pogrešci." },
-
-  "signup_form_error_forbidden": { "other": "Došlo je do pogreške." },
-
-  "combined_auth_continue": { "other": "Nastavi" },
-  "combined_auth_change": { "other": "promijeni" },
-  "combined_auth_signin": { "other": "Prijava" },
-  "combined_auth_signup": { "other": "Izradi korisnički račun" },
-  "combined_auth_signin_password": { "other": "Molimo unesite lozinku za prijavu na vaš korisnički račun." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Pogrešna lozinka." },
-  "combined_auth_error_forbidden": { "other": "Došlo je do pogreške." },
-  "combined_auth_error_too_many_requests": { "other": "Previše zahtjeva. Pokušajte ponovno kasnije." },
-
-  "forgotpassword_page_header": { "other": "Resetirajte lozinku" },
-  "forgotpassword_form_email": { "other": "Email adresa" },
-  "forgotpassword_form_submit": { "other": "Resetiraj" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Ne postoji korisnički račun povezan s email adresom." },
-  "forgotpassword_form_error_account_suspended": { "other": "Ovaj račun je blokiran." },
-  "forgotpassword_complete": { "other": "Hvala vam. Email s uputama za resetiranje lozinke upućen je na vaš email." },
-  "forgotpassword_form_error_forbidden": { "other": "Došlo je do pogreške." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Previše zahtjeva. Pokušajte ponovno kasnije." },
-
-  "resetpassword_page_header": { "other": "Promijeni lozinku" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Zahtjev za resetiranje lozinke nije valjan, molimo ispunite <a href=\"{{.URL}}\">Forgot Password</a> obrazac ponovno." },
-  "resetpassword_form_password": { "other": "Nova lozinka" },
-  "resetpassword_form_password2": { "other": "Potvrdi novu lozinku" },
-  "resetpassword_form_submit": { "other": "Izmijeni" },
-  "resetpassword_complete": { "other": "Hvala vam. Vaša lozinka je promijenjena i prijavljeni ste." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Zahtjev za resetiranje lozinke nije valjan. Molimo pokušajte kasnije." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Ključ za resetiranje lozinke je istekao. Molimo zatražite novi." },
-  "resetpassword_form_error_too_many_requests": { "other": "Previše zahtjeva. Pokušajte ponovno kasnije." },
-
-  "account_page_header": { "other": "Moj korisnički račun" },
-  "account_form_name": { "other": "Ime" },
-  "account_form_email": { "other": "Email adresa" },
-  "account_form_password": { "other": "Lozinka" },
-  "account_form_change_password": { "other": "Izmijeni" },
-  "account_form_gender": { "other": "Spol" },
-  "account_form_dob": { "other": "Datum rođenja" },
-  "account_form_submit": { "other": "Ažuriranje" },
-  "account_form_submitted": { "other": "Ažurirano" },
-  "account_form_password_changed": { "other": "Ažurirano" },
-  "account_form_error_incorrect_password": { "other": "Pogrešna lozinka." },
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "Niste postavili PIN, koji je potreban za kupovinu, posudbu i gledanje nekih naslova." },
-  "account_form_set_pin": { "other": "Postavite PIN" },
-  "account_form_pin_changed": { "other": "Ažurirano" },
-  "account_form_change_pin": { "other": "Promijenite PIN" },
-
-  "user_set_pin_header": { "other": "Postavite vaš PIN" },
-  "user_set_pin_button": { "other": "Postavite PIN" },
-  "user_submit_pin_heading": { "other": "Unesite PIN za {{.Action}} ograničenom sadržaju" },
-  "user_error_wrong_pin_retry": { "other": "Unijeli ste pogrešan PIN" },
-  "user_error_too_many_pin_errors": { "other": "<p>Došlo je do problema s unosom.</p><p>Resetirajte PIN ili nam se obratite za <a href=\"{{.HelpURL}}\" target=\"_blank\">pomoć</a>" },
-  "user_submit_pin_button": { "other": "Unos" },
-  "user_reset_pin_button": { "other": "Resetirajte PIN" },
-
-  "signup_form_optin": { "other": "Prijavite se za naš newsletter" },
-
-  "passwordconfirmation_modal_header": { "other": "Potvrdite lozinku" },
-  "passwordconfirmation_modal_label": { "other": "Molimo unesite lozinku kako bi potvrdili promjene" },
-  "passwordconfirmation_modal_confirm": { "other": "Potvrdi" },
-
-  "changepassword_modal_header": { "other": "Promijenite lozinku" },
-  "changepassword_modal_currentpassword": { "other": "Vaša trenutna lozinka" },
-  "changepassword_modal_password": { "other": "Vaša nova lozinka" },
-  "changepassword_modal_password2": { "other": "Potvrdite novu lozinku" },
-  "changepassword_modal_submit": { "other": "Ažuriranje" },
-  "changepassword_modal_error_incorrect_password": { "other": "Pogrešna lozinka." },
-
-  "userlibrary_page_header": { "other": "Moja zbirka" },
-  "userlibrary_empty_header": { "other": "Vaša zbirka je prazna." },
-  "userlibrary_empty_content": { "other": "Popunite zbirku <a href=\"{{.HomeURL}}\">pretraživanjem</a> naših sadržaja." },
-
-  "searchresults_page_header": { "other": "Rezultati pretraživanja" },
-  "searchresults_load_more": { "other": "Učitaj {{.Count}} više" },
-  "searchresults_total": { "other": "Pronađeno {{.Count}} rezultata za \"{{.Query}}\"." },
-  "searchresults_empty_header": { "other": "Nema rezultata pretrage za \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Pokušajte s drugim terminom za pretragu ili <a href=\"{{.HomeURL}}\">pretražite sadržaje</a> kako bi pronašli ono što tražite." },
-
-  "validation_name_required": { "other": "Molimo unesite ime." },
-  "validation_email_required": { "other": "Molimo unesite email adresu." },
-  "validation_email_email": { "other": "Molimo unesite valjanu email adresu." },
-  "validation_currentpassword_required": { "other": "Molimo unesite trenutnu lozinku." },
-  "validation_password_required": { "other": "Molimo unesite lozinku." },
-  "validation_password2_required": { "other": "Molimo potvrdite lozinku." },
-  "validation_password2_match": { "other": "Lozinke se ne podudaraju." },
-  "validation_password_minlength": { "other": "Molimo unesite najmanje {{.Count}} znakova." },
-  "validation_promocode_required": { "other": "Molimo unesite promotivni kod." },
-  "validation_pincode_required": { "other": "Molimo unesite PIN." },
-  "validation_pincode1_required": { "other": "Molimo unesite valjan PIN." },
-  "validation_pincode2_required": { "other": "Molimo unesite valjan PIN." },
-  "validation_pincode1_pattern": { "other": "Molimo unesite valjan PIN." },
-  "validation_pincode2_pattern": { "other": "Molimo unesite valjan PIN." },
-  "validation_pincode2_match": { "other": "PIN ne odgovara." },
-  "validation_gender_required": { "other": "Molimo unesite spol s kojim se identificirate." },
-  "validation_dob_required": { "other": "Molimo unesite datum rođenja." },
-  "validation_dob_date": { "other": "Molimo unesite valjan datum rođenja." },
-  
-  "shopping_info_subtitle_hd": { "other": "HD Video na zahtjev." },
-  "shopping_info_subtitle_sd": { "other": "SD Video na zahtjev." },
-  "shopping_info_subtitle_wallet": { "other": "Sredstva možete iskoristiti za kupovinu ili posudbu sadržaja na ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "Vidi zahtjeve sustava." },
-  "shopping_info_ownership_buy": { "other": "kupovina" },
-  "shopping_info_ownership_rent": { "other": "posudba" },
-
-  "shopping_info_sd_only": { "other": "Ograničeno na SD format." },
-  "shopping_info_release_date_title": { "other": "Dolazi {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Sadržaj možete posuditi sada, ali ga nećete moći gledati do zadanog datuma." },
-  "shopping_info_release_date_explanation_buy": { "other": "Sadržaj možete kupiti sada, ali ga nećete moći gledati do zadanog datuma." },
-
-  "shopping_info_available_until_date_title": { "other": "Dostupno do {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Nakon ovoga više ne možete gledati sadržaj." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Nakon ovoga više ne možete gledati sadržaj." },
-
-  "duration_hour": { "one": "1 sat", "other": "{{.Count}} sata" },
-  "duration_day": { "one": "1 dan", "other": "{{.Count}} dana" },
-  "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} posudbe " },
-  "shopping_info_watch_window_duration": { "other": "{{.Count}} sati zaslona za reprodukciju. " },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Settings"
+  },
+  "powered_by": {
+    "other": "Sadržaj omogućio"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "u suradnji s"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
+  "episode_name": {
+    "other": "Epizoda"
+  },
+  "season_name": {
+    "other": "Sezona"
+  },
+  "seasons": {
+    "other": "{{.Count}} sezona"
+  },
+  "tvseason": {
+    "other": "{{.ShowInfo.Title}} Serija {{.Season.SeasonNumber}}"
+  },
+  "tvseason_html": {
+    "other": "{{.ShowInfo.Title}} <span>Serija {{.Season.SeasonNumber}}</span>"
+  },
+  "tvepisode": {
+    "other": "{{.Episode.Title}}"
+  },
+  "tvseason_number": {
+    "other": "Serija {{.Season.SeasonNumber}}"
+  },
+  "episode_count": {
+    "other": "{{.Count}} Epizoda"
+  },
+  "date_day": {
+    "other": "Dan"
+  },
+  "date_month": {
+    "other": "Mjesec"
+  },
+  "date_year": {
+    "other": "Godina"
+  },
+  "404_page_header": {
+    "other": "Tražena stranica nije dostupna..."
+  },
+  "404_page_content": {
+    "other": "<p>Žao nam je, ali stranica koju tražite nije dostupna.</p><p>Stranica je možda premještena ili izbrisana, ili je unesena pogrešna adresa stranice.</p><p>Pokušajte se vratiti na početnu stranicu i ponovno pronaći traženi sadržaj.</p><p><a href=\"{{.URL}}\">Povratak na početnu stranicu</a></p>"
+  },
+  "nav_signin": {
+    "other": "Prijava"
+  },
+  "nav_signup": {
+    "other": "Izradi korisnički račun"
+  },
+  "nav_signed_in_as": {
+    "other": "Prijavljen kao"
+  },
+  "nav_library": {
+    "other": "Moja zbirka"
+  },
+  "nav_devices": {
+    "other": "Moji uređaji"
+  },
+  "nav_wishlist": {
+    "other": "Moj popis"
+  },
+  "nav_account": {
+    "other": "Moj račun"
+  },
+  "nav_signout": {
+    "other": "Odjava"
+  },
+  "play_trailer": {
+    "other": "Prikolica"
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21. filmski festival, 1. – 6. lipnja 2021"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "min"
+  },
+  "datetime_today": {
+    "other": "danas {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "sutra {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "jučer {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "posljednje {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Pretraživanje"
+  },
+  "search_control_submit": {
+    "other": "Potvrdi pretraživanje"
+  },
+  "play_button_watch": {
+    "other": "Pokreni sadržaj"
+  },
+  "play_button_resume": {
+    "other": "Nastavi"
+  },
+  "social_media_buttons_title": {
+    "other": "Podijeli"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Podijeli na Facebooku"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Podijelite na Twitteru"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Podijelite na Linkedinu"
+  },
+  "social_media_buttons_email": {
+    "other": "Podijelite putem e-pošte"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Dijeljenje veze"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Veza je kopirana u međuspremnik!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Kopirati u međuspremnikKopirati u međuspremnik"
+  },
+  "accept_invite_page_header": {
+    "other": "Dobrodošli "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Ovaj pozivni kod je već iskorišten i potrebna je ponovna <a href=\"{{.SigninURL}}\">prijava</a>. Ako ste zaboravili lozinku, možete je <a href=\"{{.ForgotPasswordURL}}\">resetirati</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Hvala vam. Izradili ste korisnički račun."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Prihvati pozivnicu"
+  },
+  "acceptinvite_agreement": {
+    "other": "Pritiskom na dugme \"Prihvati pozivnicu\" potvrđujete da ste pročitali i razumjeli <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">uvjete korištenja</a> i <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">pravila o zaštiti privatnosti</a>."
+  },
+  "signup_page_header": {
+    "other": "Izradi novi korisnički račun"
+  },
+  "signup_form_name": {
+    "other": "Ime"
+  },
+  "signup_form_email": {
+    "other": "Email adresa"
+  },
+  "signup_form_password": {
+    "other": "Lozinka"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Potvrdi lozinku"
+  },
+  "signup_form_gender": {
+    "other": "Spol"
+  },
+  "signup_form_dob": {
+    "other": "Datum rođenja"
+  },
+  "signup_form_submit": {
+    "other": "Potvrdi"
+  },
+  "signin_page_header": {
+    "other": "Prijava"
+  },
+  "signin_form_email": {
+    "other": "Email adresa"
+  },
+  "signin_form_password": {
+    "other": "Lozinka"
+  },
+  "signin_form_remember": {
+    "other": "Zapamti me"
+  },
+  "signin_form_submit": {
+    "other": "Potvrdi"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Zaboravili ste lozinku?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Nemate korisnički račun? Izradi novi korisnički račun"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Imate korisnički račun? Prijavite se"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Email adresa je povezana s drugim korisničkim računom."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Pogrešno korisničko ime ili lozinka."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Premašili ste broj pokušaja prijave. Pokušajte ponovno kasnije."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Korisnički račun je privremeno blokiran. Obratite se administratoru ako smatrate da je riječ o pogrešci."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Došlo je do pogreške."
+  },
+  "combined_auth_continue": {
+    "other": "Nastavi"
+  },
+  "combined_auth_change": {
+    "other": "promijeni"
+  },
+  "combined_auth_signin": {
+    "other": "Prijava"
+  },
+  "combined_auth_signup": {
+    "other": "Izradi korisnički račun"
+  },
+  "combined_auth_signin_password": {
+    "other": "Molimo unesite lozinku za prijavu na vaš korisnički račun."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Pogrešna lozinka."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Došlo je do pogreške."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Previše zahtjeva. Pokušajte ponovno kasnije."
+  },
+  "forgotpassword_page_header": {
+    "other": "Resetirajte lozinku"
+  },
+  "forgotpassword_form_email": {
+    "other": "Email adresa"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Resetiraj"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Ne postoji korisnički račun povezan s email adresom."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Ovaj račun je blokiran."
+  },
+  "forgotpassword_complete": {
+    "other": "Hvala vam. Email s uputama za resetiranje lozinke upućen je na vaš email."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Došlo je do pogreške."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Previše zahtjeva. Pokušajte ponovno kasnije."
+  },
+  "resetpassword_page_header": {
+    "other": "Promijeni lozinku"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Zahtjev za resetiranje lozinke nije valjan, molimo ispunite <a href=\"{{.URL}}\">Forgot Password</a> obrazac ponovno."
+  },
+  "resetpassword_form_password": {
+    "other": "Nova lozinka"
+  },
+  "resetpassword_form_password2": {
+    "other": "Potvrdi novu lozinku"
+  },
+  "resetpassword_form_submit": {
+    "other": "Izmijeni"
+  },
+  "resetpassword_complete": {
+    "other": "Hvala vam. Vaša lozinka je promijenjena i prijavljeni ste."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Zahtjev za resetiranje lozinke nije valjan. Molimo pokušajte kasnije."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Ključ za resetiranje lozinke je istekao. Molimo zatražite novi."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Previše zahtjeva. Pokušajte ponovno kasnije."
+  },
+  "account_page_header": {
+    "other": "Moj korisnički račun"
+  },
+  "account_form_name": {
+    "other": "Ime"
+  },
+  "account_form_email": {
+    "other": "Email adresa"
+  },
+  "account_form_password": {
+    "other": "Lozinka"
+  },
+  "account_form_change_password": {
+    "other": "Izmijeni"
+  },
+  "account_form_gender": {
+    "other": "Spol"
+  },
+  "account_form_dob": {
+    "other": "Datum rođenja"
+  },
+  "account_form_submit": {
+    "other": "Ažuriranje"
+  },
+  "account_form_submitted": {
+    "other": "Ažurirano"
+  },
+  "account_form_password_changed": {
+    "other": "Ažurirano"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Pogrešna lozinka."
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Niste postavili PIN, koji je potreban za kupovinu, posudbu i gledanje nekih naslova."
+  },
+  "account_form_set_pin": {
+    "other": "Postavite PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Ažurirano"
+  },
+  "account_form_change_pin": {
+    "other": "Promijenite PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Postavite vaš PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Postavite PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Unesite PIN za {{.Action}} ograničenom sadržaju"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Unijeli ste pogrešan PIN"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Došlo je do problema s unosom.</p><p>Resetirajte PIN ili nam se obratite za <a href=\"{{.HelpURL}}\" target=\"_blank\">pomoć</a>"
+  },
+  "user_submit_pin_button": {
+    "other": "Unos"
+  },
+  "user_reset_pin_button": {
+    "other": "Resetirajte PIN"
+  },
+  "signup_form_optin": {
+    "other": "Prijavite se za naš newsletter"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Potvrdite lozinku"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Molimo unesite lozinku kako bi potvrdili promjene"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Potvrdi"
+  },
+  "changepassword_modal_header": {
+    "other": "Promijenite lozinku"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Vaša trenutna lozinka"
+  },
+  "changepassword_modal_password": {
+    "other": "Vaša nova lozinka"
+  },
+  "changepassword_modal_password2": {
+    "other": "Potvrdite novu lozinku"
+  },
+  "changepassword_modal_submit": {
+    "other": "Ažuriranje"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Pogrešna lozinka."
+  },
+  "userlibrary_page_header": {
+    "other": "Moja zbirka"
+  },
+  "userlibrary_empty_header": {
+    "other": "Vaša zbirka je prazna."
+  },
+  "userlibrary_empty_content": {
+    "other": "Popunite zbirku <a href=\"{{.HomeURL}}\">pretraživanjem</a> naših sadržaja."
+  },
+  "searchresults_page_header": {
+    "other": "Rezultati pretraživanja"
+  },
+  "searchresults_load_more": {
+    "other": "Učitaj {{.Count}} više"
+  },
+  "searchresults_total": {
+    "other": "Pronađeno {{.Count}} rezultata za \"{{.Query}}\"."
+  },
+  "searchresults_empty_header": {
+    "other": "Nema rezultata pretrage za \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Pokušajte s drugim terminom za pretragu ili <a href=\"{{.HomeURL}}\">pretražite sadržaje</a> kako bi pronašli ono što tražite."
+  },
+  "validation_name_required": {
+    "other": "Molimo unesite ime."
+  },
+  "validation_email_required": {
+    "other": "Molimo unesite email adresu."
+  },
+  "validation_email_email": {
+    "other": "Molimo unesite valjanu email adresu."
+  },
+  "validation_currentpassword_required": {
+    "other": "Molimo unesite trenutnu lozinku."
+  },
+  "validation_password_required": {
+    "other": "Molimo unesite lozinku."
+  },
+  "validation_password2_required": {
+    "other": "Molimo potvrdite lozinku."
+  },
+  "validation_password2_match": {
+    "other": "Lozinke se ne podudaraju."
+  },
+  "validation_password_minlength": {
+    "other": "Molimo unesite najmanje {{.Count}} znakova."
+  },
+  "validation_promocode_required": {
+    "other": "Molimo unesite promotivni kod."
+  },
+  "validation_pincode_required": {
+    "other": "Molimo unesite PIN."
+  },
+  "validation_pincode1_required": {
+    "other": "Molimo unesite valjan PIN."
+  },
+  "validation_pincode2_required": {
+    "other": "Molimo unesite valjan PIN."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Molimo unesite valjan PIN."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Molimo unesite valjan PIN."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN ne odgovara."
+  },
+  "validation_gender_required": {
+    "other": "Molimo unesite spol s kojim se identificirate."
+  },
+  "validation_dob_required": {
+    "other": "Molimo unesite datum rođenja."
+  },
+  "validation_dob_date": {
+    "other": "Molimo unesite valjan datum rođenja."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Video na zahtjev."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video na zahtjev."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Sredstva možete iskoristiti za kupovinu ili posudbu sadržaja na ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Vidi zahtjeve sustava."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "kupovina"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "posudba"
+  },
+  "shopping_info_sd_only": {
+    "other": "Ograničeno na SD format."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Dolazi {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Sadržaj možete posuditi sada, ali ga nećete moći gledati do zadanog datuma."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Sadržaj možete kupiti sada, ali ga nećete moći gledati do zadanog datuma."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Dostupno do {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Nakon ovoga više ne možete gledati sadržaj."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Nakon ovoga više ne možete gledati sadržaj."
+  },
+  "duration_hour": {
+    "one": "1 sat",
+    "other": "{{.Count}} sata"
+  },
+  "duration_day": {
+    "one": "1 dan",
+    "other": "{{.Count}} dana"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} posudbe "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} sati zaslona za reprodukciju. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Nakon posudbe, film će biti dostupan na vašem korisničkom računu {{.ValueUnit}}. ",
     "other": "Nakon posudbe, film će biti dostupan na vašem korisničkom računu {{.ValueUnit}}. "
   },
-  "shopping_info_watch_window_explanation2_film": { "other": "Nakon pokretanja sadržaja, otvara se prozor prikazivanja i imate na raspolaganju {{.Count}} sati za gledanje filma, koliko puta želite. " },
-  "shopping_info_watch_window_explanation_bundle": { "other": "Nakon posudbe, sadržaji iz paketa će biti dostupni na vašem korisničkom računu {{.Count}} dana. " },
-  "shopping_info_watch_window_explanation2_bundle": { "other": "Nakon pokretanja određenog filma, otvara se prozor prikazivanja i imate na raspolaganju {{.Count}} sati za gledanje filma, koliko puta želite." },
-  "shopping_info_watch_window_explanation_season": { "other": "Nakon posudbe, sezona će biti dostupna na vašem korisničkom računu {{.Count}} dana. " },
-  "shopping_info_watch_window_explanation2_season": { "other": "Nakon pokretanja epizode, otvara se prozor prikazivanja i imate na raspolaganju {{.Count}} sati za gledanje epizode, koliko puta želite." },
-  
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Bonus" },
-
-  "shopping_enter_card_prompt": { "other": "Unesite podatke s vaše kreditne kartice za završetak {{.Verb}}." },
-
-  "shopping_terms": { "other": "Izvršavanjem transakcije, prihvaćam <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">uvjete korištenja</a>." },
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} popust iskorišten." },
-  "shopping_discount_apply": { "other": "Iskoristi" },
-  "shopping_discount_code": { "other": "Unesite promotivni kod." },
-  "shopping_discount_have_code": { "other": "Imam promotivni kod." },
-
-  "shopping_price_you_pay": { "other": "Plaćate" },
-  "shopping_price_nothing": { "other": "Ništa" },
-  "shopping_price_free": { "other": "Besplatno" },
-  
-  "shopping_auth_directions": { "other": "Potreban je korisnički račun. Molimo unesite email adresu." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} se već nalazi u vašoj zbirci." },
-  "shopping_error_missing_card": { "other": "Molimo unesite podatke s vaše kreditne kartice." },
-  "shopping_error_title": { "other": "Došlo je do pogreške" },
-  "shopping_error_incorrect_cvc": { "other": "Molimo unesite valjan  CVV." },
-  "shopping_error_invalid_cvc": { "other": "Molimo unesite valjan CVV." },
-  "shopping_error_incorrect_number": { "other": "Molimo unesite valjan broj kreditne kartice." },
-  "shopping_error_invalid_number": { "other": "Molimo unesite valjan broj kreditne kartice." },
-  "shopping_error_card_declined": { "other": "Kreditna kartica je odbijena." },
-  "shopping_error_invalid_expiry_month": { "other": "Molimo unesite važeći rok valjanosti.." },
-  "shopping_error_invalid_expiry_year": { "other": "Molimo unesite važeći rok valjanosti." },
-  "shopping_error_expired_card": { "other": "Kreditna kartica je istekla." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Vaša {{.Ownership}} nije izvršena. Morate se nalaziti u zemlji u kojoj je izdana vaša kreditna kartica. Molimo koristite drugu karticu za plaćanje." },
-  "shopping_error_proxy_detected": { "other": "Vaša {{.Ownership}} nije izvršena. Otkriven je kod za deblokiranje ili proxy poslužitelj. Molimo isključite takve usluge i pokušajte ponovno." },
-  
-  "shopping_error_discount_worn_out": { "other": "Promotivni kod se ne može više koristiti." },
-  "shopping_error_discount_blank": { "other": "Molimo unesite promotivni kod." },
-  "shopping_error_discount_not_applied": { "other": "Molimo unesite valjani promotivni kod." },
-  "shopping_error_discount_invalid": { "other": "Molimo unesite valjani promotivni kod." },
-  "shopping_error_discount_disabled": { "other": "Molimo unesite valjani promotivni kod." },
-  "shopping_error_discount_already_applied": { "other": "Promotivni kod je već iskorišten za ovaj termin." },
-  "shopping_error_discount_already_redeemed": { "other": "Promotivni kod je već iskorišten." },
-  "shopping_error_discount_used_previously": { "other": "Promotivni kod je već iskorišten." },
-  "shopping_error_discount_max_limit": { "other": "Promotivni kod se ne može više koristiti." },
-  "shopping_error_discount_expired": { "other": "Promotivni kod je istekao." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Promotivni kod se ne može koristiti za kupovinu." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Promotivni kod se ne može koristiti za posudbu." },
-  "shopping_error_discount_invalid_item": { "other": "Promotivni kod se ne može koristiti za ovaj naslov." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Promotivni kod se ne može koristiti u vašoj zemlji." },
-  "shopping_error_discounts_not_allowed": { "other": "Promotivni kod se ne može koristiti." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Promotivni kod ne može se koristiti za pakete." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Kreditna kartica je odbijena. Molimo pokušajte ponovno." },
-  
-  "shopping_complete_rental": { "other": "Uspješan unos!" },
-  "shopping_complete_rental_period": { "other": "Sada možete gledati sadržaj tijekom narednih {{.Count}} dana, koliko puta želite." },
-  "shopping_complete_purchase": { "other": "Hvala vam što ste kupili {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Hvala vam što ste kupili {{.Title}}, {{.CreditTotal}} je naplaćeno s vašeg računa." },
-  "shopping_complete_purchase_coming_soon": { "other": "Sadržaj možete gledati od {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Račun je upućen na vašu email adresu." },
-  "shopping_complete_library_link": { "other": "Pregled naslova iz zbirke" },
-  "shopping_complete_rental_watch_window_start": { "other": "Sada možete gledati sadržaj tijekom sljedećih {{.Count}} dana." },
-  "shopping_complete_rental_watch_window_end": { "other": "Kad započnete reprodukciju, imate {{.Count}} jedan sat za gledanje sadržaja, koliko puta želite." },
-  "shopping_complete_rental_coming_soon": { "other": "Sadržaj možete gledati od {{.Date}} i vaša posudba traje {{.Count}} dana." },
-  "shopping_complete_rental_coming_soon_watch_window_start": { "other": "Sadržaj možete gledati od {{.Date}} i vaša posudba traje {{.Count}} dana." },
+  "shopping_info_watch_window_explanation2_film": {
+    "other": "Nakon pokretanja sadržaja, otvara se prozor prikazivanja i imate na raspolaganju {{.Count}} sati za gledanje filma, koliko puta želite. "
+  },
+  "shopping_info_watch_window_explanation_bundle": {
+    "other": "Nakon posudbe, sadržaji iz paketa će biti dostupni na vašem korisničkom računu {{.Count}} dana. "
+  },
+  "shopping_info_watch_window_explanation2_bundle": {
+    "other": "Nakon pokretanja određenog filma, otvara se prozor prikazivanja i imate na raspolaganju {{.Count}} sati za gledanje filma, koliko puta želite."
+  },
+  "shopping_info_watch_window_explanation_season": {
+    "other": "Nakon posudbe, sezona će biti dostupna na vašem korisničkom računu {{.Count}} dana. "
+  },
+  "shopping_info_watch_window_explanation2_season": {
+    "other": "Nakon pokretanja epizode, otvara se prozor prikazivanja i imate na raspolaganju {{.Count}} sati za gledanje epizode, koliko puta želite."
+  },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Bonus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Unesite podatke s vaše kreditne kartice za završetak {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Izvršavanjem transakcije, prihvaćam <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">uvjete korištenja</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} popust iskorišten."
+  },
+  "shopping_discount_apply": {
+    "other": "Iskoristi"
+  },
+  "shopping_discount_code": {
+    "other": "Unesite promotivni kod."
+  },
+  "shopping_discount_have_code": {
+    "other": "Imam promotivni kod."
+  },
+  "shopping_price_you_pay": {
+    "other": "Plaćate"
+  },
+  "shopping_price_nothing": {
+    "other": "Ništa"
+  },
+  "shopping_price_free": {
+    "other": "Besplatno"
+  },
+  "shopping_auth_directions": {
+    "other": "Potreban je korisnički račun. Molimo unesite email adresu."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} se već nalazi u vašoj zbirci."
+  },
+  "shopping_error_missing_card": {
+    "other": "Molimo unesite podatke s vaše kreditne kartice."
+  },
+  "shopping_error_title": {
+    "other": "Došlo je do pogreške"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Molimo unesite valjan  CVV."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Molimo unesite valjan CVV."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Molimo unesite valjan broj kreditne kartice."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Molimo unesite valjan broj kreditne kartice."
+  },
+  "shopping_error_card_declined": {
+    "other": "Kreditna kartica je odbijena."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Molimo unesite važeći rok valjanosti.."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Molimo unesite važeći rok valjanosti."
+  },
+  "shopping_error_expired_card": {
+    "other": "Kreditna kartica je istekla."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Vaša {{.Ownership}} nije izvršena. Morate se nalaziti u zemlji u kojoj je izdana vaša kreditna kartica. Molimo koristite drugu karticu za plaćanje."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Vaša {{.Ownership}} nije izvršena. Otkriven je kod za deblokiranje ili proxy poslužitelj. Molimo isključite takve usluge i pokušajte ponovno."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Promotivni kod se ne može više koristiti."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Molimo unesite promotivni kod."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Molimo unesite valjani promotivni kod."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Molimo unesite valjani promotivni kod."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Molimo unesite valjani promotivni kod."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Promotivni kod je već iskorišten za ovaj termin."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Promotivni kod je već iskorišten."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Promotivni kod je već iskorišten."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Promotivni kod se ne može više koristiti."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Promotivni kod je istekao."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Promotivni kod se ne može koristiti za kupovinu."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Promotivni kod se ne može koristiti za posudbu."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Promotivni kod se ne može koristiti za ovaj naslov."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Promotivni kod se ne može koristiti u vašoj zemlji."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Promotivni kod se ne može koristiti."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Promotivni kod ne može se koristiti za pakete."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Kreditna kartica je odbijena. Molimo pokušajte ponovno."
+  },
+  "shopping_complete_rental": {
+    "other": "Uspješan unos!"
+  },
+  "shopping_complete_rental_period": {
+    "other": "Sada možete gledati sadržaj tijekom narednih {{.Count}} dana, koliko puta želite."
+  },
+  "shopping_complete_purchase": {
+    "other": "Hvala vam što ste kupili {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Hvala vam što ste kupili {{.Title}}, {{.CreditTotal}} je naplaćeno s vašeg računa."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Sadržaj možete gledati od {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Račun je upućen na vašu email adresu."
+  },
+  "shopping_complete_library_link": {
+    "other": "Pregled naslova iz zbirke"
+  },
+  "shopping_complete_rental_watch_window_start": {
+    "other": "Sada možete gledati sadržaj tijekom sljedećih {{.Count}} dana."
+  },
+  "shopping_complete_rental_watch_window_end": {
+    "other": "Kad započnete reprodukciju, imate {{.Count}} jedan sat za gledanje sadržaja, koliko puta želite."
+  },
+  "shopping_complete_rental_coming_soon": {
+    "other": "Sadržaj možete gledati od {{.Date}} i vaša posudba traje {{.Count}} dana."
+  },
+  "shopping_complete_rental_coming_soon_watch_window_start": {
+    "other": "Sadržaj možete gledati od {{.Date}} i vaša posudba traje {{.Count}} dana."
+  },
   "shopping_complete_plan": {
     "other": "Vaša kupnja {{ .Title }} je uspjela."
   },
-  "shopping_action_rent": { "other": "Posudi" },
-  "shopping_action_buy": { "other": "Kupi" },
-  
-  "shopping_payment_method_header": { "other": "Načini plaćanja" },
-  "shopping_payment_method_credit_card": { "other": "Kreditna kartica   " },
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  
-  "shopping_error_stripe_unknown_error": { "other": "Došlo je do pogreške prilikom plaćanja. Molimo pokušajte ponovno kasnije." },
-  "shopping_error_payment_complete_failed": { "other": "Plaćanje je odbijeno. Zatvorite ovaj prozor i pokušajte ponovno." },
-  
-  "meta_detail_cast_title": { "other": "Glumci" },
-  "meta_detail_crew_title": { "other": "Filmska ekipa" },
-  "meta_detail_languages": { "other": "Jezici" },
-  "meta_detail_studios": { "other": "Studiji" },
-  "meta_detail_countries": { "other": "Zemlje" },
-  "meta_detail_subtitles": { "other": "Podnaslovi" },
-  "meta_detail_captions": { "other": "Podnaslovi [CC]" },
-  "meta_detail_episodes_title": { "other": "Epizode" },
-  "meta_detail_bonus_title": { "other": "Bonus sadržaj" },
-  "meta_detail_recommendations_title": { "other": "Nalovi koji bi vam se mogli svidjeti" },
-  "meta_detail_bundle_items_title": { "other": "Sadržaj uključen u ovaj paket" },
-  
-  "bundle_items_all_films": { "other": "{{.Count}} filmova" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} sezona" },
-  "bundle_items_mixed": { "other": "{{.Count}} filmova i sezona" },
-  
-  "userwishlist_page_header": { "other": "Moj popis" },
-  "userwishlist_slider_header": { "other": "Moj popis" },
-  "userwishlist_empty_header": { "other": "Vaš popis je prazan." },
-  "userwishlist_empty_content": { "other": "Nadopuni popis <a href=\"{{.HomeURL}}\">pretraživanjem naslova</a> iz naše kolekcije." },
-  "userwishlist_button_add": { "other": "Dodaj na moj popis" },
-  "userwishlist_button_remove": { "other": "Moj popis" },
-  "userwishlist_button_add_compact": { "other": "Moj popis" },
-  "userwishlist_button_remove_compact": { "other": "Moj popis" },
-  
-  "activatedevice_page_header": { "other": "Aktiviraj uređaj" },
-  "activatedevice_page_content": { "other": "Slijedite upute na vašem uređaju kako bi dobili PIN. Vaše računalo i uređaj moraju biti spojeni na internet za aktivaciju." },
-  "activatedevice_form_pin": { "other": "PIN" },
-  "activatedevice_form_submit": { "other": "Aktiviraj" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN nije pronađen, pokušajte ponovno." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN nije pronađen, pokušajte ponovno." },
-  "activatedevice_signin_prompt": { "other": "Molimo prijavite se prije aktivirana uređaja." },
-  "activatedevice_page_activated": { "other": "Hvala vam što ste aktivirali {{.DeviceName}}. Sada možete pretraživati sadržaje na vašem TV-u ili uređaju." },
-  
-  "userdevices_page_header": { "other": "Uređaji  " },
-  "userdevices_page_content": { "other": "Uređaji se automatski dodaju prilikom korištenja. Broj uređaja je ograničen na {{.Count}}." },
-  "userdevices_empty_content": { "other": "Trenutno imate 0 registriranih uređaja." },
-  "userdevices_header_type": { "other": "Tip uređaja" },
-  "userdevices_header_description": { "other": "Opis" },
-  "userdevices_device_added": { "other": "Dodano {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Ukloni" },
-  "userdevices_device_actions_cancel": { "other": "Poništi" },
-  "userdevices_device_actions_confirm": { "other": "Da, ukloni uređaj" },
-  "userdevices_device_deleted": { "other": "(Uklonjeno)" },
-  "userdevices_delete_limits": { "other": "Možete ukloniti sljedeći broj {{.Limit}} uređaja s ovog popisa svakih {{.Period}} dana." },
-  "userdevices_delete_limit_reached": { "other": "Dostigli ste ograničenje i sada ne možete uklanjati uređaje. Možete ukloniti uređaj za {{.Days}} dana." },
-  
-  "playlist_page_header": { "other": "Popis za reprodukciju" },
-  "playlist_sign_in_warning": { "other": "Prijavite se za gledanje live TV-a." },
-  "playlist_share_title": { "other": "Popis za reprodukciju" },
-  "playlist_up_next_title": { "other": "Sljedeće" },
-  
-  "pricing_ownership_buy": { "other": "Kupi" },
-  "pricing_ownership_rent": { "other": "Posudi" },
-  
-  "classification_intro": { "other": "Ocjena: " },
-  "cookie_banner_message": { "other": "Mrežne stranice koriste kolačiće za bolje korisničko iskustvo. Korištenjem stranica, prihvaćate <a href=\"{{.CookiePolicyURL}}\">korištenje podataka o stranicama</a>." },
-  "cookie_banner_accept": { "other": "Prihvatiti" },
-  "all_rights_reserved": { "other": "Sva prava pridržana. Nijedan dio ovih mrežnih stranica ne smije se koristiti bez naše pisane privole." },
-  
-  "users_gender_none": { "other": "Nije definirano" },
-  "users_gender_female": { "other": "Žensko" },
-  "users_gender_male": { "other": "Muško" },
-  "users_gender_diverse": { "other": "Različito" },
-  "users_gender_other": { "other": "Ostalo" },
-  
-  "shopping_card_save_card": { "other": "Sačuvaj karticu za buduće korištenje" },
-  "shopping_card_button_change": { "other": "Prikaži sve pohranjene kartice" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} završne znamenke {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(vrijedi do {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(istekla)" },
-  "shopping_card_use_other": { "other": "Koristite novu karticu" },
-  "shopping_card_use_new_card": { "other": "Promijenite karticu" },
-  "shopping_card_update_reason_none": { "other": "Ažurirajte svoju kreditnu karticu. Podržane kartice su Visa, Mastercard i American Express." },
-  "shopping_card_new_subscription": { "other": "Ova kartica će biti pohranjena za redovitu naplatu" },
-  "shopping_card_change": { "other": "Kreditna kartica nije ispravna? <a href=\"{{.SubscriptionsURL}}\">Pritisnite ovdje za ažuriranje kartice.</a>" },
-  "shopping_info_rental_period_coming_soon": { "other": "od datuma i sata objavljivanja." },
-  
-  "availability_coming_soon": { "other": "Uskoro dostupno" },
-  "availability_renting": { "other": "Posudba" },
-  "availability_not_available": { "other": "Nije dostupno" },
-  "availability_in_watch_window": { "other": "Dostupno u prozoru sata" },
-  "availability_sold_out": { "other": "Rasprodano" },
-  "availability_available_till": { "other": "Dostupno do {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Nije dostupno u vašoj zemlji" },
-  "availability_available": { "other": "Dostupno {{.ReleaseDate}}" },
-  "availability_expires": { "other": "Ističe {{.Expiry}}" },
-  "availability_expired": { "other": "Isteklo" },
-  
-  "modal_cancel": { "other": "Prekid" },
-  "play": { "other": "Pokreni reprodukciju" },
-  
-  "combined_auth_signin_prompt": { "other": "Prijavi se " },
-  "combined_auth_signup_prompt": { "other": "Izradi korisnički račun" },
-  "combined_auth_terms": { "other": "Prihvaćam <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">uvjete korištenja</a>." },
-  
-  "signup_terms": { "other": "Prihvaćam <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">uvjete korištenja</a>." },
-  "validation_terms_required": { "other": "Morate prihvatiti uvjete korištenja." },
-  "shopping_error_item_limit_exceeded": { "other": "Nažalost, sadržaj {{.Title}} je rasprodan." },
-  
-  "changepincode_modal_header": { "other": "Promijenite PIN" },
-  "changepincode_modal_currentpassword": { "other": "Vaša trenutna lozinka" },
-  "changepincode_modal_pincode1": { "other": "Vaš novi 4-znamenkasti PIN" },
-  "changepincode_modal_pincode2": { "other": "Potvrdi novi 4-znamenkasti PIN" },
-  "changepincode_modal_submit": { "other": "Postavi PIN" },
-  "changepincode_modal_error_wrong_password": { "other": "Pogrešna lozinka." },
-  
-  "user_set_pin_intro": { "other": "Potreban je PIN za {{.Action}} ograničenom sadržaju" },
-  "user_error_wrong_pin_reset": { "other": "Pritisnite ze resetiranje PIN-a" },
-  "shopping_error_age_restricted": { "other": "Ovaj sadržaj je ograničen za maloljetnike." },
-  "shopping_error_close_button": { "other": "OK" },
-  
-  "wcag_skip_links_header": { "other": "Poveznice pristupačnosti" },
-  "wcag_skip_links_content": { "other": "Idi na sadržaj" },
-  "wcag_homepage_h1": { "other": "Početna stranica" },
-  "wcag_carousel_h2": { "other": "Kružni prikaz" },
-  "wcag_collections_h2": { "other": "Zbirke" },
-  "wcag_aria_label_footer": { "other": "Podnožje" },
-  "wcag_aria_label_nav_main": { "other": "Glavni dio" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Način prikaza" },
-  "wcag_aria_label_bundle_items": { "other": "Naslovi iz paketa" },
-  "wcag_aria_label_carousel": { "other": "Kružni prikaz" },
-  "wcag_aria_label_page_collection": { "other": "Zbirka stranica" },
-  "wcag_aria_label_collection_list": { "other": "Popis zbirki" },
-  "wcag_aria_label_collection_slider": { "other": "Klizač s naslovima iz zbirke" },
-  "wcag_aria_label_wishlist": { "other": "Popis želja" },
-  "wcag_aria_label_facebook": { "other": "Podijeli sadržaj Facebook" },
-  "wcag_aria_label_twitter": { "other": "Podijeli sadržaj Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Podijeli sadržaj LinkedIn" },
-
+  "shopping_action_rent": {
+    "other": "Posudi"
+  },
+  "shopping_action_buy": {
+    "other": "Kupi"
+  },
+  "shopping_payment_method_header": {
+    "other": "Načini plaćanja"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Kreditna kartica   "
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Došlo je do pogreške prilikom plaćanja. Molimo pokušajte ponovno kasnije."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Plaćanje je odbijeno. Zatvorite ovaj prozor i pokušajte ponovno."
+  },
+  "meta_detail_cast_title": {
+    "other": "Glumci"
+  },
+  "meta_detail_crew_title": {
+    "other": "Filmska ekipa"
+  },
+  "meta_detail_languages": {
+    "other": "Jezici"
+  },
+  "meta_detail_studios": {
+    "other": "Studiji"
+  },
+  "meta_detail_countries": {
+    "other": "Zemlje"
+  },
+  "meta_detail_subtitles": {
+    "other": "Podnaslovi"
+  },
+  "meta_detail_captions": {
+    "other": "Podnaslovi [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Epizode"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Bonus sadržaj"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Nalovi koji bi vam se mogli svidjeti"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Sadržaj uključen u ovaj paket"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} filmova"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} sezona"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} filmova i sezona"
+  },
+  "userwishlist_page_header": {
+    "other": "Moj popis"
+  },
+  "userwishlist_slider_header": {
+    "other": "Moj popis"
+  },
+  "userwishlist_empty_header": {
+    "other": "Vaš popis je prazan."
+  },
+  "userwishlist_empty_content": {
+    "other": "Nadopuni popis <a href=\"{{.HomeURL}}\">pretraživanjem naslova</a> iz naše kolekcije."
+  },
+  "userwishlist_button_add": {
+    "other": "Dodaj na moj popis"
+  },
+  "userwishlist_button_remove": {
+    "other": "Moj popis"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Moj popis"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Moj popis"
+  },
+  "activatedevice_page_header": {
+    "other": "Aktiviraj uređaj"
+  },
+  "activatedevice_page_content": {
+    "other": "Slijedite upute na vašem uređaju kako bi dobili PIN. Vaše računalo i uređaj moraju biti spojeni na internet za aktivaciju."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN"
+  },
+  "activatedevice_form_submit": {
+    "other": "Aktiviraj"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN nije pronađen, pokušajte ponovno."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN nije pronađen, pokušajte ponovno."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Molimo prijavite se prije aktivirana uređaja."
+  },
+  "activatedevice_page_activated": {
+    "other": "Hvala vam što ste aktivirali {{.DeviceName}}. Sada možete pretraživati sadržaje na vašem TV-u ili uređaju."
+  },
+  "userdevices_page_header": {
+    "other": "Uređaji  "
+  },
+  "userdevices_page_content": {
+    "other": "Uređaji se automatski dodaju prilikom korištenja. Broj uređaja je ograničen na {{.Count}}."
+  },
+  "userdevices_empty_content": {
+    "other": "Trenutno imate 0 registriranih uređaja."
+  },
+  "userdevices_header_type": {
+    "other": "Tip uređaja"
+  },
+  "userdevices_header_description": {
+    "other": "Opis"
+  },
+  "userdevices_device_added": {
+    "other": "Dodano {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Ukloni"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Poništi"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Da, ukloni uređaj"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Uklonjeno)"
+  },
+  "userdevices_delete_limits": {
+    "other": "Možete ukloniti sljedeći broj {{.Limit}} uređaja s ovog popisa svakih {{.Period}} dana."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Dostigli ste ograničenje i sada ne možete uklanjati uređaje. Možete ukloniti uređaj za {{.Days}} dana."
+  },
+  "playlist_page_header": {
+    "other": "Popis za reprodukciju"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Prijavite se za gledanje live TV-a."
+  },
+  "playlist_share_title": {
+    "other": "Popis za reprodukciju"
+  },
+  "playlist_up_next_title": {
+    "other": "Sljedeće"
+  },
+  "pricing_ownership_buy": {
+    "other": "Kupi"
+  },
+  "pricing_ownership_rent": {
+    "other": "Posudi"
+  },
+  "classification_intro": {
+    "other": "Ocjena: "
+  },
+  "cookie_banner_message": {
+    "other": "Mrežne stranice koriste kolačiće za bolje korisničko iskustvo. Korištenjem stranica, prihvaćate <a href=\"{{.CookiePolicyURL}}\">korištenje podataka o stranicama</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Prihvatiti"
+  },
+  "all_rights_reserved": {
+    "other": "Sva prava pridržana. Nijedan dio ovih mrežnih stranica ne smije se koristiti bez naše pisane privole."
+  },
+  "users_gender_none": {
+    "other": "Nije definirano"
+  },
+  "users_gender_female": {
+    "other": "Žensko"
+  },
+  "users_gender_male": {
+    "other": "Muško"
+  },
+  "users_gender_diverse": {
+    "other": "Različito"
+  },
+  "users_gender_other": {
+    "other": "Ostalo"
+  },
+  "shopping_card_save_card": {
+    "other": "Sačuvaj karticu za buduće korištenje"
+  },
+  "shopping_card_button_change": {
+    "other": "Prikaži sve pohranjene kartice"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} završne znamenke {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(vrijedi do {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(istekla)"
+  },
+  "shopping_card_use_other": {
+    "other": "Koristite novu karticu"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Promijenite karticu"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Ažurirajte svoju kreditnu karticu. Podržane kartice su Visa, Mastercard i American Express."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Ova kartica će biti pohranjena za redovitu naplatu"
+  },
+  "shopping_card_change": {
+    "other": "Kreditna kartica nije ispravna? <a href=\"{{.SubscriptionsURL}}\">Pritisnite ovdje za ažuriranje kartice.</a>"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "od datuma i sata objavljivanja."
+  },
+  "availability_coming_soon": {
+    "other": "Uskoro dostupno"
+  },
+  "availability_renting": {
+    "other": "Posudba"
+  },
+  "availability_not_available": {
+    "other": "Nije dostupno"
+  },
+  "availability_in_watch_window": {
+    "other": "Dostupno u prozoru sata"
+  },
+  "availability_sold_out": {
+    "other": "Rasprodano"
+  },
+  "availability_available_till": {
+    "other": "Dostupno do {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Nije dostupno u vašoj zemlji"
+  },
+  "availability_available": {
+    "other": "Dostupno {{.ReleaseDate}}"
+  },
+  "availability_expires": {
+    "other": "Ističe {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Isteklo"
+  },
+  "modal_cancel": {
+    "other": "Prekid"
+  },
+  "play": {
+    "other": "Pokreni reprodukciju"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Prijavi se "
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Izradi korisnički račun"
+  },
+  "combined_auth_terms": {
+    "other": "Prihvaćam <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">uvjete korištenja</a>."
+  },
+  "signup_terms": {
+    "other": "Prihvaćam <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">uvjete korištenja</a>."
+  },
+  "validation_terms_required": {
+    "other": "Morate prihvatiti uvjete korištenja."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Nažalost, sadržaj {{.Title}} je rasprodan."
+  },
+  "changepincode_modal_header": {
+    "other": "Promijenite PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Vaša trenutna lozinka"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Vaš novi 4-znamenkasti PIN"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Potvrdi novi 4-znamenkasti PIN"
+  },
+  "changepincode_modal_submit": {
+    "other": "Postavi PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Pogrešna lozinka."
+  },
+  "user_set_pin_intro": {
+    "other": "Potreban je PIN za {{.Action}} ograničenom sadržaju"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Pritisnite ze resetiranje PIN-a"
+  },
+  "shopping_error_age_restricted": {
+    "other": "Ovaj sadržaj je ograničen za maloljetnike."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "wcag_skip_links_header": {
+    "other": "Poveznice pristupačnosti"
+  },
+  "wcag_skip_links_content": {
+    "other": "Idi na sadržaj"
+  },
+  "wcag_homepage_h1": {
+    "other": "Početna stranica"
+  },
+  "wcag_carousel_h2": {
+    "other": "Kružni prikaz"
+  },
+  "wcag_collections_h2": {
+    "other": "Zbirke"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Podnožje"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Glavni dio"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Način prikaza"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Naslovi iz paketa"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Kružni prikaz"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Zbirka stranica"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Popis zbirki"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Klizač s naslovima iz zbirke"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Popis želja"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Podijeli sadržaj Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Podijeli sadržaj Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Podijeli sadržaj LinkedIn"
+  },
   "shopping_price_title_plan": {
     "other": "Cijena"
   },
@@ -493,49 +1150,91 @@
   "donate_button_text": {
     "other": "Donirajte"
   },
-
-  "shopping_error_plan_already_owned": { "other": "Već imate ovaj plan." },
-  "shopping_error_plan_expired": { "other": "Ovaj plan više nije dostupan." },
-
-  "usersubscriptions_subscription_expiry": { "other": "Istječe {{.Expiry}}" },
-  "usersubscriptions_subscription_status_cancelled": { "other": "usersubscriptions_subscription_status_cancelled" },
-  "usersubscriptions_subscription_status_errored": { "other": "usersubscriptions_subscription_status_errored" },
-  "usersubscriptions_subscription_status_past_due": { "other": "usersubscriptions_subscription_status_past_due" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Probni rok" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Otkaži moju pretplatu" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Otkazati" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Da, otkaži moju pretplatu" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Otkazati pretplatu?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "Time će se otkazati pretplata na plan {{.Name}}. I dalje ćete moći gledati sadržaj u planu dok ne istekne {{.Expiry}}." },
-
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-
-
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HD Only" },
-  "pricing_quality_sd_only": { "other": "SD Only" },
-
-  "shopping_info_ownership_plan": { "other": "Pretplata" },
-  "shopping_action_credit": { "other": "Dopuniti" },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Promjena kreditne kartice" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Ažurirajte podatke o kreditnoj kartici" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Ažuriraj" },
-
-  "app_badge_title": { "other": "Preuzmite aplikaciju za pregled kupljenog sadržaja!" },
-  "app_badge_ios": { "other": "Preuzmite na App Storeu" },
-  "app_badge_android": { "other": "Nabavite ga na Google Playu" }, 
-
-  "wcag_aria_label_letterboxd": { "other": "Pogled na Letterboxd" },
-
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" }
-
-  
-
+  "shopping_error_plan_already_owned": {
+    "other": "Već imate ovaj plan."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Ovaj plan više nije dostupan."
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Istječe {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "usersubscriptions_subscription_status_cancelled"
+  },
+  "usersubscriptions_subscription_status_errored": {
+    "other": "usersubscriptions_subscription_status_errored"
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "usersubscriptions_subscription_status_past_due"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Probni rok"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Otkaži moju pretplatu"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Otkazati"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Da, otkaži moju pretplatu"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Otkazati pretplatu?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Time će se otkazati pretplata na plan {{.Name}}. I dalje ćete moći gledati sadržaj u planu dok ne istekne {{.Expiry}}."
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD Only"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD Only"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Pretplata"
+  },
+  "shopping_action_credit": {
+    "other": "Dopuniti"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Promjena kreditne kartice"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Ažurirajte podatke o kreditnoj kartici"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Ažuriraj"
+  },
+  "app_badge_title": {
+    "other": "Preuzmite aplikaciju za pregled kupljenog sadržaja!"
+  },
+  "app_badge_ios": {
+    "other": "Preuzmite na App Storeu"
+  },
+  "app_badge_android": {
+    "other": "Nabavite ga na Google Playu"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Pogled na Letterboxd"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1,597 +1,1257 @@
 {
-    "site_owner": { "other": "ABC Cinemas" },
-    "settings_title": { "other": "Settings" },
-    "powered_by": { "other": "Powered by" },
-    "powered_by_name": { "other": "Shift72" },
-    "powered_by_url": { "other": "https://www.screenplus.com" },
-    "in_partnership_with": { "other": "in partnership with" },
-    "festival_scope": { "other": "Festival Scope" },
-    "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-    "en": { "other": "English" },
-    "fr": { "other": "French" },
-  
-    "episode_name": {
-      "other": "Epizód"
-    },
-  
-    "season_name": {
-      "other": "Évad"
-    },
-  
-    "seasons":{
-      "one": "egy szezont",
-      "other": "{{.Count}} évszakok"
-    },
-    "tvseason": {
-      "other": "{{.ShowInfo.Title}} Sorozat {{.Season.SeasonNumber}}"
-    },
-    "tvseason_html": {
-      "other": "{{.ShowInfo.Title}} <span>Sorozat {{.Season.SeasonNumber}}</span>"
-    },
-    "tvepisode": {
-      "other": "{{.Episode.Title}}"
-    },
-    "tvseason_number": {
-      "other": "Series {{.Season.SeasonNumber}}"
-    },
-    "episode_count": {
-      "one": "1 Epizód",
-      "other": "{{.Count}} Epizódok"
-    },
-  
-    "date_day": { "other": "Nap" },
-    "date_month": { "other": "Hónap" },
-    "date_year": { "other": "Év" },
-  
-    "404_page_header": { "other": "A keresett oldal nem létezik..." },
-    "404_page_content": { "other": "<p>Sajnos úgy tűnik, hogy a keresett oldal nem létezik.</p><p>Talán törölték vagy áthelyezték, kérjük ellenőrizd, hogy helyesen írtad-e be a címet.</p><p>Próbálj visszamenni a kezdőlapra, hogy megtaláld, amit keresel.</p><p><a href=\"{{.URL}}\">Vissza a kezdőlapra</a></p>" },
-  
-  
-    "nav_homepage": { "other": "ABC Cinemas" },
-    "nav_signin": { "other": "Bejelentkezés" },
-    "nav_signup": { "other": "Fiók létrehozása" },
-    "nav_signed_in_as": { "other": "Bejelentkezve" },
-    "nav_library": { "other": "Könyvtáram" },
-    "nav_devices": { "other": "Eszközeim" },
-    "nav_wishlist": { "other": "Listám" },
-    "nav_account": { "other": "Fiókom" },
-    "nav_signout": { "other": "Kijelentkezés" },
-    "play_trailer": { "other": "Előzetes" },
-    "runtime_hours": { "other": "óra" },
-    "runtime_minutes": { "other": "perc" },
-  
-    "datetime_today": { "other": "ma {{.Date}}" },
-    "datetime_tomorrow": { "other": "holnap {{.Date}}" },
-    "datetime_yesterday": { "other": "tegnap {{.Date}}" },
-    "datetime_next": { "other": "{{.Date}}" },
-    "datetime_last": { "other": "utolsó {{.Date}}" },
-  
-    "search_control_placeholder": { "other": "Keresés" },
-    "search_control_submit": { "other": "Keresés indítása" },
-  
-    "play_button_watch": { "other" : "Lejátszás"},
-    "play_button_resume": { "other" : "Folytatás"},
-  
-    "social_media_buttons_title": { "other": "Megosztás" },
-    "social_media_buttons_facebook": { "other": "Megosztani Facebookon" },
-    "social_media_buttons_twitter": { "other": "Oszd meg a Twitteren" },
-    "social_media_buttons_linkedin": { "other": "Oszd meg a Linkedin-en" },
-    "social_media_buttons_email": { "other": "Oszd meg e-mailben" },
-    "social_media_buttons_email_subject": { "other": "Link megosztás" },
-    "social_media_buttons_copied_link": { "other": "Link a vágólapra másolva!" },
-    "social_media_buttons_copy_link": { "other": "Másolja a vágólapra" },
-
-    "accept_invite_page_header": { "other": "Üdvözöljük " },
-    "acceptinvite_form_invalid_reset_password_token": { "other": "Úgy tűnik, már felhasználtad a meghívódat, próbálj meg <a href=\"{{.SigninURL}}\">bejelentkezni</a>. Ha elfelejtetted a jelszavadat, <a href=\"{{.ForgotPasswordURL}}\">állíts be újat</a>." },
-    "acceptinvite_complete": { "other": "Köszönjük. A fiókodat létrehoztuk." },
-    "acceptinvite_form_submit": { "other": "Meghívó elfogadása" },
-    "acceptinvite_agreement": { "other": "Meghívó elfogadása -ra kattintva hozzájárulsz, hogy elolvastad és megértetted a <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Felhasználói szabályzatot</a> és az <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\tvédelmi szabályzatot</a>." },
-  
-    "signup_page_header": { "other": "Új fiók létrehozása" },
-    "signup_form_name": { "other": "Név" },
-    "signup_form_email": { "other": "E-mail cím" },
-    "signup_form_password": { "other": "Jelszó" },
-    "signup_form_password_confirmation": { "other": "Jelszó megerősítése" },
-    "signup_form_gender": { "other": "Nem" },
-    "signup_form_dob": { "other": "Születési dátum" },
-    "signup_form_submit": { "other": "Fiók létrehozása" },
-  
-    "signin_page_header": { "other": "Bejelentkezés" },
-    "signin_form_email": { "other": "E-mail cím" },
-    "signin_form_password": { "other": "Jelszó" },
-    "signin_form_remember": { "other": "Emlékezz rám" },
-    "signin_form_submit": { "other": "Bejelentkezés" },
-    "signin_page_forgotpassword": { "other": "Elfelejtetted a jelszavadat?" },
-    "signin_page_createnewaccount": { "other": "Nincs még fiókod? Új fiók létrehozása" },
-    "signup_page_alreadyhaveanaccount": { "other": "Már van fiókod? Bejelentkezés" },
-    "signup_form_error_email_already_in_use": { "other": "Ezt az e-mail címet már használják." },
-    "signin_form_error_incorrect_credentials": { "other": "A felhasználónév vagy jelszó hibás." },
-    "signin_form_error_ip_throttled": { "other": "Túl sokszor nem sikerült bejelentkeznie. Kérlek, próbáld újra később." },
-    "signin_form_error_account_suspended": { "other": "A fiókod ideiglenesen fel lett függesztve. Kérjük, forduljon egy adminisztrátorhoz, ha úgy gondolja, hogy ez tévedés." },
-  
-    "signup_form_error_forbidden": { "other": "Hiba történt." },
-  
-    "combined_auth_continue": { "other": "Folytatás" },
-    "combined_auth_change": { "other": "megváltoztatás" },
-    "combined_auth_signin": { "other": "Bejelentkezés" },
-    "combined_auth_signup": { "other": "Fiók létrehozása" },
-    "combined_auth_signin_password": { "other": "Kérjük, add meg a jelszavadat a fiókodba történő belépéshez." },
-    "combined_auth_signin_error_incorrect_credentials": { "other": "Hibás jelszó." },
-    "combined_auth_error_forbidden": { "other": "Hiba történt." },
-    "combined_auth_error_too_many_requests": { "other": "Túl sok kérés. Kérlek, próbáld újra később." },
-  
-    "forgotpassword_page_header": { "other": "Új jelszó beállítása" },
-    "forgotpassword_form_email": { "other": "E-mail cím" },
-    "forgotpassword_form_submit": { "other": "Visszaállítás" },
-    "forgotpassword_form_error_email_doesnt_exist": { "other": "Nincs ehhez az e-mail címhez rendelt fiók." },
-    "forgotpassword_form_error_account_suspended": { "other": "Ezt a fiókot felfüggesztették." },
-    "forgotpassword_complete": { "other": "Köszönjük. A jelszó visszaállításáról hamarosan e-mailed érkezik." },
-    "forgotpassword_form_error_forbidden": { "other": "Hiba történt." },
-    "forgotpassword_form_error_too_many_requests": { "other": "Túl sok kérés. Kérlek, próbáld újra később." },
-  
-    "resetpassword_page_header": { "other": "Jelszó megváltoztatása." },
-    "resetpassword_form_invalid_reset_password_token": { "other": "Úgy tűnik, hogy ez a jelszó érvénytelen, kérjük töltsd ki ismét az <a href=\"{{.URL}}\">Elfelejtett jelszó</a> űrlapot.." },
-    "resetpassword_form_password": { "other": "Új jelszó" },
-    "resetpassword_form_password2": { "other": "Új jelszó megerősítése" },
-    "resetpassword_form_submit": { "other": "Megváltoztatás" },
-    "resetpassword_complete": { "other": "Köszönjük. A jelszavad megváltoztattad, bejelentkezésed sikeres." },
-    "resetpassword_form_error_invalid_reset_password_token": { "other": "A jelszó megváltoztatásának igénye érvénytelen. Kérjük, próbáld meg újra később." },
-    "resetpassword_form_error_reset_password_token_expired": { "other": "A jelszó megváltoztatására küldött token lejárt. Igényelj újat." },
-    "resetpassword_form_error_too_many_requests": { "other": "Túl sok kérés. Kérlek, próbáld újra később." },
-  
-    "account_page_header": { "other": "Fiókom" },
-    "account_form_name": { "other": "Név" },
-    "account_form_email": { "other": "E-mail cím" },
-    "account_form_password": { "other": "Jelszó" },
-    "account_form_change_password": { "other": "Megváltoztatás" },
-    "account_form_gender": { "other": "Nem" },
-    "account_form_dob": { "other": "Születési dátum" },
-    "account_form_submit": { "other": "Frissítés" },
-    "account_form_submitted": { "other": "Frissítve" },
-    "account_form_password_changed": { "other": "Frissítve" },
-    "account_form_error_incorrect_password": { "other": "Ez a jelszó hibás." },
-  
-    "signup_form_optin": {"other": "Iratkozz fel ingyenes hírlevelünkre."},
-  
-    "passwordconfirmation_modal_header": { "other": "Jelszó megerősítése." },
-    "passwordconfirmation_modal_label": { "other": "Kérjük, add meg a jelszavadat, hogy mentsd a változtatásokat." },
-    "passwordconfirmation_modal_confirm": { "other": "Megerősítés" },
-  
-    "changepassword_modal_header": { "other": "Jelszó megváltoztatása" },
-    "changepassword_modal_currentpassword": { "other": "Jelenlegi jelszavad" },
-    "changepassword_modal_password": { "other": "Új jelszó" },
-    "changepassword_modal_password2": { "other": "Erősítsd meg az új jelszavad" },
-    "changepassword_modal_submit": { "other": "Megváltoztatás" },
-    "changepassword_modal_error_incorrect_password": { "other": "Ez a jelszó hibás." },
-  
-    "userlibrary_page_header": { "other": "Könyvtáram" },
-    "userlibrary_empty_header":  { "other": "A könyvtárad üres." },
-    "userlibrary_empty_content": { "other": "Töltsd meg kiváló filmekkel, nézd át a <a href=\"{{.HomeURL}}\">programot</a>." },
-  
-    "searchresults_page_header": { "other": "Keresési találatok" },
-    "searchresults_load_more": { "other": "Mutass még {{.Count}} találatot." },
-    "searchresults_total": {
-      "one": "A \"{{.Query}}\" {{.Count}} találatot hozott.",
-      "other": "A \"{{.Query}}\" {{.Count}} találatot hozott."
-    },
-    "searchresults_empty_header":  { "other": "A \"{{.Query}}\" egy találatot sem hozott." },
-    "searchresults_empty_content": { "other": "Próbálj meg mégegyszer rákeresni vagy <a href=\"{{.HomeURL}}\">nézd át a kínálatot</a>, hogy megtaláld, amit keresel." },
-  
-    "validation_name_required": { "other": "Kérjük, add meg a nevedet." },
-    "validation_email_required": { "other": "Kérjük, add meg a nevedet." },
-    "validation_email_email": { "other": "Kérjük, adj meg egy érvényes e-mail címet." },
-    "validation_currentpassword_required": { "other": "Kérjük, add meg a jelenlegi jelszavadat." },
-    "validation_password_required": { "other": "Kérjfük, adj meg egy jelszót." },
-    "validation_password2_required": { "other": "Kérjük, erősítsd meg a jelszavadat." },
-    "validation_password2_match": { "other": "A két jelszó nem egyezik." },
-    "validation_password_minlength": { "other": "Kérjük, adj meg legalább {{.Count}} karaktert." },
-    "validation_promocode_required": { "other": "Kérjük, adj meg egy promókódot." },
-    "validation_pincode_required": { "other": "Kérjük, adjon meg egy PIN kódot." },
-    "validation_gender_required": { "other": "Kérjük válaszd ki azt a nemet, mellyel a leginkább azonosulsz." },
-    "validation_dob_required": { "other": "Kérjük, add meg a születési dátumodat." },
-    "validation_dob_date": { "other": "Kérjük, adj meg egy érvényes születési dátumot." },
-  
-    "shopping_info_subtitle_hd": { "other": "HD Videoszolgáltatás." },
-    "shopping_info_subtitle_sd": { "other": "SD Video on Demand." },
-    "shopping_info_subtitle_wallet": { "other": "A Pénztárcájában lévő pénzeszközök felhasználhatók a ScreenPlus-on található bármely tartalom megvásárlására vagy kölcsönzésére." },
-    "shopping_info_subtitle_help": { "other": "Nézd át a rendszerkövetelményeket." },
-    "shopping_info_ownership_buy": { "other": "vásárlás" },
-    "shopping_info_ownership_rent": { "other": "kölcsönzés" },
-  
-    "shopping_info_sd_only": { "other": "Csak SD lejátszásra korlátozva." },
-    "shopping_info_release_date_title": { "other": "Bemutató napja {{.Date}}. " },
-    "shopping_info_release_date_explanation_rent": { "other": "Már most kölcsönözhető, de a megjelenés dátumáig nem nézhető meg." },
-    "shopping_info_release_date_explanation_buy": { "other": "Már most megvásárolható, de a megjelenés dátumáig nem nézhető meg." },
-  
-    "shopping_info_available_until_date_title": { "other": "Elérhető {{.Date}}-ig. " },
-    "shopping_info_available_until_date_explanation_rent": { "other": "Ezután a dátum után nem lesz elérhető a tartalom." },
-    "shopping_info_available_until_date_explanation_buy": { "other": "Ezután a dátum után nem lesz elérhető a tartalom." },
-  
-    "duration_hour": { "one": "1 óra", "other": "{{.Count}} óra" },
-    "duration_day": { "one": "1 nap", "other": "{{.Count}} nap" },
-    "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} a kölcsönzési idő " },
-    "shopping_info_watch_window_duration": { "other": "{{.Count}} óra van a lejátszásra. " },
-    "shopping_info_watch_window_explanation_film": {
-      "one": "A kölcsönzéstől számítva a film elérhető lesz a fiókodban {{.ValueUnit}}. ",
-      "other": "A kölcsönzéstől számítva a film elérhető lesz a fiókodban {{.ValueUnit}}. "
-    },
-    "shopping_info_watch_window_explanation2_film": {
-      "one": "Ha megnyomod a lejátszást, a  lejátszásra biztosított idő megkezdődik és {{.Count}} órád lesz, hogy megnézd a filmet annyiszor, ahányszor akarod.",
-      "other": "Ha megnyomod a lejátszást, a  lejátszásra biztosított idő megkezdődik és {{.Count}} órád lesz, hogy megnézd a filmet annyiszor, ahányszor akarod."
-    },
-    "shopping_info_watch_window_explanation_bundle": {
-      "one": "A kölcsönzéstől számítva ez a válogatás elérhető lesz a fiókodban {{.Count}} napig. ",
-      "other": "A kölcsönzéstől számítva ez a válogatás elérhető lesz a fiókodban {{.Count}} napig. "
-    },
-    "shopping_info_watch_window_explanation2_bundle": {
-      "one": "Ha elindítod egy film lejátszását, a lejátszási idő elindul és {{.Count}} órád lesz, hogy megnézd azt a filmet annyiszor, ahányszor akarod.",
-      "other": "Ha elindítod egy film lejátszását, a lejátszási idő elindul és {{.Count}} órád lesz, hogy megnézd azt a filmet annyiszor, ahányszor akarod."
-    },
-    "shopping_info_watch_window_explanation_season": {
-      "one": "A kölcsönzéstől számítva az évad elérhető lesz a fiókodban {{.Count}} napig. ",
-      "other": "A kölcsönzéstől számítva az évad elérhető lesz a fiókodban {{.Count}} napig. "
-    },
-    "shopping_info_watch_window_explanation2_season": {
-      "one": "Ha elindítod egy epizód lejátszását, a lejátszásra biztosított idő megkezdődik és  {{.Count}} órád lesz, hogy megnézd az epizódot, ahányszor akarod.",
-      "other": "Ha elindítod egy epizód lejátszását, a lejátszásra biztosított idő megkezdődik és  {{.Count}} órád lesz, hogy megnézd az epizódot, ahányszor akarod."
-    },
-    "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Bónusz" },
-  
-    "shopping_enter_card_prompt": { "other": "Add meg bankkártya adataidat, hogy a {{.Verb}} létrejöjjön." },
-  
-    "shopping_terms": { "other": "A tranzakció teljesítésével elfogadod a <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">Felhasználói szabályzatot</a>."},
-    "shopping_discount_applied": { "other": "{{.DiscountAmount}} kedvezmény levonva." },
-    "shopping_discount_apply": { "other": "Alkalmazás." },
-    "shopping_discount_code": { "other": "Írj be egy promókódot." },
-    "shopping_discount_have_code": { "other": "Promókódom van." },
-  
-    "shopping_price_you_pay": { "other": "Fizetés összege" },
-    "shopping_price_nothing": { "other": "-" },
-    "shopping_price_free": { "other": "Ingyenes" },
-  
-    "shopping_auth_directions": { "other": "Fiók létrehozása szükséges. Kérjük, írd be az e-mail címedet." },
-  
-    "shopping_error_in_library": { "other": "{{.Title}} című film már a könyvtáradban van." },
-  
-    "shopping_error_missing_card": { "other": "Kérjük, add meg a bankkártya adataidat." },
-    "shopping_error_title": { "other": "Hiba történt." },
-    "shopping_error_incorrect_cvc": { "other": "Kérjük, adj meg egy érvényes CVV számot." },
-    "shopping_error_invalid_cvc": { "other": "Kérjük, adj meg egy érvényes CVV számot." },
-    "shopping_error_incorrect_number": { "other": "Kérjük, adj meg egy érvényes bankkártya számot." },
-    "shopping_error_invalid_number": { "other": "Kérjük, adj meg egy érvényes bankkártya számot." },
-    "shopping_error_card_declined": { "other": "A bankkártyát visszautasították." },
-    "shopping_error_invalid_expiry_month": { "other": "Kérjük, adj meg egy érvényes lejárati dátumot." },
-    "shopping_error_invalid_expiry_year": { "other": "Kérjük, adj meg egy érvényes lejárati dátumot." },
-    "shopping_error_expired_card": { "other": "A bankkártya lejárt." },
-    "shopping_error_creditcard_country_mismatch": { "other": "A {{.Ownership}} nem sikerült. Abban az országban kell tartózkodnod, ahol a bankkártyát kiállították. Kérjük, használj másik bankkártyát." },
-    "shopping_error_proxy_detected": { "other": "A {{.Ownership}} nem sikerült. Észleltük, hogy egy unblocker-t vagy proxy szolgáltatást használsz. Kérjük, kapcsold ki ezeket a szolgáltatásokat és próbálkozz újra." },
-  
-    "shopping_error_discount_worn_out": { "other": "Ez a promóciós kód már nem használható." },
-    "shopping_error_discount_blank": { "other": "Kérjük, adj meg egy promókódot." },
-    "shopping_error_discount_not_applied": { "other": "Kérjük, adj meg egy érvényes promókódot." },
-    "shopping_error_discount_invalid": { "other": "Kérjük, adj meg egy érvényes promókódot." },
-    "shopping_error_discount_disabled": { "other": "Kérjük, adj meg egy érvényes promókódot." },
-    "shopping_error_discount_already_applied": { "other": "Egy promókódot már felhasználtak erre a kérésre." },
-    "shopping_error_discount_already_redeemed": { "other": "Ezt a promókódot már felhasználták." },
-    "shopping_error_discount_used_previously": { "other": "Ezt a promókódot már felhasználták." },
-    "shopping_error_discount_max_limit": { "other": "Ezt a promókódot már nem tudod felhasználni." },
-    "shopping_error_discount_expired": { "other": "Ez a promókód már lejárt." },
-    "shopping_error_discount_invalid_ownership_buy": { "other": "Ezt a promókódot nem használhatod fel vásárláshoz." },
-    "shopping_error_discount_invalid_ownership_rent": { "other": "Ezt a promókódot nem használhatod fel kölcsönzéshez." },
-    "shopping_error_discount_invalid_item": { "other": "Ez a promókód nem használható fel erre a filmre." },
-    "shopping_error_discount_invalid_pricing_region": { "other": "Ez a promókód nem használható fel ebben az országban." },
-    "shopping_error_discounts_not_allowed": { "other": "Ez a promókód nem használható fel." },
-    "shopping_error_discount_disallowed_on_bundles": { "other": "Ezt a promókódot nem használhatod a bérletekre." },
-    "shopping_error_payment_intent_authentication_failure": { "other": "A bankkártyát visszautasították. Kérjük, próbálkozz újra." },
-  
-    "shopping_complete_rental": { "other": "Sikerült!" },
-    "shopping_complete_rental_period": {
-      "one": "Mostantól akárhányszor megnézheted a következő {{.Count}} napban.",
-      "other": "Mostantól akárhányszor megnézheted a következő {{.Count}} napban."
-    },
-    "shopping_complete_purchase": { "other": "Köszönjük a {.Title}} megvásárlását." },
-    "shopping_complete_credit_purchase": { "other": "Köszönjük, hogy megvásárolta a(z) {{.Title}} összeget, a(z) {{.CreditTotal}} hozzáadva a fiókjához." },
-    "shopping_complete_purchase_coming_soon": { "other": "{{.Date}}-tól megtekinthető." },
-    "shopping_complete_receipt": { "other": "A bizonylatot e-mailben elküldtük számodra." },
-    "shopping_complete_library_link": { "other": "Kezd el nézni bármelyiket a {{.BundleItems}} filmjei közül, melyeket mostantól megtalálsz a könyvtáradban." },
-    "shopping_complete_plan": {
-      "other": "A {{ .Title }} vásárlása sikeres volt."
-    },  
-    "shopping_complete_rental_watch_window_start": {
-      "one": "Mostantól bármikor elkezdheted megnézni a következő {{.Count}} napban.",
-      "other": "Mostantól bármikor elkezdheted megnézni a következő {{.Count}} napban."
-    },
-    "shopping_complete_rental_watch_window_end": {
-      "one": "Miután a lejátszást elindítottad {{.Count}} órád lesz, hogy megnézd a filmet, ahányszor csak szeretnéd.",
-      "other": "Miután a lejátszást elindítottad {{.Count}} órád lesz, hogy megnézd a filmet, ahányszor csak szeretnéd."
-    },
-    "shopping_complete_rental_coming_soon": {
-      "one": "{{.Date}}-tól tudod megnézni a filmet és a kölcsönzésed státusza aktív lesz további {{.Count}} napig.",
-      "other": "{{.Date}}-tól tudod megnézni a filmet és a kölcsönzésed státusza aktív lesz további {{.Count}} napig."
-    },
-    "shopping_complete_rental_coming_soon_watch_window_start": {
-      "one": "{{.Date}}-tól tudod megnézni a filmet és a kölcsönzésed státusza aktív lesz további {{.Count}} napig.",
-      "other": "{{.Date}}-tól tudod megnézni a filmet és a kölcsönzésed státusza aktív lesz további {{.Count}} napig."
-    },
-  
-    "shopping_action_rent": { "other": "Kölcsönzés" },
-    "shopping_action_buy": { "other": "Vásárlás" },
-  
-    "meta_detail_cast_title": { "other": "Szereplők" },
-    "meta_detail_crew_title": { "other": "Stáb" },
-    "meta_detail_languages": { "one": "Nyelv", "other": "Nyelv" },
-    "meta_detail_studios": { "one": "Gyártó", "other": "Gyártó" },
-    "meta_detail_countries": { "one": "Ország", "other": "Ország" },
-    "meta_detail_subtitles": { "other": "Felirat" },
-    "meta_detail_captions": { "other": "Felirat [CC]" },
-    "meta_detail_episodes_title": { "other": "Epizódok" },
-    "meta_detail_bonus_title": { "other": "Extra tartalom" },
-    "meta_detail_recommendations_title": { "other": "Talán ez is tetszene" },
-    "meta_detail_bundle_items_title": { "other": "A válogatásban szereplő filmek" },
-  
-    "bundle_items_all_films": { "other": "{{.Count}} film" },
-    "bundle_items_all_seasons": { "other": "{{.Count}} évad" },
-    "bundle_items_mixed": { "other": "{{.Count}} film és évad" },
-    "userwishlist_page_header": { "other": "Listám" },
-    "userwishlist_slider_header": { "other": "Listám" },
-    "userwishlist_empty_header":  { "other": "A listád üres." },
-    "userwishlist_empty_content": { "other": "Töltsd meg kiváló filmekkel, nézd át a <a href=\"{{.HomeURL}}\">programot</a>." },
-    "userwishlist_button_add": { "other": "Add hozzá a listámhoz." },
-    "userwishlist_button_remove": { "other": "Listám" },
-    "userwishlist_button_add_compact": { "other": "Listám" },
-    "userwishlist_button_remove_compact": { "other": "Listám" },
-  
-    "activatedevice_page_header": { "other": "Eszköz aktiválása" },
-    "activatedevice_page_content": { "other": "Kövesse az eszközén megjelenő utasításokat a PIN-kód megszerzéséhez. Az aktiváláshoz számítógépének és eszközének egyaránt csatlakoznia kell az internethez." },
-    "activatedevice_form_pin": { "other": "PIN-kód" },
-    "activatedevice_form_submit": { "other": "Aktiválja" },
-    "activatedevice_form_error_invalid_code": { "other": "A PIN kód nem található, próbálja újra." },
-    "activatedevice_form_error_pin_not_found": { "other": "A PIN kód nem található, próbálja újra." },
-    "activatedevice_signin_prompt": { "other": "Kérjük, jelentkezzen be az eszköz aktiválása előtt." },
-    "activatedevice_page_activated": { "other": "Köszönjük a {{.DeviceName}} aktiválását. Most már képesnek kell lennie böngészni a könyvtárában televízióján vagy eszközén." },
-  
-    "userdevices_page_header": { "other": "Eszközök" },
-    "userdevices_page_content": {
-      "one": "Az eszközök a használat során automatikusan felkerülnek ide. A maximum használható eszközök száma {{.Count}}.",
-      "other": "Az eszközök a használat során automatikusan felkerülnek ide. A maximum használható eszközök száma {{.Count}}."
-    },
-    "userdevices_empty_content": { "other": "Jelenleg egy eszköz sincs regisztrálva." },
-    "userdevices_header_type": { "other": "Eszköz típusa" },
-    "userdevices_header_description": { "other": "Leírás" },
-    "userdevices_device_added": { "other": "Hozzáadva {{.Date}}" },
-    "userdevices_device_actions_delete": { "other": "Eltávolítás" },
-    "userdevices_device_actions_cancel": { "other": "Mégse" },
-    "userdevices_device_actions_confirm": { "other": "Igen, töröld az eszközt" },
-    "userdevices_device_deleted": { "other": "(Törölve)" },
-  
-    "playlist_page_header": { "other": "lejátszási lista" },
-    "playlist_sign_in_warning": { "other": "Kérjük, jelentkezzen be, hogy élő tévéadást nézhessen."},
-    "playlist_share_title": { "other": "lejátszási lista" },
-    "playlist_up_next_title": { "other": "Fel Következő" },
-  
-    "pricing_ownership_buy": { "other": "Megveszem" },
-    "pricing_ownership_rent": { "other": "Kikölcsönzöm" },
-  
-    "classification_intro": { "other": "Korhatár besorolás: " },
-    "classification_divider": { "other": " - " },
-    "classification_outro": { "other": "" },
-  
-    "cookie_banner_message": { "other": "Ez az oldal sütiket használ a felhasználói élmény növelésének érdekében. Amennyiben ezt az oldalt használod, elfogadod a <a href=\"{{.CookiePolicyURL}}\">sütik használatára vonatkozó feltételeket</a>-ot." },
-    "cookie_banner_accept": { "other": "Elfogad" },
-  
-    "all_rights_reserved": { "other": "Minden jog fenntartva. Az oldal egyetlen része sem reprodukálható írásos engedélyünk nélkül." },
-  
-    "users_gender_none": { "other": "Nem meghatározott" },
-    "users_gender_female": { "other": "Nő" },
-    "users_gender_male": { "other": "Férfi" },
-    "users_gender_diverse": { "other": "Diverz" },
-    "users_gender_other": { "other": "Egyéb" },
-  
-    "pricing_quality_hd": { "other": "HD" },
-    "pricing_quality_sd": { "other": "SD" },
-    "pricing_quality_hd_only": { "other": "Csak HD" },
-    "pricing_quality_sd_only": { "other": "Csak SD" },
-  
-    "shopping_card_save_card": { "other": "Őrizze meg ezt a kártyát későbbi használatra" },
-    "shopping_card_button_change": { "other": "Az összes mentett kártya megjelenítése" },
-    "shopping_card_existing_description": { "other": "{{.Card.Brand}}, amely a következőre végződik: {{.Card.Number}}" },
-    "shopping_card_existing_expiry": { "other": "(lejár: {{.Card.Expiry}})" },
-    "shopping_card_existing_expired": { "other": "(lejárt)" },
-    "shopping_card_use_other": { "other": "Használjon új kártyát" },
-    "shopping_card_use_new_card": { "other": "Válts kártyát" },
-  
-    "shopping_info_ownership_plan": { "other": "Feliratkozás" },
-  
-    "shopping_action_credit": { "other": "Feltölt" },
-
-    "shopping_info_rental_period_coming_soon": { "other": "a bemutató időpontjától." },
-
-  
-    "usersubscriptions_change_payment_method_change": { "other": "Hitelkártya módosítása" },
-    "usersubscriptions_change_payment_method_modal_title": { "other": "Frissítse a hitelkártya adatait" },
-    "usersubscriptions_change_payment_method_modal_submit": { "other": "Frissítés" },
-  
-    "usersubscriptions_subscription_expiry": { "other": "Lejár: {{.Expiry}}" },
-    "usersubscriptions_subscription_status_cancelled": { "other": "usersubscriptions_subscription_status_cancelled" },
-    "usersubscriptions_subscription_status_errored": { "other": "usersubscriptions_subscription_status_errored" },
-    "usersubscriptions_subscription_status_past_due": { "other": "usersubscriptions_subscription_status_past_due" },
-    "usersubscriptions_subscription_status_trialing": { "other": "Próbaidő" },
-    "usersubscriptions_subscription_unsubscribe": { "other": "Lemondom az előfizetésemet" },
-    "usersubscriptions_unsubscribe_modal_cancel": { "other": "Megszünteti" },
-    "usersubscriptions_unsubscribe_modal_confirm": { "other": "Igen, mondd le az előfizetésemet" },
-    "usersubscriptions_unsubscribe_modal_title": { "other": "Feliratkozás visszavonása?" },
-    "usersubscriptions_unsubscribe_modal_body": { "other": "Ezzel törli az előfizetést a {{.Name}} csomagra. Továbbra is megtekintheti a csomag tartalmát, amíg le nem jár {{.Expiry}}." },
-  
-    "shopping_card_update_reason_none": { "other": "Frissítse hitelkártyáját. A támogatott kártyák a Visa, Mastercard és az American Express." },
-  
-    "availability_coming_soon": { "other": "Hamarosan" },
-    "availability_renting": { "other": "Kölcsönözve" },
-    "availability_not_available": { "other": "Nem elérhető" },
-    "availability_in_watch_window": { "other": "Elérhető" },
-    "availability_sold_out": { "other": "Teltház" },
-    "availability_available_till": { "other": "Elérhető {{.ExpiryDate}}-ig" },
-    "availability_not_available_in_country": { "other": "Nem elérhető" },
-    "availability_available": { "other": "Elérhető {{.ReleaseDate}}" },
-  
-    "modal_cancel": { "other": "Mégsem" },
-  
-    "play": { "other": "Lejátszás" },
-  
-    "combined_auth_signin_prompt": { "other": "Bejelentkezés" },
-    "combined_auth_signup_prompt": { "other": "Feliratkozás" },
-    "combined_auth_terms": { "other": "Elfogadom a <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Felhasználói szabályzatot</a>." },
-    "signup_terms": { "other": "Elfogadom a <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Felhasználói szabályzatot</a>." },
-    "validation_terms_required": { "other": "Kérjük, fogadd el a Felhasználói szabályzatot." },
-    "shopping_error_item_limit_exceeded": { "other": "Sajnáljuk, de {{.Title}} tételre már minden jegy elkelt." },
-
-    "shopping_card_change": { "other": "Hitelkártya nem megfelelő? <a href=\"{{.SubscriptionsURL}}\">Kattintson ide a kártya frissítéséhez.</a>" },
-
-    "user_error_too_many_pin_errors": { "other": "<p>Úgy tűnik, hogy problémái vannak.</p><p>Állítsa vissza PIN-kódját, vagy forduljon hozzánk <a href=\"{{.HelpURL}}\" target=\"_blank\">segítségért</. a>" },
-    
-    "app_badge_title": { "other": "Töltse le az alkalmazást a megvásárolt tartalmak megtekintéséhez!" },
-    "app_badge_ios": { "other": "Töltse le az App Store-ból" },
-    "app_badge_android": { "other": "Szerezd meg a Google Play" },
-
-    "shopping_price_title_plan": {
-      "other": "Ár"
-    },
-    "shopping_price_plan_note": {
-      "zero": "{{ .Interval }} minden .Intervallum .",
-      "one": "A 24 órás ingyenes próbaidőszak {{ .Interval }} után minden .Intervallumonként felszámításra kerül.",
-      "other": "{{ .Count }} napos ingyenes próbaidőszak {{ .Interval }} után minden .Intervallum felszámításra kerül."
-    },
-    "shopping_price_plan_note_interval": {
-      "one": "{{ .Interval }}",
-      "other": "{{ .Count }} {{ .Interval }}"
-    },
-    "shopping_enter_card_prompt_plan": {
-      "other": "Az előfizetés megkezdéséhez adja meg alább hitelkártyaadatait."
-    },
-    "shopping_action_plan": {
-      "other": "teljes"
-    },
-    "shopping_complete_subscription": {
-      "other": "Az előfizetés vásárlása sikeres volt. Feliratkozott a {{ .Title }} ."
-    },
-    "shopping_complete_subscription_browse": {
-      "other": "Nyugodtan <a href=\"/\">böngésszen</a> az oldalon, vagy <a href=\"/search.html\">keressen</a> valami konkrétat."
-    },
-    "shopping_info_plan_offer": {
-      "one": "Automatikusan megújítja minden {{ .Interval }}",
-      "other": "Automatikusan {{ .Count }} {{ .Interval }}"
-    },
-    "shopping_info_trial_period_offer": {
-      "one": "Próbálja ki most az ingyenes 24 órás próbaverziót!",
-      "other": "Próbálja ki ingyenes {{ .Count }} napos próbaverzióját!"
-    },
-    "plans_page_header": {
-      "other": "Rendelkezésre álló tervek"
-    },
-    "plan_label_owned": {
-      "other": "Öné ez a terv"
-    },
-    "plan_expiry_date": {
-      "other": "Az értékesítés lezárása:"
-    },
-    "plan_read_more": {
-      "other": "Tudjon meg többet"
-    },
-    "plan_page_read_more": {
-      "other": "Olvass tovább"
-    },
-    "plan_page_header_text": {
-      "other": "Élvezze {{ .Name }}"
-    },
-    "page_plan_explore_intro": {
-      "other": "VAGY"
-    },
-    "page_plan_explore_link": {
-      "other": "Fedezzen fel más bérleteket"
-    },
-    "plan_showcase_page_ownership_button_buy": {
-      "other": "Vásárolj most"
-    },
-    "plan_free_link_text": {
-      "other": "Regisztrálj ingyen"
-    },
-    "awards_in_competition": {
-      "other": "Versenyben"
-    },
-    "awards_winner": {
-      "other": "Győztes"
-    },
-    "donate_button_text": {
-      "other": "Dhuroni"
-    },
-    "wcag_skip_links_header": { "other": "Kisegítő lehetőségek linkek" },
-    "wcag_skip_links_content": { "other": "Ugrás a tartalomra" },
-  
-    "wcag_homepage_h1": { "other": "Kezdőlap" },
-    "wcag_carousel_h2": { "other": "Körhinta" },
-    "wcag_collections_h2": { "other": "Gyűjtemények" },
-  
-    "wcag_aria_label_footer": { "other": "Lábléc" },
-    "wcag_aria_label_nav_main": { "other": "Fő" },
-    "wcag_aria_label_nav_sub": { "other": "Alatti" },
-    "wcag_aria_label_toggle_nav": { "other": "Kapcsolja be a navigációt" },
-    "wcag_aria_label_bundle_items": { "other": "Csomag tételek" },
-    "wcag_aria_label_carousel": { "other": "Körhinta" },
-    "wcag_aria_label_page_collection": { "other": "Oldalgyűjtemény" },
-    "wcag_aria_label_collection_list": { "other": "Gyűjteménylista" },
-    "wcag_aria_label_collection_slider": { "other": "Gyűjteménycsúszka" },
-    "wcag_aria_label_wishlist": { "other": "Kívánság lista" },
-    "wcag_aria_label_facebook": { "other": "Megosztani Facebook" },
-    "wcag_aria_label_twitter": { "other": "Oszd meg a Twitter" },
-    "wcag_aria_label_linkedin": { "other": "Oszd meg a LinkedIn" },
-    "wcag_aria_label_letterboxd": { "other": "Megtekintés a Letterboxd" },
-
-    "shopping_error_plan_already_owned": { "other": "Már megvan ez a terv." },
-    "shopping_error_plan_expired": { "other": "Ez a terv már nem elérhető." },
-    "shopping_payment_method_header": { "other": "Fizetési módok" },
-    "shopping_payment_method_credit_card": { "other": "Hitelkártya" },
-    "shopping_payment_method_giropay": { "other": "Giropay" },
-    "shopping_error_stripe_unknown_error": { "other": "Hiba történt ezzel a fizetéssel. Kérlek, próbáld újra később." },
-    "shopping_error_payment_complete_failed": { "other": "A fizetést elutasították. Zárja be ezt az ablakot, és próbálja újra." },
-
-    "header_banner": { "other": "ABC Cinemas – 21. Filmfesztivál, 2021. június 1. és 6. között" },
-
-    "account_form_pin_code": { "other": "PIN" },
-    "account_form_pin_code_not_set": { "other": "Nincs beállítva PIN-kód, amely bizonyos címek megvásárlásához, kölcsönzéséhez és megtekintéséhez szükséges."},
-    "account_form_set_pin": { "other": "Állítsa be a PIN-kódot" },
-    "account_form_pin_changed": { "other": "Frissítve" },
-    "account_form_change_pin": { "other": "PIN módosítása" },
-
-    "user_set_pin_header": { "other": "Állítsa be a PIN-kódot" },
-    "user_set_pin_button": { "other": "Állítsa be a PIN-kódot" },
-    "user_submit_pin_heading": { "other": "Adja meg PIN-kódját ehhez a korlátozott tartalomhoz {{.Action}}" },
-    "user_error_wrong_pin_retry": { "other": "Hoppá, hibás PIN-kódot adott meg" },
-    "user_submit_pin_button": { "other": "Belép" },
-    "user_reset_pin_button": { "other": "Állítsa vissza a PIN-kódot" },
-
-    "validation_pincode1_required": { "other": "Kérjük, adjon meg egy érvényes PIN kódot." },
-    "validation_pincode2_required": { "other": "Kérjük, adjon meg egy érvényes PIN kódot" },
-    "validation_pincode1_pattern": { "other": "Kérjük, adjon meg egy érvényes PIN kódot" },
-    "validation_pincode2_pattern": { "other": "Kérjük, adjon meg egy érvényes PIN kódot" },
-    "validation_pincode2_match": { "other": "A PIN kód nem egyezik." },
-  
-    "userdevices_delete_limits": { "other": "{{.Limit}} eszközt eltávolíthat a listáról minden {{.Period}} napon."},
-    "userdevices_delete_limit_reached": { "other": "Elérte ezt a korlátot, és jelenleg nem távolíthat el egyetlen eszközt sem. Egy eszközt {{.Days}} napon belül törölhet." },
-    "shopping_card_new_subscription": { "other": "Ezt a kártyát a rendszer elmenti és rendszeresen megterheli" },
-
-  "changepincode_modal_header": { "other": "Módosítsa a PIN-kódot" },
-  "changepincode_modal_currentpassword": { "other": "Az aktuális jelszavad" },
-  "changepincode_modal_pincode1": { "other": "Az új 4 számjegyű PIN-kód" },
-  "changepincode_modal_pincode2": { "other": "Erősítse meg új 4 számjegyű PIN-kódját" },
-  "changepincode_modal_submit": { "other": "Állítsa be a PIN-kódot" },
-  "changepincode_modal_error_wrong_password": { "other": "Ez a jelszó helytelen." },
-
-  "user_set_pin_intro": { "other": "A {{.Action}} korlátozott tartalomhoz PIN-kódra van szüksége"},
-  "user_error_wrong_pin_reset": { "other": "Kattintson ide a PIN-kód visszaállításához" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Ez a tartalom korhatáros." },
-  "shopping_error_close_button": { "other": "OK" }, 
-
-  "availability_expires": { "other": "Lejár {{.Expiry}}" },
-  "availability_expired": { "other": "Lejárt"}
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Settings"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
+  "episode_name": {
+    "other": "Epizód"
+  },
+  "season_name": {
+    "other": "Évad"
+  },
+  "seasons": {
+    "one": "egy szezont",
+    "other": "{{.Count}} évszakok"
+  },
+  "tvseason": {
+    "other": "{{.ShowInfo.Title}} Sorozat {{.Season.SeasonNumber}}"
+  },
+  "tvseason_html": {
+    "other": "{{.ShowInfo.Title}} <span>Sorozat {{.Season.SeasonNumber}}</span>"
+  },
+  "tvepisode": {
+    "other": "{{.Episode.Title}}"
+  },
+  "tvseason_number": {
+    "other": "Series {{.Season.SeasonNumber}}"
+  },
+  "episode_count": {
+    "one": "1 Epizód",
+    "other": "{{.Count}} Epizódok"
+  },
+  "date_day": {
+    "other": "Nap"
+  },
+  "date_month": {
+    "other": "Hónap"
+  },
+  "date_year": {
+    "other": "Év"
+  },
+  "404_page_header": {
+    "other": "A keresett oldal nem létezik..."
+  },
+  "404_page_content": {
+    "other": "<p>Sajnos úgy tűnik, hogy a keresett oldal nem létezik.</p><p>Talán törölték vagy áthelyezték, kérjük ellenőrizd, hogy helyesen írtad-e be a címet.</p><p>Próbálj visszamenni a kezdőlapra, hogy megtaláld, amit keresel.</p><p><a href=\"{{.URL}}\">Vissza a kezdőlapra</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Bejelentkezés"
+  },
+  "nav_signup": {
+    "other": "Fiók létrehozása"
+  },
+  "nav_signed_in_as": {
+    "other": "Bejelentkezve"
+  },
+  "nav_library": {
+    "other": "Könyvtáram"
+  },
+  "nav_devices": {
+    "other": "Eszközeim"
+  },
+  "nav_wishlist": {
+    "other": "Listám"
+  },
+  "nav_account": {
+    "other": "Fiókom"
+  },
+  "nav_signout": {
+    "other": "Kijelentkezés"
+  },
+  "play_trailer": {
+    "other": "Előzetes"
+  },
+  "runtime_hours": {
+    "other": "óra"
+  },
+  "runtime_minutes": {
+    "other": "perc"
+  },
+  "datetime_today": {
+    "other": "ma {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "holnap {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "tegnap {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "utolsó {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Keresés"
+  },
+  "search_control_submit": {
+    "other": "Keresés indítása"
+  },
+  "play_button_watch": {
+    "other": "Lejátszás"
+  },
+  "play_button_resume": {
+    "other": "Folytatás"
+  },
+  "social_media_buttons_title": {
+    "other": "Megosztás"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Megosztani Facebookon"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Oszd meg a Twitteren"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Oszd meg a Linkedin-en"
+  },
+  "social_media_buttons_email": {
+    "other": "Oszd meg e-mailben"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Link megosztás"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link a vágólapra másolva!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Másolja a vágólapra"
+  },
+  "accept_invite_page_header": {
+    "other": "Üdvözöljük "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Úgy tűnik, már felhasználtad a meghívódat, próbálj meg <a href=\"{{.SigninURL}}\">bejelentkezni</a>. Ha elfelejtetted a jelszavadat, <a href=\"{{.ForgotPasswordURL}}\">állíts be újat</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Köszönjük. A fiókodat létrehoztuk."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Meghívó elfogadása"
+  },
+  "acceptinvite_agreement": {
+    "other": "Meghívó elfogadása -ra kattintva hozzájárulsz, hogy elolvastad és megértetted a <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Felhasználói szabályzatot</a> és az <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\tvédelmi szabályzatot</a>."
+  },
+  "signup_page_header": {
+    "other": "Új fiók létrehozása"
+  },
+  "signup_form_name": {
+    "other": "Név"
+  },
+  "signup_form_email": {
+    "other": "E-mail cím"
+  },
+  "signup_form_password": {
+    "other": "Jelszó"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Jelszó megerősítése"
+  },
+  "signup_form_gender": {
+    "other": "Nem"
+  },
+  "signup_form_dob": {
+    "other": "Születési dátum"
+  },
+  "signup_form_submit": {
+    "other": "Fiók létrehozása"
+  },
+  "signin_page_header": {
+    "other": "Bejelentkezés"
+  },
+  "signin_form_email": {
+    "other": "E-mail cím"
+  },
+  "signin_form_password": {
+    "other": "Jelszó"
+  },
+  "signin_form_remember": {
+    "other": "Emlékezz rám"
+  },
+  "signin_form_submit": {
+    "other": "Bejelentkezés"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Elfelejtetted a jelszavadat?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Nincs még fiókod? Új fiók létrehozása"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Már van fiókod? Bejelentkezés"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Ezt az e-mail címet már használják."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "A felhasználónév vagy jelszó hibás."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Túl sokszor nem sikerült bejelentkeznie. Kérlek, próbáld újra később."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "A fiókod ideiglenesen fel lett függesztve. Kérjük, forduljon egy adminisztrátorhoz, ha úgy gondolja, hogy ez tévedés."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Hiba történt."
+  },
+  "combined_auth_continue": {
+    "other": "Folytatás"
+  },
+  "combined_auth_change": {
+    "other": "megváltoztatás"
+  },
+  "combined_auth_signin": {
+    "other": "Bejelentkezés"
+  },
+  "combined_auth_signup": {
+    "other": "Fiók létrehozása"
+  },
+  "combined_auth_signin_password": {
+    "other": "Kérjük, add meg a jelszavadat a fiókodba történő belépéshez."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Hibás jelszó."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Hiba történt."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Túl sok kérés. Kérlek, próbáld újra később."
+  },
+  "forgotpassword_page_header": {
+    "other": "Új jelszó beállítása"
+  },
+  "forgotpassword_form_email": {
+    "other": "E-mail cím"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Visszaállítás"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Nincs ehhez az e-mail címhez rendelt fiók."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Ezt a fiókot felfüggesztették."
+  },
+  "forgotpassword_complete": {
+    "other": "Köszönjük. A jelszó visszaállításáról hamarosan e-mailed érkezik."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Hiba történt."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Túl sok kérés. Kérlek, próbáld újra később."
+  },
+  "resetpassword_page_header": {
+    "other": "Jelszó megváltoztatása."
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Úgy tűnik, hogy ez a jelszó érvénytelen, kérjük töltsd ki ismét az <a href=\"{{.URL}}\">Elfelejtett jelszó</a> űrlapot.."
+  },
+  "resetpassword_form_password": {
+    "other": "Új jelszó"
+  },
+  "resetpassword_form_password2": {
+    "other": "Új jelszó megerősítése"
+  },
+  "resetpassword_form_submit": {
+    "other": "Megváltoztatás"
+  },
+  "resetpassword_complete": {
+    "other": "Köszönjük. A jelszavad megváltoztattad, bejelentkezésed sikeres."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "A jelszó megváltoztatásának igénye érvénytelen. Kérjük, próbáld meg újra később."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "A jelszó megváltoztatására küldött token lejárt. Igényelj újat."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Túl sok kérés. Kérlek, próbáld újra később."
+  },
+  "account_page_header": {
+    "other": "Fiókom"
+  },
+  "account_form_name": {
+    "other": "Név"
+  },
+  "account_form_email": {
+    "other": "E-mail cím"
+  },
+  "account_form_password": {
+    "other": "Jelszó"
+  },
+  "account_form_change_password": {
+    "other": "Megváltoztatás"
+  },
+  "account_form_gender": {
+    "other": "Nem"
+  },
+  "account_form_dob": {
+    "other": "Születési dátum"
+  },
+  "account_form_submit": {
+    "other": "Frissítés"
+  },
+  "account_form_submitted": {
+    "other": "Frissítve"
+  },
+  "account_form_password_changed": {
+    "other": "Frissítve"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Ez a jelszó hibás."
+  },
+  "signup_form_optin": {
+    "other": "Iratkozz fel ingyenes hírlevelünkre."
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Jelszó megerősítése."
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Kérjük, add meg a jelszavadat, hogy mentsd a változtatásokat."
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Megerősítés"
+  },
+  "changepassword_modal_header": {
+    "other": "Jelszó megváltoztatása"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Jelenlegi jelszavad"
+  },
+  "changepassword_modal_password": {
+    "other": "Új jelszó"
+  },
+  "changepassword_modal_password2": {
+    "other": "Erősítsd meg az új jelszavad"
+  },
+  "changepassword_modal_submit": {
+    "other": "Megváltoztatás"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Ez a jelszó hibás."
+  },
+  "userlibrary_page_header": {
+    "other": "Könyvtáram"
+  },
+  "userlibrary_empty_header": {
+    "other": "A könyvtárad üres."
+  },
+  "userlibrary_empty_content": {
+    "other": "Töltsd meg kiváló filmekkel, nézd át a <a href=\"{{.HomeURL}}\">programot</a>."
+  },
+  "searchresults_page_header": {
+    "other": "Keresési találatok"
+  },
+  "searchresults_load_more": {
+    "other": "Mutass még {{.Count}} találatot."
+  },
+  "searchresults_total": {
+    "one": "A \"{{.Query}}\" {{.Count}} találatot hozott.",
+    "other": "A \"{{.Query}}\" {{.Count}} találatot hozott."
+  },
+  "searchresults_empty_header": {
+    "other": "A \"{{.Query}}\" egy találatot sem hozott."
+  },
+  "searchresults_empty_content": {
+    "other": "Próbálj meg mégegyszer rákeresni vagy <a href=\"{{.HomeURL}}\">nézd át a kínálatot</a>, hogy megtaláld, amit keresel."
+  },
+  "validation_name_required": {
+    "other": "Kérjük, add meg a nevedet."
+  },
+  "validation_email_required": {
+    "other": "Kérjük, add meg a nevedet."
+  },
+  "validation_email_email": {
+    "other": "Kérjük, adj meg egy érvényes e-mail címet."
+  },
+  "validation_currentpassword_required": {
+    "other": "Kérjük, add meg a jelenlegi jelszavadat."
+  },
+  "validation_password_required": {
+    "other": "Kérjfük, adj meg egy jelszót."
+  },
+  "validation_password2_required": {
+    "other": "Kérjük, erősítsd meg a jelszavadat."
+  },
+  "validation_password2_match": {
+    "other": "A két jelszó nem egyezik."
+  },
+  "validation_password_minlength": {
+    "other": "Kérjük, adj meg legalább {{.Count}} karaktert."
+  },
+  "validation_promocode_required": {
+    "other": "Kérjük, adj meg egy promókódot."
+  },
+  "validation_pincode_required": {
+    "other": "Kérjük, adjon meg egy PIN kódot."
+  },
+  "validation_gender_required": {
+    "other": "Kérjük válaszd ki azt a nemet, mellyel a leginkább azonosulsz."
+  },
+  "validation_dob_required": {
+    "other": "Kérjük, add meg a születési dátumodat."
+  },
+  "validation_dob_date": {
+    "other": "Kérjük, adj meg egy érvényes születési dátumot."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Videoszolgáltatás."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video on Demand."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "A Pénztárcájában lévő pénzeszközök felhasználhatók a ScreenPlus-on található bármely tartalom megvásárlására vagy kölcsönzésére."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Nézd át a rendszerkövetelményeket."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "vásárlás"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "kölcsönzés"
+  },
+  "shopping_info_sd_only": {
+    "other": "Csak SD lejátszásra korlátozva."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Bemutató napja {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Már most kölcsönözhető, de a megjelenés dátumáig nem nézhető meg."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Már most megvásárolható, de a megjelenés dátumáig nem nézhető meg."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Elérhető {{.Date}}-ig. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Ezután a dátum után nem lesz elérhető a tartalom."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Ezután a dátum után nem lesz elérhető a tartalom."
+  },
+  "duration_hour": {
+    "one": "1 óra",
+    "other": "{{.Count}} óra"
+  },
+  "duration_day": {
+    "one": "1 nap",
+    "other": "{{.Count}} nap"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} a kölcsönzési idő "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} óra van a lejátszásra. "
+  },
+  "shopping_info_watch_window_explanation_film": {
+    "one": "A kölcsönzéstől számítva a film elérhető lesz a fiókodban {{.ValueUnit}}. ",
+    "other": "A kölcsönzéstől számítva a film elérhető lesz a fiókodban {{.ValueUnit}}. "
+  },
+  "shopping_info_watch_window_explanation2_film": {
+    "one": "Ha megnyomod a lejátszást, a  lejátszásra biztosított idő megkezdődik és {{.Count}} órád lesz, hogy megnézd a filmet annyiszor, ahányszor akarod.",
+    "other": "Ha megnyomod a lejátszást, a  lejátszásra biztosított idő megkezdődik és {{.Count}} órád lesz, hogy megnézd a filmet annyiszor, ahányszor akarod."
+  },
+  "shopping_info_watch_window_explanation_bundle": {
+    "one": "A kölcsönzéstől számítva ez a válogatás elérhető lesz a fiókodban {{.Count}} napig. ",
+    "other": "A kölcsönzéstől számítva ez a válogatás elérhető lesz a fiókodban {{.Count}} napig. "
+  },
+  "shopping_info_watch_window_explanation2_bundle": {
+    "one": "Ha elindítod egy film lejátszását, a lejátszási idő elindul és {{.Count}} órád lesz, hogy megnézd azt a filmet annyiszor, ahányszor akarod.",
+    "other": "Ha elindítod egy film lejátszását, a lejátszási idő elindul és {{.Count}} órád lesz, hogy megnézd azt a filmet annyiszor, ahányszor akarod."
+  },
+  "shopping_info_watch_window_explanation_season": {
+    "one": "A kölcsönzéstől számítva az évad elérhető lesz a fiókodban {{.Count}} napig. ",
+    "other": "A kölcsönzéstől számítva az évad elérhető lesz a fiókodban {{.Count}} napig. "
+  },
+  "shopping_info_watch_window_explanation2_season": {
+    "one": "Ha elindítod egy epizód lejátszását, a lejátszásra biztosított idő megkezdődik és  {{.Count}} órád lesz, hogy megnézd az epizódot, ahányszor akarod.",
+    "other": "Ha elindítod egy epizód lejátszását, a lejátszásra biztosított idő megkezdődik és  {{.Count}} órád lesz, hogy megnézd az epizódot, ahányszor akarod."
+  },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Bónusz"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Add meg bankkártya adataidat, hogy a {{.Verb}} létrejöjjön."
+  },
+  "shopping_terms": {
+    "other": "A tranzakció teljesítésével elfogadod a <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">Felhasználói szabályzatot</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} kedvezmény levonva."
+  },
+  "shopping_discount_apply": {
+    "other": "Alkalmazás."
+  },
+  "shopping_discount_code": {
+    "other": "Írj be egy promókódot."
+  },
+  "shopping_discount_have_code": {
+    "other": "Promókódom van."
+  },
+  "shopping_price_you_pay": {
+    "other": "Fizetés összege"
+  },
+  "shopping_price_nothing": {
+    "other": "-"
+  },
+  "shopping_price_free": {
+    "other": "Ingyenes"
+  },
+  "shopping_auth_directions": {
+    "other": "Fiók létrehozása szükséges. Kérjük, írd be az e-mail címedet."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} című film már a könyvtáradban van."
+  },
+  "shopping_error_missing_card": {
+    "other": "Kérjük, add meg a bankkártya adataidat."
+  },
+  "shopping_error_title": {
+    "other": "Hiba történt."
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Kérjük, adj meg egy érvényes CVV számot."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Kérjük, adj meg egy érvényes CVV számot."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Kérjük, adj meg egy érvényes bankkártya számot."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Kérjük, adj meg egy érvényes bankkártya számot."
+  },
+  "shopping_error_card_declined": {
+    "other": "A bankkártyát visszautasították."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Kérjük, adj meg egy érvényes lejárati dátumot."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Kérjük, adj meg egy érvényes lejárati dátumot."
+  },
+  "shopping_error_expired_card": {
+    "other": "A bankkártya lejárt."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "A {{.Ownership}} nem sikerült. Abban az országban kell tartózkodnod, ahol a bankkártyát kiállították. Kérjük, használj másik bankkártyát."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "A {{.Ownership}} nem sikerült. Észleltük, hogy egy unblocker-t vagy proxy szolgáltatást használsz. Kérjük, kapcsold ki ezeket a szolgáltatásokat és próbálkozz újra."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Ez a promóciós kód már nem használható."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Kérjük, adj meg egy promókódot."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Kérjük, adj meg egy érvényes promókódot."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Kérjük, adj meg egy érvényes promókódot."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Kérjük, adj meg egy érvényes promókódot."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Egy promókódot már felhasználtak erre a kérésre."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Ezt a promókódot már felhasználták."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Ezt a promókódot már felhasználták."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Ezt a promókódot már nem tudod felhasználni."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Ez a promókód már lejárt."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Ezt a promókódot nem használhatod fel vásárláshoz."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Ezt a promókódot nem használhatod fel kölcsönzéshez."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Ez a promókód nem használható fel erre a filmre."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Ez a promókód nem használható fel ebben az országban."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Ez a promókód nem használható fel."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Ezt a promókódot nem használhatod a bérletekre."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "A bankkártyát visszautasították. Kérjük, próbálkozz újra."
+  },
+  "shopping_complete_rental": {
+    "other": "Sikerült!"
+  },
+  "shopping_complete_rental_period": {
+    "one": "Mostantól akárhányszor megnézheted a következő {{.Count}} napban.",
+    "other": "Mostantól akárhányszor megnézheted a következő {{.Count}} napban."
+  },
+  "shopping_complete_purchase": {
+    "other": "Köszönjük a {.Title}} megvásárlását."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Köszönjük, hogy megvásárolta a(z) {{.Title}} összeget, a(z) {{.CreditTotal}} hozzáadva a fiókjához."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "{{.Date}}-tól megtekinthető."
+  },
+  "shopping_complete_receipt": {
+    "other": "A bizonylatot e-mailben elküldtük számodra."
+  },
+  "shopping_complete_library_link": {
+    "other": "Kezd el nézni bármelyiket a {{.BundleItems}} filmjei közül, melyeket mostantól megtalálsz a könyvtáradban."
+  },
+  "shopping_complete_plan": {
+    "other": "A {{ .Title }} vásárlása sikeres volt."
+  },
+  "shopping_complete_rental_watch_window_start": {
+    "one": "Mostantól bármikor elkezdheted megnézni a következő {{.Count}} napban.",
+    "other": "Mostantól bármikor elkezdheted megnézni a következő {{.Count}} napban."
+  },
+  "shopping_complete_rental_watch_window_end": {
+    "one": "Miután a lejátszást elindítottad {{.Count}} órád lesz, hogy megnézd a filmet, ahányszor csak szeretnéd.",
+    "other": "Miután a lejátszást elindítottad {{.Count}} órád lesz, hogy megnézd a filmet, ahányszor csak szeretnéd."
+  },
+  "shopping_complete_rental_coming_soon": {
+    "one": "{{.Date}}-tól tudod megnézni a filmet és a kölcsönzésed státusza aktív lesz további {{.Count}} napig.",
+    "other": "{{.Date}}-tól tudod megnézni a filmet és a kölcsönzésed státusza aktív lesz további {{.Count}} napig."
+  },
+  "shopping_complete_rental_coming_soon_watch_window_start": {
+    "one": "{{.Date}}-tól tudod megnézni a filmet és a kölcsönzésed státusza aktív lesz további {{.Count}} napig.",
+    "other": "{{.Date}}-tól tudod megnézni a filmet és a kölcsönzésed státusza aktív lesz további {{.Count}} napig."
+  },
+  "shopping_action_rent": {
+    "other": "Kölcsönzés"
+  },
+  "shopping_action_buy": {
+    "other": "Vásárlás"
+  },
+  "meta_detail_cast_title": {
+    "other": "Szereplők"
+  },
+  "meta_detail_crew_title": {
+    "other": "Stáb"
+  },
+  "meta_detail_languages": {
+    "one": "Nyelv",
+    "other": "Nyelv"
+  },
+  "meta_detail_studios": {
+    "one": "Gyártó",
+    "other": "Gyártó"
+  },
+  "meta_detail_countries": {
+    "one": "Ország",
+    "other": "Ország"
+  },
+  "meta_detail_subtitles": {
+    "other": "Felirat"
+  },
+  "meta_detail_captions": {
+    "other": "Felirat [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Epizódok"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Extra tartalom"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Talán ez is tetszene"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "A válogatásban szereplő filmek"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} film"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} évad"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} film és évad"
+  },
+  "userwishlist_page_header": {
+    "other": "Listám"
+  },
+  "userwishlist_slider_header": {
+    "other": "Listám"
+  },
+  "userwishlist_empty_header": {
+    "other": "A listád üres."
+  },
+  "userwishlist_empty_content": {
+    "other": "Töltsd meg kiváló filmekkel, nézd át a <a href=\"{{.HomeURL}}\">programot</a>."
+  },
+  "userwishlist_button_add": {
+    "other": "Add hozzá a listámhoz."
+  },
+  "userwishlist_button_remove": {
+    "other": "Listám"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Listám"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Listám"
+  },
+  "activatedevice_page_header": {
+    "other": "Eszköz aktiválása"
+  },
+  "activatedevice_page_content": {
+    "other": "Kövesse az eszközén megjelenő utasításokat a PIN-kód megszerzéséhez. Az aktiváláshoz számítógépének és eszközének egyaránt csatlakoznia kell az internethez."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN-kód"
+  },
+  "activatedevice_form_submit": {
+    "other": "Aktiválja"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "A PIN kód nem található, próbálja újra."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "A PIN kód nem található, próbálja újra."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Kérjük, jelentkezzen be az eszköz aktiválása előtt."
+  },
+  "activatedevice_page_activated": {
+    "other": "Köszönjük a {{.DeviceName}} aktiválását. Most már képesnek kell lennie böngészni a könyvtárában televízióján vagy eszközén."
+  },
+  "userdevices_page_header": {
+    "other": "Eszközök"
+  },
+  "userdevices_page_content": {
+    "one": "Az eszközök a használat során automatikusan felkerülnek ide. A maximum használható eszközök száma {{.Count}}.",
+    "other": "Az eszközök a használat során automatikusan felkerülnek ide. A maximum használható eszközök száma {{.Count}}."
+  },
+  "userdevices_empty_content": {
+    "other": "Jelenleg egy eszköz sincs regisztrálva."
+  },
+  "userdevices_header_type": {
+    "other": "Eszköz típusa"
+  },
+  "userdevices_header_description": {
+    "other": "Leírás"
+  },
+  "userdevices_device_added": {
+    "other": "Hozzáadva {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Eltávolítás"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Mégse"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Igen, töröld az eszközt"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Törölve)"
+  },
+  "playlist_page_header": {
+    "other": "lejátszási lista"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Kérjük, jelentkezzen be, hogy élő tévéadást nézhessen."
+  },
+  "playlist_share_title": {
+    "other": "lejátszási lista"
+  },
+  "playlist_up_next_title": {
+    "other": "Fel Következő"
+  },
+  "pricing_ownership_buy": {
+    "other": "Megveszem"
+  },
+  "pricing_ownership_rent": {
+    "other": "Kikölcsönzöm"
+  },
+  "classification_intro": {
+    "other": "Korhatár besorolás: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Ez az oldal sütiket használ a felhasználói élmény növelésének érdekében. Amennyiben ezt az oldalt használod, elfogadod a <a href=\"{{.CookiePolicyURL}}\">sütik használatára vonatkozó feltételeket</a>-ot."
+  },
+  "cookie_banner_accept": {
+    "other": "Elfogad"
+  },
+  "all_rights_reserved": {
+    "other": "Minden jog fenntartva. Az oldal egyetlen része sem reprodukálható írásos engedélyünk nélkül."
+  },
+  "users_gender_none": {
+    "other": "Nem meghatározott"
+  },
+  "users_gender_female": {
+    "other": "Nő"
+  },
+  "users_gender_male": {
+    "other": "Férfi"
+  },
+  "users_gender_diverse": {
+    "other": "Diverz"
+  },
+  "users_gender_other": {
+    "other": "Egyéb"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "Csak HD"
+  },
+  "pricing_quality_sd_only": {
+    "other": "Csak SD"
+  },
+  "shopping_card_save_card": {
+    "other": "Őrizze meg ezt a kártyát későbbi használatra"
+  },
+  "shopping_card_button_change": {
+    "other": "Az összes mentett kártya megjelenítése"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}}, amely a következőre végződik: {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(lejár: {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(lejárt)"
+  },
+  "shopping_card_use_other": {
+    "other": "Használjon új kártyát"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Válts kártyát"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Feliratkozás"
+  },
+  "shopping_action_credit": {
+    "other": "Feltölt"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "a bemutató időpontjától."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Hitelkártya módosítása"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Frissítse a hitelkártya adatait"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Frissítés"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Lejár: {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "usersubscriptions_subscription_status_cancelled"
+  },
+  "usersubscriptions_subscription_status_errored": {
+    "other": "usersubscriptions_subscription_status_errored"
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "usersubscriptions_subscription_status_past_due"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Próbaidő"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Lemondom az előfizetésemet"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Megszünteti"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Igen, mondd le az előfizetésemet"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Feliratkozás visszavonása?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Ezzel törli az előfizetést a {{.Name}} csomagra. Továbbra is megtekintheti a csomag tartalmát, amíg le nem jár {{.Expiry}}."
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Frissítse hitelkártyáját. A támogatott kártyák a Visa, Mastercard és az American Express."
+  },
+  "availability_coming_soon": {
+    "other": "Hamarosan"
+  },
+  "availability_renting": {
+    "other": "Kölcsönözve"
+  },
+  "availability_not_available": {
+    "other": "Nem elérhető"
+  },
+  "availability_in_watch_window": {
+    "other": "Elérhető"
+  },
+  "availability_sold_out": {
+    "other": "Teltház"
+  },
+  "availability_available_till": {
+    "other": "Elérhető {{.ExpiryDate}}-ig"
+  },
+  "availability_not_available_in_country": {
+    "other": "Nem elérhető"
+  },
+  "availability_available": {
+    "other": "Elérhető {{.ReleaseDate}}"
+  },
+  "modal_cancel": {
+    "other": "Mégsem"
+  },
+  "play": {
+    "other": "Lejátszás"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Bejelentkezés"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Feliratkozás"
+  },
+  "combined_auth_terms": {
+    "other": "Elfogadom a <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Felhasználói szabályzatot</a>."
+  },
+  "signup_terms": {
+    "other": "Elfogadom a <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Felhasználói szabályzatot</a>."
+  },
+  "validation_terms_required": {
+    "other": "Kérjük, fogadd el a Felhasználói szabályzatot."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Sajnáljuk, de {{.Title}} tételre már minden jegy elkelt."
+  },
+  "shopping_card_change": {
+    "other": "Hitelkártya nem megfelelő? <a href=\"{{.SubscriptionsURL}}\">Kattintson ide a kártya frissítéséhez.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Úgy tűnik, hogy problémái vannak.</p><p>Állítsa vissza PIN-kódját, vagy forduljon hozzánk <a href=\"{{.HelpURL}}\" target=\"_blank\">segítségért</. a>"
+  },
+  "app_badge_title": {
+    "other": "Töltse le az alkalmazást a megvásárolt tartalmak megtekintéséhez!"
+  },
+  "app_badge_ios": {
+    "other": "Töltse le az App Store-ból"
+  },
+  "app_badge_android": {
+    "other": "Szerezd meg a Google Play"
+  },
+  "shopping_price_title_plan": {
+    "other": "Ár"
+  },
+  "shopping_price_plan_note": {
+    "zero": "{{ .Interval }} minden .Intervallum .",
+    "one": "A 24 órás ingyenes próbaidőszak {{ .Interval }} után minden .Intervallumonként felszámításra kerül.",
+    "other": "{{ .Count }} napos ingyenes próbaidőszak {{ .Interval }} után minden .Intervallum felszámításra kerül."
+  },
+  "shopping_price_plan_note_interval": {
+    "one": "{{ .Interval }}",
+    "other": "{{ .Count }} {{ .Interval }}"
+  },
+  "shopping_enter_card_prompt_plan": {
+    "other": "Az előfizetés megkezdéséhez adja meg alább hitelkártyaadatait."
+  },
+  "shopping_action_plan": {
+    "other": "teljes"
+  },
+  "shopping_complete_subscription": {
+    "other": "Az előfizetés vásárlása sikeres volt. Feliratkozott a {{ .Title }} ."
+  },
+  "shopping_complete_subscription_browse": {
+    "other": "Nyugodtan <a href=\"/\">böngésszen</a> az oldalon, vagy <a href=\"/search.html\">keressen</a> valami konkrétat."
+  },
+  "shopping_info_plan_offer": {
+    "one": "Automatikusan megújítja minden {{ .Interval }}",
+    "other": "Automatikusan {{ .Count }} {{ .Interval }}"
+  },
+  "shopping_info_trial_period_offer": {
+    "one": "Próbálja ki most az ingyenes 24 órás próbaverziót!",
+    "other": "Próbálja ki ingyenes {{ .Count }} napos próbaverzióját!"
+  },
+  "plans_page_header": {
+    "other": "Rendelkezésre álló tervek"
+  },
+  "plan_label_owned": {
+    "other": "Öné ez a terv"
+  },
+  "plan_expiry_date": {
+    "other": "Az értékesítés lezárása:"
+  },
+  "plan_read_more": {
+    "other": "Tudjon meg többet"
+  },
+  "plan_page_read_more": {
+    "other": "Olvass tovább"
+  },
+  "plan_page_header_text": {
+    "other": "Élvezze {{ .Name }}"
+  },
+  "page_plan_explore_intro": {
+    "other": "VAGY"
+  },
+  "page_plan_explore_link": {
+    "other": "Fedezzen fel más bérleteket"
+  },
+  "plan_showcase_page_ownership_button_buy": {
+    "other": "Vásárolj most"
+  },
+  "plan_free_link_text": {
+    "other": "Regisztrálj ingyen"
+  },
+  "awards_in_competition": {
+    "other": "Versenyben"
+  },
+  "awards_winner": {
+    "other": "Győztes"
+  },
+  "donate_button_text": {
+    "other": "Dhuroni"
+  },
+  "wcag_skip_links_header": {
+    "other": "Kisegítő lehetőségek linkek"
+  },
+  "wcag_skip_links_content": {
+    "other": "Ugrás a tartalomra"
+  },
+  "wcag_homepage_h1": {
+    "other": "Kezdőlap"
+  },
+  "wcag_carousel_h2": {
+    "other": "Körhinta"
+  },
+  "wcag_collections_h2": {
+    "other": "Gyűjtemények"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Lábléc"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Fő"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Alatti"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Kapcsolja be a navigációt"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Csomag tételek"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Körhinta"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Oldalgyűjtemény"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Gyűjteménylista"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Gyűjteménycsúszka"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Kívánság lista"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Megosztani Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Oszd meg a Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Oszd meg a LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Megtekintés a Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Már megvan ez a terv."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Ez a terv már nem elérhető."
+  },
+  "shopping_payment_method_header": {
+    "other": "Fizetési módok"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Hitelkártya"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Hiba történt ezzel a fizetéssel. Kérlek, próbáld újra később."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "A fizetést elutasították. Zárja be ezt az ablakot, és próbálja újra."
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21. Filmfesztivál, 2021. június 1. és 6. között"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Nincs beállítva PIN-kód, amely bizonyos címek megvásárlásához, kölcsönzéséhez és megtekintéséhez szükséges."
+  },
+  "account_form_set_pin": {
+    "other": "Állítsa be a PIN-kódot"
+  },
+  "account_form_pin_changed": {
+    "other": "Frissítve"
+  },
+  "account_form_change_pin": {
+    "other": "PIN módosítása"
+  },
+  "user_set_pin_header": {
+    "other": "Állítsa be a PIN-kódot"
+  },
+  "user_set_pin_button": {
+    "other": "Állítsa be a PIN-kódot"
+  },
+  "user_submit_pin_heading": {
+    "other": "Adja meg PIN-kódját ehhez a korlátozott tartalomhoz {{.Action}}"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Hoppá, hibás PIN-kódot adott meg"
+  },
+  "user_submit_pin_button": {
+    "other": "Belép"
+  },
+  "user_reset_pin_button": {
+    "other": "Állítsa vissza a PIN-kódot"
+  },
+  "validation_pincode1_required": {
+    "other": "Kérjük, adjon meg egy érvényes PIN kódot."
+  },
+  "validation_pincode2_required": {
+    "other": "Kérjük, adjon meg egy érvényes PIN kódot"
+  },
+  "validation_pincode1_pattern": {
+    "other": "Kérjük, adjon meg egy érvényes PIN kódot"
+  },
+  "validation_pincode2_pattern": {
+    "other": "Kérjük, adjon meg egy érvényes PIN kódot"
+  },
+  "validation_pincode2_match": {
+    "other": "A PIN kód nem egyezik."
+  },
+  "userdevices_delete_limits": {
+    "other": "{{.Limit}} eszközt eltávolíthat a listáról minden {{.Period}} napon."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Elérte ezt a korlátot, és jelenleg nem távolíthat el egyetlen eszközt sem. Egy eszközt {{.Days}} napon belül törölhet."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Ezt a kártyát a rendszer elmenti és rendszeresen megterheli"
+  },
+  "changepincode_modal_header": {
+    "other": "Módosítsa a PIN-kódot"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Az aktuális jelszavad"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Az új 4 számjegyű PIN-kód"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Erősítse meg új 4 számjegyű PIN-kódját"
+  },
+  "changepincode_modal_submit": {
+    "other": "Állítsa be a PIN-kódot"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Ez a jelszó helytelen."
+  },
+  "user_set_pin_intro": {
+    "other": "A {{.Action}} korlátozott tartalomhoz PIN-kódra van szüksége"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Kattintson ide a PIN-kód visszaállításához"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Ez a tartalom korhatáros."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "availability_expires": {
+    "other": "Lejár {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Lejárt"
   }
-  
+}

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Impostazioni" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Impostazioni"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
   "episode_name": {
     "other": "Episodio"
   },
-
   "season_name": {
     "other": "Stagione"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "una stagione",
     "other": "{{.Count}} stagioni"
   },
@@ -38,180 +55,444 @@
     "one": "1 Episodio",
     "other": "{{.Count}} Episodi"
   },
-
-  "date_day": { "other": "Giorno" },
-  "date_month": { "other": "Mese" },
-  "date_year": { "other": "Anno" },
-
-  "404_page_header": { "other": "La pagina non esiste..." },
-  "404_page_content": { "other": "<p>Ci scusiamo, ma sembra che la pagina che stai cercando non esista.</p><p>Potrebbe essere stata spostata o cancellata, o forse potresti aver sbagliato qualcosa nella digitazione.</p><p>Prova a tornare alla homepage per trovare quello che stavi cercando.</p><p><a href=\"{{.URL}}\">Torna alla Homepage</a></p>" },
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Accedi" },
-  "nav_signup": { "other": "Registrati" },
-  "nav_signed_in_as": { "other": "Registrato come" },
-  "nav_library": { "other": "I miei film" },
-  "nav_devices": { "other": "I miei dispositivi" },
-  "nav_wishlist": { "other": "La mia wishlist" },
-  "nav_account": { "other": "Il mio Account" },
-  "nav_signout": { "other": "Esci" },
-  "play_trailer": { "other": "Trailer" },
-  "runtime_hours": { "other": "h" },
-  "runtime_minutes": { "other": "m" },
-
-  "datetime_today": { "other": "oggi {{.Date}}" },
-  "datetime_tomorrow": { "other": "domani {{.Date}}" },
-  "datetime_yesterday": { "other": "ieri {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "lo scorso {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Cerca" },
-  "search_control_submit": { "other": "Invia la ricerca" },
-
-  "play_button_watch": { "other" : "Guarda ora"},
-  "play_button_resume": { "other" : "Continua"},
-
-  "social_media_buttons_title": { "other": "Condividi" },
-  "social_media_buttons_facebook": { "other": "Condividi su Facebook" },
-  "social_media_buttons_twitter": { "other": "Condividi su Twitter" },
-  "social_media_buttons_linkedin": { "other": "Condividi su Linkedin" },
-  "social_media_buttons_email": { "other": "Condividi via e-mail" },
-  "social_media_buttons_email_subject": { "other": "Condividi link" },
-  "social_media_buttons_copied_link": { "other": "Link copiato negli appunti!" },
-  "social_media_buttons_copy_link": { "other": "Copia negli appunti" },
-
-  "accept_invite_page_header": { "other": "Accoglienza " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Questo Invito è già stato usato." },
-  "acceptinvite_complete": { "other": "Grazie. Il tuo account è stato creato." },
-  "acceptinvite_form_submit": { "other": "Accetta l'Invito" },
-  "acceptinvite_agreement": { "other": "Cliccando su “Accetta l’Invito” acconsenti ad aver letto e compreso i nostri <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termini &amp; condizioni</a> e la nostra <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">privacy policy</a>." },
-
-  "signup_page_header": { "other": "Crea un nuovo Account" },
-  "signup_form_name": { "other": "Nome" },
-  "signup_form_email": { "other": "Indirizzo email" },
-  "signup_form_password": { "other": "Password" },
-  "signup_form_password_confirmation": { "other": "Conferma la tua password" },
-  "signup_form_gender": { "other": "Genere" },
-  "signup_form_dob": { "other": "Data di nascita" },
-  "signup_form_submit": { "other": "Invia" },
-
-  "signup_terms": { "other": "Cliccando sul bottone, dichiari di aver letto e accettato <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Termini &amp; Condizioni</a>." },
-  "combined_auth_terms": { "other": "Cliccando sul bottone, dichiari di aver letto e accettato <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Termini &amp; Condizioni</a>." },
-
-  "signin_page_header": { "other": "Accedi" },
-  "signin_form_email": { "other": "Indirizzo email" },
-  "signin_form_password": { "other": "Password" },
-  "signin_form_remember": { "other": "Ricordami" },
-  "signin_form_submit": { "other": "Invia" },
-  "signin_page_forgotpassword": { "other": "Hai dimenticato la password?" },
-  "signin_page_createnewaccount": { "other": "Non hai un account utente? Creane uno nuovo" },
-  "signup_page_alreadyhaveanaccount": { "other": "Hai già un Account? Accedi qui" },
-  "signup_form_error_email_already_in_use": { "other": "L'indirizzo email è già in uso." },
-  "signin_form_error_incorrect_credentials": { "other": "Il nome utente o la password non sono corretti." },
-  "signup_form_error_forbidden": { "other": "C'è stato un errore." },
-
-  "combined_auth_continue": { "other": "Continua" },
-  "combined_auth_change": { "other": "modifica" },
-  "combined_auth_signin": { "other": "Accedi" },
-  "combined_auth_signup": { "other": "Crea un nuovo Account utente" },
-  "combined_auth_signin_password": { "other": "Inserisci la tua password per poterti loggare al tuo nuovo account." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "La password è errata." },
-  "combined_auth_error_forbidden": { "other": "C'è stato un errore." },
-  "combined_auth_error_too_many_requests": { "other": "Troppe richieste. La preghiamo di riprovare più tardi." },
-
-  "forgotpassword_page_header": { "other": "Resetta la tua password" },
-  "forgotpassword_form_email": { "other": "Indirizzo email" },
-  "forgotpassword_form_submit": { "other": "Resetta" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Non ci sono account utente che corrispondono all'indirizzo email." },
-  "forgotpassword_form_error_account_suspended": { "other": "L'account utente è sospeso." },
-  "forgotpassword_complete": { "other": "Grazie. A breve ti arriverà un'email per poter resettare la tua password." },
-  "forgotpassword_form_error_forbidden": { "other": "C'è stato un errore." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Troppe richieste. La preghiamo di riprovare più tardi." },
-
-  "resetpassword_page_header": { "other": "Cambia la tua password" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Sembra che la richiesta di reset della password non sia valida. Riempi di nuovo il form<a href=\"{{.URL}}\">Ho dimenticato la Password</a>, grazie." },
-  "resetpassword_form_password": { "other": "Nuova password" },
-  "resetpassword_form_password2": { "other": "Confermare la nuova password" },
-  "resetpassword_form_submit": { "other": "Modifica" },
-  "resetpassword_complete": { "other": "Grazie. La tua password è stata modificata, ora sei loggato." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "La richiesta di reset della password non è valida. Riprova più tardi." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Il token per il reset della password è scaduto. Richiedine uno nuovo." },
-  "resetpassword_form_error_too_many_requests": { "other": "Troppe richieste. La preghiamo di riprovare più tardi." },
-
-  "account_page_header": { "other": "Il mio account" },
-  "account_form_name": { "other": "Nome" },
-  "account_form_email": { "other": "Indirizzo email" },
-  "account_form_password": { "other": "Password" },
-  "account_form_change_password": { "other": "Modifica" },
-  "account_form_gender": { "other": "Genere" },
-  "account_form_dob": { "other": "Data di nascita" },
-  "account_form_submit": { "other": "Aggiorna" },
-  "account_form_submitted": { "other": "Aggiornato" },
-  "account_form_password_changed": { "other": "Aggiornata" },
-  "account_form_error_incorrect_password": { "other": "La password è errata." },
-
-  "signup_form_optin": {"other": "Registrati per ricevere la nostra newsletter gratuita"},
-
-  "passwordconfirmation_modal_header": { "other": "Conferma la tua password" },
-  "passwordconfirmation_modal_label": { "other": "Per favore inserisci la password per salvare le modifiche" },
-  "passwordconfirmation_modal_confirm": { "other": "Conferma" },
-
-  "changepassword_modal_header": { "other": "Cambia la tua password" },
-  "changepassword_modal_currentpassword": { "other": "La tua attuale password" },
-  "changepassword_modal_password": { "other": "La tua nuova password" },
-  "changepassword_modal_password2": { "other": "Confermare la nuova password" },
-  "changepassword_modal_submit": { "other": "Aggiorna" },
-  "changepassword_modal_error_incorrect_password": { "other": "La password è errata." },
-
-  "userlibrary_page_header": { "other": "I miei Film" },
-  "userlibrary_empty_header":  { "other": "Non hai Film." },
-  "userlibrary_empty_content": { "other": "Scegli un titolo <a href=\"{{.HomeURL}}\">sfogliando</a> la nostra grande selezione." },
-
-  "searchresults_page_header": { "other": "Risultati della ricerca" },
-  "searchresults_load_more": { "other": "Carica altri {{.Count}}" },
+  "date_day": {
+    "other": "Giorno"
+  },
+  "date_month": {
+    "other": "Mese"
+  },
+  "date_year": {
+    "other": "Anno"
+  },
+  "404_page_header": {
+    "other": "La pagina non esiste..."
+  },
+  "404_page_content": {
+    "other": "<p>Ci scusiamo, ma sembra che la pagina che stai cercando non esista.</p><p>Potrebbe essere stata spostata o cancellata, o forse potresti aver sbagliato qualcosa nella digitazione.</p><p>Prova a tornare alla homepage per trovare quello che stavi cercando.</p><p><a href=\"{{.URL}}\">Torna alla Homepage</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Accedi"
+  },
+  "nav_signup": {
+    "other": "Registrati"
+  },
+  "nav_signed_in_as": {
+    "other": "Registrato come"
+  },
+  "nav_library": {
+    "other": "I miei film"
+  },
+  "nav_devices": {
+    "other": "I miei dispositivi"
+  },
+  "nav_wishlist": {
+    "other": "La mia wishlist"
+  },
+  "nav_account": {
+    "other": "Il mio Account"
+  },
+  "nav_signout": {
+    "other": "Esci"
+  },
+  "play_trailer": {
+    "other": "Trailer"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "m"
+  },
+  "datetime_today": {
+    "other": "oggi {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "domani {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "ieri {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "lo scorso {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Cerca"
+  },
+  "search_control_submit": {
+    "other": "Invia la ricerca"
+  },
+  "play_button_watch": {
+    "other": "Guarda ora"
+  },
+  "play_button_resume": {
+    "other": "Continua"
+  },
+  "social_media_buttons_title": {
+    "other": "Condividi"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Condividi su Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Condividi su Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Condividi su Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Condividi via e-mail"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Condividi link"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link copiato negli appunti!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Copia negli appunti"
+  },
+  "accept_invite_page_header": {
+    "other": "Accoglienza "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Questo Invito è già stato usato."
+  },
+  "acceptinvite_complete": {
+    "other": "Grazie. Il tuo account è stato creato."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Accetta l'Invito"
+  },
+  "acceptinvite_agreement": {
+    "other": "Cliccando su “Accetta l’Invito” acconsenti ad aver letto e compreso i nostri <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termini &amp; condizioni</a> e la nostra <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">privacy policy</a>."
+  },
+  "signup_page_header": {
+    "other": "Crea un nuovo Account"
+  },
+  "signup_form_name": {
+    "other": "Nome"
+  },
+  "signup_form_email": {
+    "other": "Indirizzo email"
+  },
+  "signup_form_password": {
+    "other": "Password"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Conferma la tua password"
+  },
+  "signup_form_gender": {
+    "other": "Genere"
+  },
+  "signup_form_dob": {
+    "other": "Data di nascita"
+  },
+  "signup_form_submit": {
+    "other": "Invia"
+  },
+  "signup_terms": {
+    "other": "Cliccando sul bottone, dichiari di aver letto e accettato <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Termini &amp; Condizioni</a>."
+  },
+  "combined_auth_terms": {
+    "other": "Cliccando sul bottone, dichiari di aver letto e accettato <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Termini &amp; Condizioni</a>."
+  },
+  "signin_page_header": {
+    "other": "Accedi"
+  },
+  "signin_form_email": {
+    "other": "Indirizzo email"
+  },
+  "signin_form_password": {
+    "other": "Password"
+  },
+  "signin_form_remember": {
+    "other": "Ricordami"
+  },
+  "signin_form_submit": {
+    "other": "Invia"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Hai dimenticato la password?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Non hai un account utente? Creane uno nuovo"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Hai già un Account? Accedi qui"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "L'indirizzo email è già in uso."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Il nome utente o la password non sono corretti."
+  },
+  "signup_form_error_forbidden": {
+    "other": "C'è stato un errore."
+  },
+  "combined_auth_continue": {
+    "other": "Continua"
+  },
+  "combined_auth_change": {
+    "other": "modifica"
+  },
+  "combined_auth_signin": {
+    "other": "Accedi"
+  },
+  "combined_auth_signup": {
+    "other": "Crea un nuovo Account utente"
+  },
+  "combined_auth_signin_password": {
+    "other": "Inserisci la tua password per poterti loggare al tuo nuovo account."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "La password è errata."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "C'è stato un errore."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Troppe richieste. La preghiamo di riprovare più tardi."
+  },
+  "forgotpassword_page_header": {
+    "other": "Resetta la tua password"
+  },
+  "forgotpassword_form_email": {
+    "other": "Indirizzo email"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Resetta"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Non ci sono account utente che corrispondono all'indirizzo email."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "L'account utente è sospeso."
+  },
+  "forgotpassword_complete": {
+    "other": "Grazie. A breve ti arriverà un'email per poter resettare la tua password."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "C'è stato un errore."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Troppe richieste. La preghiamo di riprovare più tardi."
+  },
+  "resetpassword_page_header": {
+    "other": "Cambia la tua password"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Sembra che la richiesta di reset della password non sia valida. Riempi di nuovo il form<a href=\"{{.URL}}\">Ho dimenticato la Password</a>, grazie."
+  },
+  "resetpassword_form_password": {
+    "other": "Nuova password"
+  },
+  "resetpassword_form_password2": {
+    "other": "Confermare la nuova password"
+  },
+  "resetpassword_form_submit": {
+    "other": "Modifica"
+  },
+  "resetpassword_complete": {
+    "other": "Grazie. La tua password è stata modificata, ora sei loggato."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "La richiesta di reset della password non è valida. Riprova più tardi."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Il token per il reset della password è scaduto. Richiedine uno nuovo."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Troppe richieste. La preghiamo di riprovare più tardi."
+  },
+  "account_page_header": {
+    "other": "Il mio account"
+  },
+  "account_form_name": {
+    "other": "Nome"
+  },
+  "account_form_email": {
+    "other": "Indirizzo email"
+  },
+  "account_form_password": {
+    "other": "Password"
+  },
+  "account_form_change_password": {
+    "other": "Modifica"
+  },
+  "account_form_gender": {
+    "other": "Genere"
+  },
+  "account_form_dob": {
+    "other": "Data di nascita"
+  },
+  "account_form_submit": {
+    "other": "Aggiorna"
+  },
+  "account_form_submitted": {
+    "other": "Aggiornato"
+  },
+  "account_form_password_changed": {
+    "other": "Aggiornata"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "La password è errata."
+  },
+  "signup_form_optin": {
+    "other": "Registrati per ricevere la nostra newsletter gratuita"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Conferma la tua password"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Per favore inserisci la password per salvare le modifiche"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Conferma"
+  },
+  "changepassword_modal_header": {
+    "other": "Cambia la tua password"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "La tua attuale password"
+  },
+  "changepassword_modal_password": {
+    "other": "La tua nuova password"
+  },
+  "changepassword_modal_password2": {
+    "other": "Confermare la nuova password"
+  },
+  "changepassword_modal_submit": {
+    "other": "Aggiorna"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "La password è errata."
+  },
+  "userlibrary_page_header": {
+    "other": "I miei Film"
+  },
+  "userlibrary_empty_header": {
+    "other": "Non hai Film."
+  },
+  "userlibrary_empty_content": {
+    "other": "Scegli un titolo <a href=\"{{.HomeURL}}\">sfogliando</a> la nostra grande selezione."
+  },
+  "searchresults_page_header": {
+    "other": "Risultati della ricerca"
+  },
+  "searchresults_load_more": {
+    "other": "Carica altri {{.Count}}"
+  },
   "searchresults_total": {
     "one": "Trovato 1 risultato per \"{{.Query}}\".",
     "other": "Trovati {{.Count}} risultati per \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "Non ho trovato risultati per \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Prova con un'altra ricerca oppure <a href=\"{{.HomeURL}}\">sfoglia i nostri contenuti</a> per trovare quello che stai cercando." },
-
-  "validation_name_required": { "other": "Per favore inserisci il tuo nome." },
-  "validation_email_required": { "other": "Per favore inserisci il tuo indirizzo email." },
-  "validation_email_email": { "other": "Per favore inserisci un indirizzo email valido." },
-  "validation_currentpassword_required": { "other": "Per favore inserisci la tua password attuale." },
-  "validation_password_required": { "other": "Per favore inseririsci una password." },
-  "validation_password2_required": { "other": "Per favore conferma la password." },
-  "validation_password2_match": { "other": "Le password non coincidono." },
-  "validation_password_minlength": { "other": "Per favore inserisci almeno {{.Count}} caratteri." },
-  "validation_promocode_required": { "other": "Per favore inserisci un codice promozionale." },
-  "validation_pincode_required": { "other": "Per favore inserisci un codice promozionale." },
-  "validation_gender_required": { "other": "Per favore scegli il sesso." },
-  "validation_dob_required": { "other": "Per favore inserisci la tua data di nascita." },
-  "validation_dob_date": { "other": "Per favore inserisci una data di nascita valida." },
-
-  "shopping_info_subtitle_hd": { "other": "Video on Demand HD." },
-  "shopping_info_subtitle_sd": { "other": "SD Video on Demand." },
-  "shopping_info_subtitle_wallet": { "other": "I fondi a disposizione nel tuo Wallet possono essere usati per l'acquisto o il noleggio di qualsiasi contenuto su ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "Controlla qui i requisiti di sistema." },
-  "shopping_info_ownership_buy": { "other": "acquisto" },
-  "shopping_info_ownership_rent": { "other": "noleggio" },
-
-  "shopping_info_sd_only": { "other": "Limitato alla sola riproduzione SD." },
-  "shopping_info_release_date_title": { "other": "Disponibile dal {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Puoi noleggiarlo ora, ma non potrai vederlo fino a questa data." },
-  "shopping_info_release_date_explanation_buy": { "other": "Puoi comprarlo ora, ma non potrai vederlo fino a questa data." },
-
-  "shopping_info_available_until_date_title": { "other": "Disponibile fino {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Non potrai vedere il contenuto oltre questa data." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Non potrai vedere il contenuto oltre questa data." },
-
-  "duration_hour": { "one": "1 ora", "other": "{{.Count}} ore" },
-  "duration_day": { "one": "1 giorno", "other": "{{.Count}} giorni" },
-  "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} di noleggio " },
-  "shopping_info_rental_period_coming_soon": { "other": "dalla data e ora della pubblicazione." },
-  "shopping_info_watch_window_duration": { "other": "Finestra di riproduzione: {{.Count}} ore. " },
+  "searchresults_empty_header": {
+    "other": "Non ho trovato risultati per \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Prova con un'altra ricerca oppure <a href=\"{{.HomeURL}}\">sfoglia i nostri contenuti</a> per trovare quello che stai cercando."
+  },
+  "validation_name_required": {
+    "other": "Per favore inserisci il tuo nome."
+  },
+  "validation_email_required": {
+    "other": "Per favore inserisci il tuo indirizzo email."
+  },
+  "validation_email_email": {
+    "other": "Per favore inserisci un indirizzo email valido."
+  },
+  "validation_currentpassword_required": {
+    "other": "Per favore inserisci la tua password attuale."
+  },
+  "validation_password_required": {
+    "other": "Per favore inseririsci una password."
+  },
+  "validation_password2_required": {
+    "other": "Per favore conferma la password."
+  },
+  "validation_password2_match": {
+    "other": "Le password non coincidono."
+  },
+  "validation_password_minlength": {
+    "other": "Per favore inserisci almeno {{.Count}} caratteri."
+  },
+  "validation_promocode_required": {
+    "other": "Per favore inserisci un codice promozionale."
+  },
+  "validation_pincode_required": {
+    "other": "Per favore inserisci un codice promozionale."
+  },
+  "validation_gender_required": {
+    "other": "Per favore scegli il sesso."
+  },
+  "validation_dob_required": {
+    "other": "Per favore inserisci la tua data di nascita."
+  },
+  "validation_dob_date": {
+    "other": "Per favore inserisci una data di nascita valida."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "Video on Demand HD."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video on Demand."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "I fondi a disposizione nel tuo Wallet possono essere usati per l'acquisto o il noleggio di qualsiasi contenuto su ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Controlla qui i requisiti di sistema."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "acquisto"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "noleggio"
+  },
+  "shopping_info_sd_only": {
+    "other": "Limitato alla sola riproduzione SD."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Disponibile dal {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Puoi noleggiarlo ora, ma non potrai vederlo fino a questa data."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Puoi comprarlo ora, ma non potrai vederlo fino a questa data."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Disponibile fino {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Non potrai vedere il contenuto oltre questa data."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Non potrai vedere il contenuto oltre questa data."
+  },
+  "duration_hour": {
+    "one": "1 ora",
+    "other": "{{.Count}} ore"
+  },
+  "duration_day": {
+    "one": "1 giorno",
+    "other": "{{.Count}} giorni"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} di noleggio "
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "dalla data e ora della pubblicazione."
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "Finestra di riproduzione: {{.Count}} ore. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Una volta noleggiato, il film sarà disponibile nel tuo account per {{.ValueUnit}}. ",
     "other": "Una volta noleggiato, il film sarà disponibile nel tuo account per {{.ValueUnit}}. "
@@ -236,65 +517,151 @@
     "one": "Dopo aver premuto Play su un episodio, inizia la finestra di visualizzazione e hai un'ora per guardare quell'episodio tutte le volte che vuoi.",
     "other": "Una volta che premi Play su un episodio, la watch window ha inizio e hai {{.Count}} ore a disposizione per guardare quell'episodio quante volte vorrai."
   },
-  "shopping_info_credit_bonus_title": { "other": "Bonus {{.BonusPercentage}}%" },
-
-  "shopping_enter_card_prompt": { "other": "Inserisci i dati della tua carta di credito per completare l'ordine." },
-
-  "shopping_terms": { "other": "Procedendo con questo pagamento, accetto i <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">termini e le condizioni</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} sconto applicato." },
-  "shopping_discount_apply": { "other": "Applica" },
-  "shopping_discount_code": { "other": "Inserisci il codice." },
-  "shopping_discount_have_code": { "other": "Ho un codice promozionale." },
-
-  "shopping_price_you_pay": { "other": "Paghi" },
-  "shopping_price_nothing": { "other": "Nulla" },
-  "shopping_price_free": { "other": "Gratuito" },
-
-  "shopping_auth_directions": { "other": "È necessario avere un Account. Inserisci il tuo indirizzo email." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} è già nella tua library." },
-
-  "shopping_error_missing_card": { "other": "Prego, inserisci i dettagli della tua carta di credito." },
-  "shopping_error_title": { "other": "C'è stato un errore" },
-  "shopping_error_incorrect_cvc": { "other": "Prego, inserisci un CVV valido." },
-  "shopping_error_invalid_cvc": { "other": "Prego, inserisci un CVV valido." },
-  "shopping_error_incorrect_number": { "other": "Prego, inserisci un numero di carta di credito valido." },
-  "shopping_error_invalid_number": { "other": "Prego, inserisci un numero di carta di credito valido." },
-  "shopping_error_card_declined": { "other": "La carta di credito è stata rifiutata." },
-  "shopping_error_invalid_expiry_month": { "other": "Prego, inserisci una data di scadenza valida." },
-  "shopping_error_invalid_expiry_year": { "other": "Prego, inserisci una data di scadenza valida." },
-  "shopping_error_expired_card": { "other": "La carta di credito è scaduta." },
-  "shopping_error_creditcard_country_mismatch": { "other": "La tua {{.Ownership}} non è stata completata. Devi essere nella nazione in cui la tua carta è stata emessa. Prego, utilizza un'altra carta per eseguire il pagamento." },
-  "shopping_error_proxy_detected": { "other": "La tua {{.Ownership}} non è stata completata. Abbiamo verificato che stati utilizzando un servizio proxy oppure un unblocker. Spegni questi servizi e riprova, grazie." },
-
-  "shopping_error_discount_worn_out": { "other": "Il codice promozionale non può più essere utilizzato." },
-  "shopping_error_discount_blank": { "other": "Prego, inserisci un codice promozionale." },
-  "shopping_error_discount_not_applied": { "other": "Inserisci un codice valido." },
-  "shopping_error_discount_invalid": { "other": "Inserisci un codice valido." },
-  "shopping_error_discount_disabled": { "other": "Inserisci un codice valido." },
-  "shopping_error_discount_already_applied": { "other": "Un codice promozionale è già stato usato per questa sessione." },
-  "shopping_error_discount_already_redeemed": { "other": "Il codice promozionale è già stato utilizzato." },
-  "shopping_error_discount_used_previously": { "other": "Il codice promozionale è già stato utilizzato." },
-  "shopping_error_discount_max_limit": { "other": "Il codice promozionale non può più essere utilizzato." },
-  "shopping_error_discount_expired": { "other": "Il codice promozionale è scaduto." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Il codice promozionale non può essere usato per un acquisto." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Il codice promozionale non può essere usato per un noleggio." },
-  "shopping_error_discount_invalid_item": { "other": "Il codice promozionale non può essere usato per questo item." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Il codice promozionale non può essere usato in questa nazione." },
-  "shopping_error_discounts_not_allowed": { "other": "Il codice promozionale non può essere usato." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Il codice promozionale non può essere usato per i bundle." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "La carta di credito è stata rifiutata. Ti prego di riprovare." },
-
-  "shopping_complete_rental": { "other": "Fatto!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "Bonus {{.BonusPercentage}}%"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Inserisci i dati della tua carta di credito per completare l'ordine."
+  },
+  "shopping_terms": {
+    "other": "Procedendo con questo pagamento, accetto i <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">termini e le condizioni</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} sconto applicato."
+  },
+  "shopping_discount_apply": {
+    "other": "Applica"
+  },
+  "shopping_discount_code": {
+    "other": "Inserisci il codice."
+  },
+  "shopping_discount_have_code": {
+    "other": "Ho un codice promozionale."
+  },
+  "shopping_price_you_pay": {
+    "other": "Paghi"
+  },
+  "shopping_price_nothing": {
+    "other": "Nulla"
+  },
+  "shopping_price_free": {
+    "other": "Gratuito"
+  },
+  "shopping_auth_directions": {
+    "other": "È necessario avere un Account. Inserisci il tuo indirizzo email."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} è già nella tua library."
+  },
+  "shopping_error_missing_card": {
+    "other": "Prego, inserisci i dettagli della tua carta di credito."
+  },
+  "shopping_error_title": {
+    "other": "C'è stato un errore"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Prego, inserisci un CVV valido."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Prego, inserisci un CVV valido."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Prego, inserisci un numero di carta di credito valido."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Prego, inserisci un numero di carta di credito valido."
+  },
+  "shopping_error_card_declined": {
+    "other": "La carta di credito è stata rifiutata."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Prego, inserisci una data di scadenza valida."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Prego, inserisci una data di scadenza valida."
+  },
+  "shopping_error_expired_card": {
+    "other": "La carta di credito è scaduta."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "La tua {{.Ownership}} non è stata completata. Devi essere nella nazione in cui la tua carta è stata emessa. Prego, utilizza un'altra carta per eseguire il pagamento."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "La tua {{.Ownership}} non è stata completata. Abbiamo verificato che stati utilizzando un servizio proxy oppure un unblocker. Spegni questi servizi e riprova, grazie."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Il codice promozionale non può più essere utilizzato."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Prego, inserisci un codice promozionale."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Inserisci un codice valido."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Inserisci un codice valido."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Inserisci un codice valido."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Un codice promozionale è già stato usato per questa sessione."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Il codice promozionale è già stato utilizzato."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Il codice promozionale è già stato utilizzato."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Il codice promozionale non può più essere utilizzato."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Il codice promozionale è scaduto."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Il codice promozionale non può essere usato per un acquisto."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Il codice promozionale non può essere usato per un noleggio."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Il codice promozionale non può essere usato per questo item."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Il codice promozionale non può essere usato in questa nazione."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Il codice promozionale non può essere usato."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Il codice promozionale non può essere usato per i bundle."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "La carta di credito è stata rifiutata. Ti prego di riprovare."
+  },
+  "shopping_complete_rental": {
+    "other": "Fatto!"
+  },
   "shopping_complete_rental_period": {
     "one": "Ora puoi guardarlo tutte le volte che vuoi il giorno successivo.",
     "other": "Ora puoi rivederlo quante volte vuoi nei prossimi {{.Count}} giorni."
   },
-  "shopping_complete_purchase": { "other": "Grazie per aver acquistato {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Grazie per aver acquistato {{.Title}}, {{.CreditTotal}} è stato aggiunto al tuo account utente." },
-  "shopping_complete_purchase_coming_soon": { "other": "Potrai vederlo a partire da {{.Date}}." },
-  "shopping_complete_receipt": { "other": "La ricevuta ti è stata inviata via email." },
-  "shopping_complete_library_link": { "other": "Consulta la tua library" },
+  "shopping_complete_purchase": {
+    "other": "Grazie per aver acquistato {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Grazie per aver acquistato {{.Title}}, {{.CreditTotal}} è stato aggiunto al tuo account utente."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Potrai vederlo a partire da {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "La ricevuta ti è stata inviata via email."
+  },
+  "shopping_complete_library_link": {
+    "other": "Consulta la tua library"
+  },
   "shopping_complete_plan": {
     "other": "L'acquisto di {{ .Title }} buon fine."
   },
@@ -314,100 +681,232 @@
     "one": "Potrai guardarlo da {{.Date}} e il tuo noleggio rimarrà attivo per un giorno.",
     "other": "Potrai vederlo a partire da {{.Date}} e il tuo noleggio rimarrà attivo per {{.Count}} giorni."
   },
-
-  "shopping_action_rent": { "other": "Noleggia" },
-  "shopping_action_buy": { "other": "Acquista" },
-
-  "shopping_payment_method_header": { "other": "Metodi di pagamento" },
-  "shopping_payment_method_credit_card": { "other": "Carta di credito" },
-  "shopping_payment_method_giropay": { "other": "Giropay (Germania)" },
-  
-  "shopping_error_stripe_unknown_error": { "other": "Con questo pagamento qualcosa non ha funzionato. Si prega di riprovare più tardi." },
-  "shopping_error_payment_complete_failed": { "other": "Il pagamento è stato rifiutato. Chiudi la finestra e riprova." },
-
-  "meta_detail_cast_title": { "other": "Cast" },
-  "meta_detail_crew_title": { "other": "Crew" },
-  "meta_detail_languages": { "one": "Lingua", "other": "Lingua" },
-  "meta_detail_studios": { "one": "Studio", "other": "Studios" },
-  "meta_detail_countries": { "one": "Paese", "other": "Paese" },
-  "meta_detail_subtitles": { "other": "Sottotitoli" },
-  "meta_detail_captions": { "other": "Sottotitoli [CC]" },
-  "meta_detail_episodes_title": { "other": "Episodi" },
-  "meta_detail_bonus_title": { "other": "Contenuti Extra" },
-  "meta_detail_recommendations_title": { "other": "Potrebbe piacerti anche" },
-  "meta_detail_bundle_items_title": { "other": "Contenuto incluso nel bundle" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} film" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} stagioni" },
-  "bundle_items_mixed": { "other": "{{.Count}} films e stagioni" },
-  "userwishlist_page_header": { "other": "La mia wishlist" },
-  "userwishlist_slider_header": { "other": "La mia wishlist" },
-  "userwishlist_empty_header":  { "other": "L'elenco è vuoto." },
-  "userwishlist_empty_content": { "other": "Riempilo <a href=\"{{.HomeURL}}\">sfogliando</a> la nostra fantastica selezione." },
-  "userwishlist_button_add": { "other": "Aggiungi alla mia wishlist" },
-  "userwishlist_button_remove": { "other": "La mia wishlist" },
-  "userwishlist_button_add_compact": { "other": "La mia wishlist" },
-  "userwishlist_button_remove_compact": { "other": "La mia wishlist" },
-
-  "activatedevice_page_header": { "other": "Attiva il dispositivo" },
-  "activatedevice_page_content": { "other": "Segui le istruzioni sul tuo dispositivo per ottenere un PIN. Il tuo computer e il dispositivo devono entrambi essere connessi a internet per l'attivazione." },
-  "activatedevice_form_pin": { "other": "PIN" },
-  "activatedevice_form_submit": { "other": "Attiva" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN non trovato, riprova." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN non trovato, riprova." },
-  "activatedevice_signin_prompt": { "other": "Registrati prima di attivare il tuo dispositivo." },
-  "activatedevice_page_activated": { "other": "Grazie per aver attivato {{.DeviceName}}. Ora potrai sfogliare la tua library sulla tua tv o sul tuo dispositivo." },
-
-  "userdevices_page_header": { "other": "Dispositivi" },
+  "shopping_action_rent": {
+    "other": "Noleggia"
+  },
+  "shopping_action_buy": {
+    "other": "Acquista"
+  },
+  "shopping_payment_method_header": {
+    "other": "Metodi di pagamento"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Carta di credito"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay (Germania)"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Con questo pagamento qualcosa non ha funzionato. Si prega di riprovare più tardi."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Il pagamento è stato rifiutato. Chiudi la finestra e riprova."
+  },
+  "meta_detail_cast_title": {
+    "other": "Cast"
+  },
+  "meta_detail_crew_title": {
+    "other": "Crew"
+  },
+  "meta_detail_languages": {
+    "one": "Lingua",
+    "other": "Lingua"
+  },
+  "meta_detail_studios": {
+    "one": "Studio",
+    "other": "Studios"
+  },
+  "meta_detail_countries": {
+    "one": "Paese",
+    "other": "Paese"
+  },
+  "meta_detail_subtitles": {
+    "other": "Sottotitoli"
+  },
+  "meta_detail_captions": {
+    "other": "Sottotitoli [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Episodi"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Contenuti Extra"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Potrebbe piacerti anche"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Contenuto incluso nel bundle"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} film"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} stagioni"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} films e stagioni"
+  },
+  "userwishlist_page_header": {
+    "other": "La mia wishlist"
+  },
+  "userwishlist_slider_header": {
+    "other": "La mia wishlist"
+  },
+  "userwishlist_empty_header": {
+    "other": "L'elenco è vuoto."
+  },
+  "userwishlist_empty_content": {
+    "other": "Riempilo <a href=\"{{.HomeURL}}\">sfogliando</a> la nostra fantastica selezione."
+  },
+  "userwishlist_button_add": {
+    "other": "Aggiungi alla mia wishlist"
+  },
+  "userwishlist_button_remove": {
+    "other": "La mia wishlist"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "La mia wishlist"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "La mia wishlist"
+  },
+  "activatedevice_page_header": {
+    "other": "Attiva il dispositivo"
+  },
+  "activatedevice_page_content": {
+    "other": "Segui le istruzioni sul tuo dispositivo per ottenere un PIN. Il tuo computer e il dispositivo devono entrambi essere connessi a internet per l'attivazione."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN"
+  },
+  "activatedevice_form_submit": {
+    "other": "Attiva"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN non trovato, riprova."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN non trovato, riprova."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Registrati prima di attivare il tuo dispositivo."
+  },
+  "activatedevice_page_activated": {
+    "other": "Grazie per aver attivato {{.DeviceName}}. Ora potrai sfogliare la tua library sulla tua tv o sul tuo dispositivo."
+  },
+  "userdevices_page_header": {
+    "other": "Dispositivi"
+  },
   "userdevices_page_content": {
     "one": "I dispositivi verranno aggiunti automaticamente qui quando saranno attivati. Puoi aggiungere fino a 1 dispositivi.",
     "other": "I dispositivi verranno aggiunti automaticamente qui quando saranno attivati. Puoi aggiungere fino a {{.Count}} dispositivi."
   },
-  "userdevices_empty_content": { "other": "Attualmente hai 0 dispositivi registrati." },
-  "userdevices_header_type": { "other": "Tipo di dispositivo" },
-  "userdevices_header_description": { "other": "Descrizione" },
-  "userdevices_device_added": { "other": "Aggiunto {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Rimuovi" },
-  "userdevices_device_actions_cancel": { "other": "Annulla" },
-  "userdevices_device_actions_confirm": { "other": "Sì, rimuovi il dispositivo" },
-  "userdevices_device_deleted": { "other": "(Rimosso)" },
-
-  "playlist_page_header": { "other": "Playlist" },
-  "playlist_sign_in_warning": { "other": "Collegati per guardare la TV live."},
-  "playlist_share_title": { "other": "Playlist" },
-  "playlist_up_next_title": { "other": "Prossimo" },
-
-  "pricing_ownership_buy": { "other": "Prossimo" },
-  "pricing_ownership_rent": { "other": "Noleggia" },
-
-  "classification_intro": { "other": "Voto: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Utilizziamo cookies e altre tecnologie per migliorare la tua navigazione. Utilizzando il nostro sito Web, accetti queste condizioni. Leggi la nostra <a href=\"{{.CookiePolicyURL}}\">informativa sulla privacy</a> per scoprire a cosa servono i cookies e come modificare le tue impostazioni." },
-  "cookie_banner_accept": { "other": "Accetta" },
-
-  "all_rights_reserved": { "other": "Tutti i diritti riservati. Nessuna parte di questo sito può essere riprodotta senza la nostra autorizzazione scritta." },
-
-  "availability_available": { "other": "Disponibile {{.ReleaseDate}}"},
-  "availability_renting": { "other": "Noleggiato" },
-  "availability_available_till": { "other": "Disponibile fino {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Non Disponibile" },
-  "availability_expires": { "other": "Scaduto il {{.Expiry}}" },
-  "availability_expired": { "other": "Scaduto" },
-  "availability_coming_soon": { "other": "Presto Disponibile" },
-  "availability_not_available": { "other": "Non Disponibile" },
-  "availability_in_watch_window": { "other": "Disponibile nella finestra dell'orologio" },
-  "availability_sold_out": { "other": "Esaurito" },
-
-  "shopping_card_change": { "other": "Carta di credito non corretta? <a href=\"{{.SubscriptionsURL}}\">Fai clic qui per aggiornare la tua carta.</a>" },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Sembra che tu abbia problemi.</p><p>Reimposta il PIN o contattaci per <a href=\"{{.HelpURL}}\" target=\"_blank\">aiuto</a>" },
-
-  "app_badge_title": { "other": "Scarica l'app per visualizzare i contenuti acquistati!" },
-  "app_badge_ios": { "other": "Scarica dall'App Store" },
-  "app_badge_android": { "other": "Scaricalo su Google Play" },
-
+  "userdevices_empty_content": {
+    "other": "Attualmente hai 0 dispositivi registrati."
+  },
+  "userdevices_header_type": {
+    "other": "Tipo di dispositivo"
+  },
+  "userdevices_header_description": {
+    "other": "Descrizione"
+  },
+  "userdevices_device_added": {
+    "other": "Aggiunto {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Rimuovi"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Annulla"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Sì, rimuovi il dispositivo"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Rimosso)"
+  },
+  "playlist_page_header": {
+    "other": "Playlist"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Collegati per guardare la TV live."
+  },
+  "playlist_share_title": {
+    "other": "Playlist"
+  },
+  "playlist_up_next_title": {
+    "other": "Prossimo"
+  },
+  "pricing_ownership_buy": {
+    "other": "Prossimo"
+  },
+  "pricing_ownership_rent": {
+    "other": "Noleggia"
+  },
+  "classification_intro": {
+    "other": "Voto: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Utilizziamo cookies e altre tecnologie per migliorare la tua navigazione. Utilizzando il nostro sito Web, accetti queste condizioni. Leggi la nostra <a href=\"{{.CookiePolicyURL}}\">informativa sulla privacy</a> per scoprire a cosa servono i cookies e come modificare le tue impostazioni."
+  },
+  "cookie_banner_accept": {
+    "other": "Accetta"
+  },
+  "all_rights_reserved": {
+    "other": "Tutti i diritti riservati. Nessuna parte di questo sito può essere riprodotta senza la nostra autorizzazione scritta."
+  },
+  "availability_available": {
+    "other": "Disponibile {{.ReleaseDate}}"
+  },
+  "availability_renting": {
+    "other": "Noleggiato"
+  },
+  "availability_available_till": {
+    "other": "Disponibile fino {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Non Disponibile"
+  },
+  "availability_expires": {
+    "other": "Scaduto il {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Scaduto"
+  },
+  "availability_coming_soon": {
+    "other": "Presto Disponibile"
+  },
+  "availability_not_available": {
+    "other": "Non Disponibile"
+  },
+  "availability_in_watch_window": {
+    "other": "Disponibile nella finestra dell'orologio"
+  },
+  "availability_sold_out": {
+    "other": "Esaurito"
+  },
+  "shopping_card_change": {
+    "other": "Carta di credito non corretta? <a href=\"{{.SubscriptionsURL}}\">Fai clic qui per aggiornare la tua carta.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Sembra che tu abbia problemi.</p><p>Reimposta il PIN o contattaci per <a href=\"{{.HelpURL}}\" target=\"_blank\">aiuto</a>"
+  },
+  "app_badge_title": {
+    "other": "Scarica l'app per visualizzare i contenuti acquistati!"
+  },
+  "app_badge_ios": {
+    "other": "Scarica dall'App Store"
+  },
+  "app_badge_android": {
+    "other": "Scaricalo su Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Prezzo"
   },
@@ -479,116 +978,271 @@
   "donate_button_text": {
     "other": "Donare"
   },
-  "wcag_skip_links_header": { "other": "Collegamenti di accessibilità" },
-  "wcag_skip_links_content": { "other": "Salta al contenuto" },
-
-  "wcag_homepage_h1": { "other": "Pagina iniziale" },
-  "wcag_carousel_h2": { "other": "Giostra" },
-  "wcag_collections_h2": { "other": "Collezioni" },
-
-  "wcag_aria_label_footer": { "other": "Piè di pagina" },
-  "wcag_aria_label_nav_main": { "other": "Principale" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Attiva/disattiva navigazione" },
-  "wcag_aria_label_bundle_items": { "other": "Articoli in bundle" },
-  "wcag_aria_label_carousel": { "other": "Giostra" },
-  "wcag_aria_label_page_collection": { "other": "Collezione di pagine" },
-  "wcag_aria_label_collection_list": { "other": "Elenco di raccolta" },
-  "wcag_aria_label_collection_slider": { "other": "Dispositivo di scorrimento della raccolta" },
-  "wcag_aria_label_wishlist": { "other": "Lista dei desideri" },
-  "wcag_aria_label_facebook": { "other": "Condividi su Facebook" },
-  "wcag_aria_label_twitter": { "other": "Condividi su Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Condividi su LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Visualizza su Letterboxdd" },
-
-  "header_banner": { "other": "ABC Cinemas – 21° Festival del Cinema, 1 – 6 giugno 2021" },
-
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "Non hai un PIN impostato, necessario per l'acquisto, il noleggio e la visione di alcuni titoli."},
-  "account_form_set_pin": { "other": "Imposta PIN" },
-  "account_form_pin_changed": { "other": "Aggiornata" },
-  "account_form_change_pin": { "other": "Cambia PIN" },
-
-  "user_set_pin_header": { "other": "Imposta il tuo PIN" },
-  "user_set_pin_button": { "other": "Imposta PIN" },
-  "user_submit_pin_heading": { "other": "Inserisci il tuo PIN per {{.Action}} questo contenuto con restrizioni" },
-  "user_error_wrong_pin_retry": { "other": "Spiacenti, hai inserito un PIN errato" },
-  "user_submit_pin_button": { "other": "Accedere" },
-  "user_reset_pin_button": { "other": "Reimposta PIN" },
-
-  "validation_pincode1_required": { "other": "Si prega di inserire un codice PIN valido." },
-  "validation_pincode2_required": { "other": "Si prega di inserire un codice PIN valido." },
-  "validation_pincode1_pattern": { "other": "Si prega di inserire un codice PIN valido." },
-  "validation_pincode2_pattern": { "other": "Si prega di inserire un codice PIN valido." },
-  "validation_pincode2_match": { "other": "Il codice PIN non corrisponde." },
-
-  "userdevices_delete_limits": { "other": "Puoi rimuovere {{.Limit}} dispositivo/i da questo elenco ogni {{.Period}} giorno/i."},
-  "userdevices_delete_limit_reached": { "other": "Hai raggiunto questo limite e al momento non puoi rimuovere alcun dispositivo. Puoi eliminare un dispositivo tra {{.Days}} giorno/i." },
-  "shopping_card_new_subscription": { "other": "Questa carta verrà salvata e addebitata regolarmente" },
-
-"changepincode_modal_header": { "other": "Cambia il tuo PIN" },
-"changepincode_modal_currentpassword": { "other": "la tua password attuale" },
-"changepincode_modal_pincode1": { "other": "Il tuo nuovo PIN a 4 cifre" },
-"changepincode_modal_pincode2": { "other": "Conferma il tuo nuovo PIN a 4 cifre" },
-"changepincode_modal_submit": { "other": "Imposta PIN" },
-"changepincode_modal_error_wrong_password": { "other": "Quella password non è corretta." },
-
-"user_set_pin_intro": { "other": "Hai bisogno di un PIN per {{.Action}} contenuto limitato"},
-"user_error_wrong_pin_reset": { "other": "Clicca qui per reimpostare il PIN" },
-"user_error_too_many_pin_errors_help_page_link": { "other": "" },
-"shopping_error_age_restricted": { "other": "Questo contenuto è soggetto a limiti di età." },
-"shopping_error_close_button": { "other": "OK" }, 
-
-"usersubscriptions_subscription_expiry": { "other": "Scade {{.Expiry}}" },
-"usersubscriptions_subscription_status_trialing": { "other": "Periodo di prova" },
-"usersubscriptions_subscription_unsubscribe": { "other": "Annulla il mio abbonamento" },
-"usersubscriptions_unsubscribe_modal_cancel": { "other": "Annulla" },
-"usersubscriptions_unsubscribe_modal_confirm": { "other": "Sì, cancella il mio abbonamento" },
-"usersubscriptions_unsubscribe_modal_title": { "other": "Annullare l'iscrizione?" },
-"usersubscriptions_unsubscribe_modal_body": { "other": "Questo annullerà l'abbonamento al piano {{.Name}}. Potrai comunque guardare i contenuti del piano fino alla scadenza {{.Expiry}}." },
-
-
-"signin_form_error_ip_throttled": { "other": "Non sei riuscito ad accedere troppe volte. Per favore riprova più tardi." },
-"signin_form_error_account_suspended": { "other": "Il tuo account è stato temporaneamente sospeso. Contatta un amministratore se ritieni che si tratti di un errore." },
-
-"shopping_error_plan_already_owned": { "other": "Hai già questo piano." },
-"shopping_error_plan_expired": { "other": "Questo piano non è più disponibile." },
-
-"users_gender_none": { "other": "Non specificato" },
-"users_gender_female": { "other": "Femmina" },
-"users_gender_male": { "other": "Maschio" },
-"users_gender_diverse": { "other": "Diverse" },
-"users_gender_other": { "other": "Altro" },
-
-"pricing_quality_hd": { "other": "HD" },
-"pricing_quality_sd": { "other": "SD" },
-"pricing_quality_hd_only": { "other": "Solo HD" },
-"pricing_quality_sd_only": { "other": "Solo SD" },
-
-"shopping_card_save_card": { "other": "Salva questa carta per un uso futuro" },
-  "shopping_card_button_change": { "other": "Mostra tutte le carte salvate" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} che termina con {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(scade {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(scaduta)" },
-  "shopping_card_use_other": { "other": "Usa una nuova carta" },
-  "shopping_card_use_new_card": { "other": "Cambia carta" },
-  "shopping_card_update_reason_none": { "other": "Aggiorna la tua carta di credito. Le carte supportate sono Visa, Mastercard e American Express." },
-  "shopping_action_credit": { "other": "Riempire" },
-  "shopping_info_ownership_plan": { "other": "Sottoscrizione" },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Cambia carta di credito" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Aggiorna i dettagli della carta di credito" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Aggiornare" },
-
-  "modal_cancel": { "other": "Annulla" },
-
-  "play": { "other": "Giocare" },
-
-  "combined_auth_signin_prompt": { "other": "Accedi" },
-  "combined_auth_signup_prompt": { "other": "Registrati" },
-
-  "validation_terms_required": { "other": "Devi accettare i termini e le condizioni." },
-  "shopping_error_item_limit_exceeded": { "other": "Sfortunatamente, {{.Title}} è esaurito." }
-
-
+  "wcag_skip_links_header": {
+    "other": "Collegamenti di accessibilità"
+  },
+  "wcag_skip_links_content": {
+    "other": "Salta al contenuto"
+  },
+  "wcag_homepage_h1": {
+    "other": "Pagina iniziale"
+  },
+  "wcag_carousel_h2": {
+    "other": "Giostra"
+  },
+  "wcag_collections_h2": {
+    "other": "Collezioni"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Piè di pagina"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Principale"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Attiva/disattiva navigazione"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Articoli in bundle"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Giostra"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Collezione di pagine"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Elenco di raccolta"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Dispositivo di scorrimento della raccolta"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Lista dei desideri"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Condividi su Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Condividi su Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Condividi su LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Visualizza su Letterboxdd"
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21° Festival del Cinema, 1 – 6 giugno 2021"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Non hai un PIN impostato, necessario per l'acquisto, il noleggio e la visione di alcuni titoli."
+  },
+  "account_form_set_pin": {
+    "other": "Imposta PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Aggiornata"
+  },
+  "account_form_change_pin": {
+    "other": "Cambia PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Imposta il tuo PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Imposta PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Inserisci il tuo PIN per {{.Action}} questo contenuto con restrizioni"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Spiacenti, hai inserito un PIN errato"
+  },
+  "user_submit_pin_button": {
+    "other": "Accedere"
+  },
+  "user_reset_pin_button": {
+    "other": "Reimposta PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "Si prega di inserire un codice PIN valido."
+  },
+  "validation_pincode2_required": {
+    "other": "Si prega di inserire un codice PIN valido."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Si prega di inserire un codice PIN valido."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Si prega di inserire un codice PIN valido."
+  },
+  "validation_pincode2_match": {
+    "other": "Il codice PIN non corrisponde."
+  },
+  "userdevices_delete_limits": {
+    "other": "Puoi rimuovere {{.Limit}} dispositivo/i da questo elenco ogni {{.Period}} giorno/i."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Hai raggiunto questo limite e al momento non puoi rimuovere alcun dispositivo. Puoi eliminare un dispositivo tra {{.Days}} giorno/i."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Questa carta verrà salvata e addebitata regolarmente"
+  },
+  "changepincode_modal_header": {
+    "other": "Cambia il tuo PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "la tua password attuale"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Il tuo nuovo PIN a 4 cifre"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Conferma il tuo nuovo PIN a 4 cifre"
+  },
+  "changepincode_modal_submit": {
+    "other": "Imposta PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Quella password non è corretta."
+  },
+  "user_set_pin_intro": {
+    "other": "Hai bisogno di un PIN per {{.Action}} contenuto limitato"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Clicca qui per reimpostare il PIN"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Questo contenuto è soggetto a limiti di età."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Scade {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Periodo di prova"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Annulla il mio abbonamento"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Annulla"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Sì, cancella il mio abbonamento"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Annullare l'iscrizione?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Questo annullerà l'abbonamento al piano {{.Name}}. Potrai comunque guardare i contenuti del piano fino alla scadenza {{.Expiry}}."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Non sei riuscito ad accedere troppe volte. Per favore riprova più tardi."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Il tuo account è stato temporaneamente sospeso. Contatta un amministratore se ritieni che si tratti di un errore."
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Hai già questo piano."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Questo piano non è più disponibile."
+  },
+  "users_gender_none": {
+    "other": "Non specificato"
+  },
+  "users_gender_female": {
+    "other": "Femmina"
+  },
+  "users_gender_male": {
+    "other": "Maschio"
+  },
+  "users_gender_diverse": {
+    "other": "Diverse"
+  },
+  "users_gender_other": {
+    "other": "Altro"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "Solo HD"
+  },
+  "pricing_quality_sd_only": {
+    "other": "Solo SD"
+  },
+  "shopping_card_save_card": {
+    "other": "Salva questa carta per un uso futuro"
+  },
+  "shopping_card_button_change": {
+    "other": "Mostra tutte le carte salvate"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} che termina con {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(scade {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(scaduta)"
+  },
+  "shopping_card_use_other": {
+    "other": "Usa una nuova carta"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Cambia carta"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Aggiorna la tua carta di credito. Le carte supportate sono Visa, Mastercard e American Express."
+  },
+  "shopping_action_credit": {
+    "other": "Riempire"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Sottoscrizione"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Cambia carta di credito"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Aggiorna i dettagli della carta di credito"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Aggiornare"
+  },
+  "modal_cancel": {
+    "other": "Annulla"
+  },
+  "play": {
+    "other": "Giocare"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Accedi"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Registrati"
+  },
+  "validation_terms_required": {
+    "other": "Devi accettare i termini e le condizioni."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Sfortunatamente, {{.Title}} è esaurito."
+  }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1,188 +1,457 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Settings" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "ScreenPlus" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Settings"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "ScreenPlus"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
   "episode_name": {
     "other": "シーズン"
   },
   "season_name": {
     "other": "エピソード"
   },
-
-  "date_day": { "other": "日" },
-  "date_month": { "other": "月" },
-  "date_year": { "other": "年" },
-
-  "404_page_header": { "other": "このページは存在しません…" },
-  "404_page_content": { "other": "<p>お探しのページは存在しないようです。移 動もしくは削除されたか、入力間違いかも しれません。ホーム画面でページを探して みてください。</p><p><a href=\"/\">ホーム 画面に戻る</a></p>" },
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "サインイン" },
-  "nav_signup": { "other": "アカウント登録" },
-  "nav_signed_in_as": { "other": "サインイン中" },
-  "nav_library": { "other": "マイライブラリー" },
-  "nav_devices": { "other": "マイデバイス" },
-  "nav_wishlist": { "other": "マイリスト" },
-  "nav_account": { "other": "マイアカウント" },
-  "nav_signout": { "other": "サインアウト" },
-  "play_trailer": { "other": "予告編" },
-  "runtime_hours": { "other": "時間" },
-  "runtime_minutes": { "other": "分" },
-
-  "datetime_today": { "other": "本日 {{.Date}}" },
-  "datetime_tomorrow": { "other": "明日 {{.Date}}" },
-  "datetime_yesterday": { "other": "昨日 {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "最終 {{.Date}}" },
-
-  "search_control_placeholder": { "other": "検索" },
-  "search_control_submit": { "other": "検索する" },
-
-  "play_button_watch": { "other" : "再生する"},
-  "play_button_resume": { "other" : "続きから見る"},
-
-  "social_media_buttons_title": { "other": "共有" },
-  "social_media_buttons_facebook": { "other": "Facebookでシェア" },
-  "social_media_buttons_twitter": { "other": "Twitterで共有する" },
-  "social_media_buttons_linkedin": { "other": "Linkedinで共有する" },
-  "social_media_buttons_email": { "other": "メールで共有する" },
-  "social_media_buttons_email_subject": { "other": "リンクシェア" },
-  "social_media_buttons_copied_link": { "other": "リンクがクリップボードにコピーされました！" },
-  "social_media_buttons_copy_link": { "other": "クリップボードにコピー" },
-
-  "accept_invite_page_header": { "other": "ようこそ " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "すでに招待リクエスト済みですので、サインインしてください。" },
-  "acceptinvite_complete": { "other": "ありがとうございます。アカウント登録は完了しました。" },
-  "acceptinvite_form_submit": { "other": "招待を受け取る" },
-  "acceptinvite_agreement": { "other": "「招待を受け取る」をクリックすること で、<a href=\"/page/terms-and-conditions/\" target=\"_blank\">利用規約</a>と<a href=\"/page/privacy/\" target=\"_blank\">プラ イベートポリシー</a>を確認・同意したと みなします。" },
-
-  "signup_page_header": { "other": "アカウントを新規作成する" },
-  "signup_form_name": { "other": "名前" },
-  "signup_form_email": { "other": "Eメールアドレス" },
-  "signup_form_password": { "other": "パスワード" },
-  "signup_form_password_confirmation": { "other": "パスワード再確認" },
-  "signup_form_gender": { "other": "性別" },
-  "signup_form_dob": { "other": "生年月日" },
-  "signup_form_submit": { "other": "送信" },
-
-  "signin_page_header": { "other": "サインイン" },
-  "signin_form_email": { "other": "Eメールアドレス" },
-  "signin_form_password": { "other": "パスワード" },
-  "signin_form_remember": { "other": "ログイン情報を記憶する" },
-  "signin_form_submit": { "other": "送信" },
-  "signin_page_forgotpassword": { "other": "パスワードを忘れましたか？" },
-  "signin_page_createnewaccount": { "other": "アカウント登録がお済みでない方は初めに登録してください。" },
-  "signup_page_alreadyhaveanaccount": { "other": "アカウントをお持ちの方はサインインしてください。" },
-  "signup_form_error_email_already_in_use": { "other": "このEメールアドレスは登録済みです。" },
-  "signin_form_error_incorrect_credentials": { "other": "ユーザー名とパスワードが間違っています。" },
-
-  "signup_form_error_forbidden": { "other": "エラーが発生しました。" },
-
-  "combined_auth_continue": { "other": "続ける" },
-  "combined_auth_change": { "other": "変更する" },
-  "combined_auth_signin": { "other": "サインイン" },
-  "combined_auth_signup": { "other": "アカウントを作成する" },
-  "combined_auth_signin_password": { "other": "パスワードを入力してサインインする。" },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "このパスワードは不正です。" },
-  "combined_auth_error_forbidden": { "other": "エラーが発生しました。" },
-  "combined_auth_error_too_many_requests": { "other": "要求が多すぎます。あとで言ってください。" },
-
-  "forgotpassword_page_header": { "other": "パスワードをリセットする" },
-  "forgotpassword_form_email": { "other": "Eメールアドレス" },
-  "forgotpassword_form_submit": { "other": "リセット" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "このEメールアドレスと一致するアカウントは存在しません。" },
-  "forgotpassword_form_error_account_suspended": { "other": "このアカウントは停止中です。" },
-  "forgotpassword_complete": { "other": "ありがとうございます。パスワード再登録の案内メールをお送りしました。" },
-  "forgotpassword_form_error_forbidden": { "other": "エラーが発生しました。" },
-  "forgotpassword_form_error_too_many_requests": { "other": "要求が多すぎます。あとで言ってください。" },
-
-  "resetpassword_page_header": { "other": "パスワードを変更する" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "パスワード再設定リクエスト有効期限切れのようです。再度、 <a href=\"{{.URL}}\">パスワード再設定</a> フォームから申請してください。" },
-  "resetpassword_form_password": { "other": "新しいパスワード" },
-  "resetpassword_form_password2": { "other": "パスワードを再確認" },
-  "resetpassword_form_submit": { "other": "変更する" },
-  "resetpassword_complete": { "other": "ありがとうございます。パスワードは変更されました。サインイン中です。" },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "パスワード再設定リクエストは無効です。もう一度リクエストしてください。" },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "パスワード再設定のトークンは有効期限が切れました。新しいトークンを申請してください。" },
-  "resetpassword_form_error_too_many_requests": { "other": "要求が多すぎます。あとで言ってください。" },
-
-  "account_page_header": { "other": "マイアカウント" },
-  "account_form_name": { "other": "名前" },
-  "account_form_email": { "other": "Eメールアドレス" },
-  "account_form_password": { "other": "パスワード" },
-  "account_form_change_password": { "other": "変更する" },
-  "account_form_gender": { "other": "性別" },
-  "account_form_dob": { "other": "生年月日" },
-  "account_form_submit": { "other": "更新する" },
-  "account_form_submitted": { "other": "更新済み" },
-  "account_form_password_changed": { "other": "更新済み" },
-  "account_form_error_incorrect_password": { "other": "パスワードが正しくありません" },
-
-  "signup_form_optin": {"other": "無料のニュースレターを購読する"},
-
-  "passwordconfirmation_modal_header": { "other": "パスワードを再入力する" },
-  "passwordconfirmation_modal_label": { "other": "変更を登録するためにパスワードを入力してください" },
-  "passwordconfirmation_modal_confirm": { "other": "確定する" },
-
-  "changepassword_modal_header": { "other": "パスワードを変更する" },
-  "changepassword_modal_currentpassword": { "other": "現在のパスワード" },
-  "changepassword_modal_password": { "other": "新しいパスワード" },
-  "changepassword_modal_password2": { "other": "新しいパスワードを再入力する" },
-  "changepassword_modal_submit": { "other": "更新する" },
-  "changepassword_modal_error_incorrect_password": { "other": "パスワードが正しくありません" },
-
-  "userlibrary_page_header": { "other": "マイライブラリー" },
-  "userlibrary_empty_header":  { "other": "あなたのライブラリーには何も入っていません" },
-  "userlibrary_empty_content": { "other": "<a href=\"{{.HomeURL}}\">作品ラインナップ</a>からご覧になりたい作品を選んでください" },
-
-  "searchresults_page_header": { "other": "検索結果" },
-  "searchresults_load_more": { "other": "{{.Count}} 以上を読み込んでいます" },
+  "date_day": {
+    "other": "日"
+  },
+  "date_month": {
+    "other": "月"
+  },
+  "date_year": {
+    "other": "年"
+  },
+  "404_page_header": {
+    "other": "このページは存在しません…"
+  },
+  "404_page_content": {
+    "other": "<p>お探しのページは存在しないようです。移 動もしくは削除されたか、入力間違いかも しれません。ホーム画面でページを探して みてください。</p><p><a href=\"/\">ホーム 画面に戻る</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "サインイン"
+  },
+  "nav_signup": {
+    "other": "アカウント登録"
+  },
+  "nav_signed_in_as": {
+    "other": "サインイン中"
+  },
+  "nav_library": {
+    "other": "マイライブラリー"
+  },
+  "nav_devices": {
+    "other": "マイデバイス"
+  },
+  "nav_wishlist": {
+    "other": "マイリスト"
+  },
+  "nav_account": {
+    "other": "マイアカウント"
+  },
+  "nav_signout": {
+    "other": "サインアウト"
+  },
+  "play_trailer": {
+    "other": "予告編"
+  },
+  "runtime_hours": {
+    "other": "時間"
+  },
+  "runtime_minutes": {
+    "other": "分"
+  },
+  "datetime_today": {
+    "other": "本日 {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "明日 {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "昨日 {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "最終 {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "検索"
+  },
+  "search_control_submit": {
+    "other": "検索する"
+  },
+  "play_button_watch": {
+    "other": "再生する"
+  },
+  "play_button_resume": {
+    "other": "続きから見る"
+  },
+  "social_media_buttons_title": {
+    "other": "共有"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Facebookでシェア"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Twitterで共有する"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Linkedinで共有する"
+  },
+  "social_media_buttons_email": {
+    "other": "メールで共有する"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "リンクシェア"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "リンクがクリップボードにコピーされました！"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "クリップボードにコピー"
+  },
+  "accept_invite_page_header": {
+    "other": "ようこそ "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "すでに招待リクエスト済みですので、サインインしてください。"
+  },
+  "acceptinvite_complete": {
+    "other": "ありがとうございます。アカウント登録は完了しました。"
+  },
+  "acceptinvite_form_submit": {
+    "other": "招待を受け取る"
+  },
+  "acceptinvite_agreement": {
+    "other": "「招待を受け取る」をクリックすること で、<a href=\"/page/terms-and-conditions/\" target=\"_blank\">利用規約</a>と<a href=\"/page/privacy/\" target=\"_blank\">プラ イベートポリシー</a>を確認・同意したと みなします。"
+  },
+  "signup_page_header": {
+    "other": "アカウントを新規作成する"
+  },
+  "signup_form_name": {
+    "other": "名前"
+  },
+  "signup_form_email": {
+    "other": "Eメールアドレス"
+  },
+  "signup_form_password": {
+    "other": "パスワード"
+  },
+  "signup_form_password_confirmation": {
+    "other": "パスワード再確認"
+  },
+  "signup_form_gender": {
+    "other": "性別"
+  },
+  "signup_form_dob": {
+    "other": "生年月日"
+  },
+  "signup_form_submit": {
+    "other": "送信"
+  },
+  "signin_page_header": {
+    "other": "サインイン"
+  },
+  "signin_form_email": {
+    "other": "Eメールアドレス"
+  },
+  "signin_form_password": {
+    "other": "パスワード"
+  },
+  "signin_form_remember": {
+    "other": "ログイン情報を記憶する"
+  },
+  "signin_form_submit": {
+    "other": "送信"
+  },
+  "signin_page_forgotpassword": {
+    "other": "パスワードを忘れましたか？"
+  },
+  "signin_page_createnewaccount": {
+    "other": "アカウント登録がお済みでない方は初めに登録してください。"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "アカウントをお持ちの方はサインインしてください。"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "このEメールアドレスは登録済みです。"
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "ユーザー名とパスワードが間違っています。"
+  },
+  "signup_form_error_forbidden": {
+    "other": "エラーが発生しました。"
+  },
+  "combined_auth_continue": {
+    "other": "続ける"
+  },
+  "combined_auth_change": {
+    "other": "変更する"
+  },
+  "combined_auth_signin": {
+    "other": "サインイン"
+  },
+  "combined_auth_signup": {
+    "other": "アカウントを作成する"
+  },
+  "combined_auth_signin_password": {
+    "other": "パスワードを入力してサインインする。"
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "このパスワードは不正です。"
+  },
+  "combined_auth_error_forbidden": {
+    "other": "エラーが発生しました。"
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "要求が多すぎます。あとで言ってください。"
+  },
+  "forgotpassword_page_header": {
+    "other": "パスワードをリセットする"
+  },
+  "forgotpassword_form_email": {
+    "other": "Eメールアドレス"
+  },
+  "forgotpassword_form_submit": {
+    "other": "リセット"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "このEメールアドレスと一致するアカウントは存在しません。"
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "このアカウントは停止中です。"
+  },
+  "forgotpassword_complete": {
+    "other": "ありがとうございます。パスワード再登録の案内メールをお送りしました。"
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "エラーが発生しました。"
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "要求が多すぎます。あとで言ってください。"
+  },
+  "resetpassword_page_header": {
+    "other": "パスワードを変更する"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "パスワード再設定リクエスト有効期限切れのようです。再度、 <a href=\"{{.URL}}\">パスワード再設定</a> フォームから申請してください。"
+  },
+  "resetpassword_form_password": {
+    "other": "新しいパスワード"
+  },
+  "resetpassword_form_password2": {
+    "other": "パスワードを再確認"
+  },
+  "resetpassword_form_submit": {
+    "other": "変更する"
+  },
+  "resetpassword_complete": {
+    "other": "ありがとうございます。パスワードは変更されました。サインイン中です。"
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "パスワード再設定リクエストは無効です。もう一度リクエストしてください。"
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "パスワード再設定のトークンは有効期限が切れました。新しいトークンを申請してください。"
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "要求が多すぎます。あとで言ってください。"
+  },
+  "account_page_header": {
+    "other": "マイアカウント"
+  },
+  "account_form_name": {
+    "other": "名前"
+  },
+  "account_form_email": {
+    "other": "Eメールアドレス"
+  },
+  "account_form_password": {
+    "other": "パスワード"
+  },
+  "account_form_change_password": {
+    "other": "変更する"
+  },
+  "account_form_gender": {
+    "other": "性別"
+  },
+  "account_form_dob": {
+    "other": "生年月日"
+  },
+  "account_form_submit": {
+    "other": "更新する"
+  },
+  "account_form_submitted": {
+    "other": "更新済み"
+  },
+  "account_form_password_changed": {
+    "other": "更新済み"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "パスワードが正しくありません"
+  },
+  "signup_form_optin": {
+    "other": "無料のニュースレターを購読する"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "パスワードを再入力する"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "変更を登録するためにパスワードを入力してください"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "確定する"
+  },
+  "changepassword_modal_header": {
+    "other": "パスワードを変更する"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "現在のパスワード"
+  },
+  "changepassword_modal_password": {
+    "other": "新しいパスワード"
+  },
+  "changepassword_modal_password2": {
+    "other": "新しいパスワードを再入力する"
+  },
+  "changepassword_modal_submit": {
+    "other": "更新する"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "パスワードが正しくありません"
+  },
+  "userlibrary_page_header": {
+    "other": "マイライブラリー"
+  },
+  "userlibrary_empty_header": {
+    "other": "あなたのライブラリーには何も入っていません"
+  },
+  "userlibrary_empty_content": {
+    "other": "<a href=\"{{.HomeURL}}\">作品ラインナップ</a>からご覧になりたい作品を選んでください"
+  },
+  "searchresults_page_header": {
+    "other": "検索結果"
+  },
+  "searchresults_load_more": {
+    "other": "{{.Count}} 以上を読み込んでいます"
+  },
   "searchresults_total": {
     "one": "\"{{.Query}}\"について1件の 検索結果",
     "other": "\"{{.Query}}\"について{{.Count}} 件の 検索結果"
   },
-  "searchresults_empty_header":  { "other": "\"{{.Query}}\"では検索結果なし" },
-  "searchresults_empty_content": { "other": "他の検索用語を入力して<a href=\"{{.HomeURL}}\">検索</a> してください" },
-
-  "validation_name_required": { "other": "お名前を入力してください" },
-  "validation_email_required": { "other": "Eメールアドレスを入力してください" },
-  "validation_email_email": { "other": "正しいEメールアドレスを入力してください" },
-  "validation_currentpassword_required": { "other": "現在のパスワードを入力してください" },
-  "validation_password_required": { "other": "パスワードを入力してください" },
-  "validation_password2_required": { "other": "パスワードを再入力してください" },
-  "validation_password2_match": { "other": "パスワードが一致しません" },
-  "validation_password_minlength": { "other": "少なくとも{{.Count}} 以上の文字を含めてください" },
-  "validation_promocode_required": { "other": "プロモーションコードを入力してください" },
-  "validation_gender_required": { "other": "性別を入力してください" },
-  "validation_dob_required": { "other": "生年月日を入力してください" },
-  "validation_dob_date": { "other": "生年月日を入力してください" },
-
-  "shopping_info_subtitle_hd": { "other": "HD画質で見る" },
-  "shopping_info_subtitle_help": { "other": "システム要件をご確認ください" },
-  "shopping_info_ownership_buy": { "other": "購入" },
-  "shopping_info_ownership_rent": { "other": "期間限定視聴（レンタル）" },
-
-  "shopping_info_release_date_title": { "other": "{{.Date}} より視聴可能になります。" },
-  "shopping_info_release_date_explanation_rent": { "other": "現在、お申し込みはできますが、期日まではご視聴いただけません。" },
-  "shopping_info_release_date_explanation_buy": { "other": "現在、購入はできますが、配信日まではご視聴いただけません。" },
-
-  
-  "shopping_info_available_until_date_title": { "other": "{{.Date}}から利用可能" },
-  "shopping_info_available_until_date_explanation_rent": { "other": "この日時以降の視聴はできません。" },
-  "shopping_info_available_until_date_explanation_buy": { "other": "この日時以降の視聴はできません。" },
-
-  "duration_hour": { "one": "1時間", "other": "{{.Count}}時間" },
-  "duration_day": { "one": "1日", "other": "{{.Count}}日間" },
-  "shopping_info_rental_period_duration": { "other": "レンタル期間 {{.ValueUnit}}" },
-  "shopping_info_watch_window_duration": { "other": "再生開始後{{.Count}} 時間視聴できます。" },
+  "searchresults_empty_header": {
+    "other": "\"{{.Query}}\"では検索結果なし"
+  },
+  "searchresults_empty_content": {
+    "other": "他の検索用語を入力して<a href=\"{{.HomeURL}}\">検索</a> してください"
+  },
+  "validation_name_required": {
+    "other": "お名前を入力してください"
+  },
+  "validation_email_required": {
+    "other": "Eメールアドレスを入力してください"
+  },
+  "validation_email_email": {
+    "other": "正しいEメールアドレスを入力してください"
+  },
+  "validation_currentpassword_required": {
+    "other": "現在のパスワードを入力してください"
+  },
+  "validation_password_required": {
+    "other": "パスワードを入力してください"
+  },
+  "validation_password2_required": {
+    "other": "パスワードを再入力してください"
+  },
+  "validation_password2_match": {
+    "other": "パスワードが一致しません"
+  },
+  "validation_password_minlength": {
+    "other": "少なくとも{{.Count}} 以上の文字を含めてください"
+  },
+  "validation_promocode_required": {
+    "other": "プロモーションコードを入力してください"
+  },
+  "validation_gender_required": {
+    "other": "性別を入力してください"
+  },
+  "validation_dob_required": {
+    "other": "生年月日を入力してください"
+  },
+  "validation_dob_date": {
+    "other": "生年月日を入力してください"
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD画質で見る"
+  },
+  "shopping_info_subtitle_help": {
+    "other": "システム要件をご確認ください"
+  },
+  "shopping_info_ownership_buy": {
+    "other": "購入"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "期間限定視聴（レンタル）"
+  },
+  "shopping_info_release_date_title": {
+    "other": "{{.Date}} より視聴可能になります。"
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "現在、お申し込みはできますが、期日まではご視聴いただけません。"
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "現在、購入はできますが、配信日まではご視聴いただけません。"
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "{{.Date}}から利用可能"
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "この日時以降の視聴はできません。"
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "この日時以降の視聴はできません。"
+  },
+  "duration_hour": {
+    "one": "1時間",
+    "other": "{{.Count}}時間"
+  },
+  "duration_day": {
+    "one": "1日",
+    "other": "{{.Count}}日間"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "レンタル期間 {{.ValueUnit}}"
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "再生開始後{{.Count}} 時間視聴できます。"
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "お申し込み完了後、{{.ValueUnit}}以内に視聴を開始してください。",
     "other": "お申し込み完了後、{{.ValueUnit}}以内に視聴を開始してください。"
@@ -207,65 +476,145 @@
     "one": "シーズン内のエピソード再生開始後は、1時間以内に限り、そのエピソードを何度でも視聴いただけます。",
     "other": "シーズン内のエピソード再生開始後は、{{.Count}} 時間以内に限り、そのエピソードを何度でも視聴いただけます。"
   },
-
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% ボーナス" },
-
-  "shopping_enter_card_prompt": { "other": "クレジットカード情報を入力して{{.Verb}}を完了してください。" },
-
-  "shopping_terms": { "other": "<a href=\"/page/terms-and-conditions/\"target=\"_blank\" tabindex=\"-1\">利用規約</a>に同意して決済を完了する。"},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} 割引が適用されました。" },
-  "shopping_discount_apply": { "other": "適用する" },
-  "shopping_discount_code": { "other": "プロモーションコードを入力する" },
-  "shopping_discount_have_code": { "other": "プロモーションコードを持っている" },
-
-  "shopping_price_you_pay": { "other": "お支払い額" },
-  "shopping_price_nothing": { "other": "なし" },
-  "shopping_price_free": { "other": "無料" },
-
-  "shopping_auth_directions": { "other": "最初にアカウントが必要です。Eメールアドレスを入力してください。" },
-
-  "shopping_error_in_library": { "other": "{{.Title}} はすでにお客様のライブラリーに入っています。" },
-
-  "shopping_error_missing_card": { "other": "お客様のクレジットカード情報を入力してください。" },
-  "shopping_error_title": { "other": "エラーが発生しました。" },
-  "shopping_error_incorrect_cvc": { "other": "有効なセキュリティコードを入力してください。" },
-  "shopping_error_invalid_cvc": { "other": "有効なセキュリティコードを入力してください。" },
-  "shopping_error_incorrect_number": { "other": "有効なクレジットカード番号を入力してください。" },
-  "shopping_error_invalid_number": { "other": "有効なクレジットカード番号を入力してください。" },
-  "shopping_error_card_declined": { "other": "このクレジットカードは有効ではありません。" },
-  "shopping_error_invalid_expiry_month": { "other": "正しい有効期限を入力してください。" },
-  "shopping_error_invalid_expiry_year": { "other": "正しい有効期限を入力してください。" },
-  "shopping_error_expired_card": { "other": "このクレジットカードは有効期限切れです。" },
-  "shopping_error_creditcard_country_mismatch": { "other": "{{.Ownership}} は完了していません。ご入力いただいたクレジットカードが発行された国でのみご視聴が可能です。お支払いには別のクレジットカードをご利用ください。" },
-  "shopping_error_proxy_detected": { "other": "{{.Ownership}} は完了していません。ブロック解除機能またはプロキシサービスをご利用のようです。これらのサービスを停止してから再度お試しください。" },
-
-  "shopping_error_discount_blank": { "other": "有効なプロモーションコードを入力する" },
-  "shopping_error_discount_not_applied": { "other": "有効なプロモーションコードを入力する" },
-  "shopping_error_discount_invalid": { "other": "有効なプロモーションコードを入力する" },
-  "shopping_error_discount_disabled": { "other": "有効なプロモーションコードを入力する" },
-  "shopping_error_discount_already_applied": { "other": "このプロモーションコードはすでにご使用済みです。" },
-  "shopping_error_discount_already_redeemed": { "other": "このプロモーションコードはすでにご使用済みです。" },
-  "shopping_error_discount_used_previously": { "other": "このプロモーションコードはすでにご使用済みです。" },
-  "shopping_error_discount_max_limit": { "other": "このプロモーションコードはご利用いただけません。" },
-  "shopping_error_discount_expired": { "other": "このプロモーションコードは有効期限切れです。" },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "このプロモーションコードは購入にはご利用いただけません。" },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "このプローモションコードは期間限定視聴（レンタル）にはご利用いただけません" },
-  "shopping_error_discount_invalid_item": { "other": "このプロモーションコードはこの作品にはご使用いただけません。" },
-  "shopping_error_discount_invalid_pricing_region": { "other": "このプロモーションコードはお客様の国ではご使用いただけません。" },
-  "shopping_error_discounts_not_allowed": { "other": "このプロモーションコードはご使用いただけません。" },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "このプロモーションコードはパックではご使用いただけません。" },
-  "shopping_error_payment_intent_authentication_failure": { "other": "このクレジットカードは拒否されました。もう一度お試しください。" },
-
-  
-  "shopping_complete_rental": { "other": "成功しました！" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% ボーナス"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "クレジットカード情報を入力して{{.Verb}}を完了してください。"
+  },
+  "shopping_terms": {
+    "other": "<a href=\"/page/terms-and-conditions/\"target=\"_blank\" tabindex=\"-1\">利用規約</a>に同意して決済を完了する。"
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} 割引が適用されました。"
+  },
+  "shopping_discount_apply": {
+    "other": "適用する"
+  },
+  "shopping_discount_code": {
+    "other": "プロモーションコードを入力する"
+  },
+  "shopping_discount_have_code": {
+    "other": "プロモーションコードを持っている"
+  },
+  "shopping_price_you_pay": {
+    "other": "お支払い額"
+  },
+  "shopping_price_nothing": {
+    "other": "なし"
+  },
+  "shopping_price_free": {
+    "other": "無料"
+  },
+  "shopping_auth_directions": {
+    "other": "最初にアカウントが必要です。Eメールアドレスを入力してください。"
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} はすでにお客様のライブラリーに入っています。"
+  },
+  "shopping_error_missing_card": {
+    "other": "お客様のクレジットカード情報を入力してください。"
+  },
+  "shopping_error_title": {
+    "other": "エラーが発生しました。"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "有効なセキュリティコードを入力してください。"
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "有効なセキュリティコードを入力してください。"
+  },
+  "shopping_error_incorrect_number": {
+    "other": "有効なクレジットカード番号を入力してください。"
+  },
+  "shopping_error_invalid_number": {
+    "other": "有効なクレジットカード番号を入力してください。"
+  },
+  "shopping_error_card_declined": {
+    "other": "このクレジットカードは有効ではありません。"
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "正しい有効期限を入力してください。"
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "正しい有効期限を入力してください。"
+  },
+  "shopping_error_expired_card": {
+    "other": "このクレジットカードは有効期限切れです。"
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "{{.Ownership}} は完了していません。ご入力いただいたクレジットカードが発行された国でのみご視聴が可能です。お支払いには別のクレジットカードをご利用ください。"
+  },
+  "shopping_error_proxy_detected": {
+    "other": "{{.Ownership}} は完了していません。ブロック解除機能またはプロキシサービスをご利用のようです。これらのサービスを停止してから再度お試しください。"
+  },
+  "shopping_error_discount_blank": {
+    "other": "有効なプロモーションコードを入力する"
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "有効なプロモーションコードを入力する"
+  },
+  "shopping_error_discount_invalid": {
+    "other": "有効なプロモーションコードを入力する"
+  },
+  "shopping_error_discount_disabled": {
+    "other": "有効なプロモーションコードを入力する"
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "このプロモーションコードはすでにご使用済みです。"
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "このプロモーションコードはすでにご使用済みです。"
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "このプロモーションコードはすでにご使用済みです。"
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "このプロモーションコードはご利用いただけません。"
+  },
+  "shopping_error_discount_expired": {
+    "other": "このプロモーションコードは有効期限切れです。"
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "このプロモーションコードは購入にはご利用いただけません。"
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "このプローモションコードは期間限定視聴（レンタル）にはご利用いただけません"
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "このプロモーションコードはこの作品にはご使用いただけません。"
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "このプロモーションコードはお客様の国ではご使用いただけません。"
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "このプロモーションコードはご使用いただけません。"
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "このプロモーションコードはパックではご使用いただけません。"
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "このクレジットカードは拒否されました。もう一度お試しください。"
+  },
+  "shopping_complete_rental": {
+    "other": "成功しました！"
+  },
   "shopping_complete_rental_period": {
     "one": "今から明日まで、何度でもご視聴いただけます。",
     "other": "今から{{.Count}} 日間、何度でもご視聴いただけます。"
   },
-  "shopping_complete_purchase": { "other": "{{.Title}}をご購入ありがとうございます。" },
-  "shopping_complete_purchase_coming_soon": { "other": "{{.Date}}からご視聴いただけます。" },
-  "shopping_complete_receipt": { "other": "領収証をEメールでお送りしました。" },
-  "shopping_complete_library_link": { "other": "お客様のライブラリー内にある{{.BundleItems}} の作品をご視聴いただけます。" },
+  "shopping_complete_purchase": {
+    "other": "{{.Title}}をご購入ありがとうございます。"
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "{{.Date}}からご視聴いただけます。"
+  },
+  "shopping_complete_receipt": {
+    "other": "領収証をEメールでお送りしました。"
+  },
+  "shopping_complete_library_link": {
+    "other": "お客様のライブラリー内にある{{.BundleItems}} の作品をご視聴いただけます。"
+  },
   "shopping_complete_plan": {
     "other": "{{ .Title }}購入は成功しました。"
   },
@@ -285,93 +634,211 @@
     "one": "{{.Date}} より視聴開始可能です。お客様の視聴可能期間は1日間です。",
     "other": "{{.Date}} より視聴開始可能です。お客様の視聴可能期間は{{.Count}} 日間です"
   },
-
-  "shopping_action_rent": { "other": "期間限定視聴（レンタル）する" },
-  "shopping_action_buy": { "other": "購入する" },
-
-  "shopping_info_rental_period_coming_soon": { "other": "視聴開始可能日時より" },
-
-  "meta_detail_cast_title": { "other": "出演" },
-  "meta_detail_crew_title": { "other": "スタッフ" },
-  "meta_detail_languages": { "one": "言語", "other": "言語" },
-  "meta_detail_studios": { "one": "製作", "other": "製作" },
-  "meta_detail_countries": { "one": "製作国", "other": "製作国" },
-  "meta_detail_subtitles": { "other": "字幕" },
-  "meta_detail_captions": { "other": "字幕 [CC]" },
-  "meta_detail_episodes_title": { "other": "エピソード" },
-  "meta_detail_bonus_title": { "other": "特典映像" },
-  "meta_detail_recommendations_title": { "other": "おすすめ作品" },
-  "meta_detail_bundle_items_title": { "other": "このパックに含まれる作品" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} 作品" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} シーズン" },
-  "bundle_items_mixed": { "other": "{{.Count}} 作品およびシーズン" },
-  
-  "userwishlist_page_header": { "other": "マイリスト" },
-  "userwishlist_slider_header": { "other": "マイリスト" },
-  "userwishlist_empty_header":  { "other": "お客様のマイリストには何も入っていません。" },
-  "userwishlist_empty_content": { "other": "作品を<a href=\"/\">チェック</a> してマイリストに追加してみてください。" },
-  "userwishlist_button_add": { "other": "マイリストに追加" },
-  "userwishlist_button_remove": { "other": "マイリスト" },
-  "userwishlist_button_add_compact": { "other": "マイリスト" },
-  "userwishlist_button_remove_compact": { "other": "マイリスト" },
-
-  "userdevices_page_header": { "other": "視聴端末（デバイス）" },
+  "shopping_action_rent": {
+    "other": "期間限定視聴（レンタル）する"
+  },
+  "shopping_action_buy": {
+    "other": "購入する"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "視聴開始可能日時より"
+  },
+  "meta_detail_cast_title": {
+    "other": "出演"
+  },
+  "meta_detail_crew_title": {
+    "other": "スタッフ"
+  },
+  "meta_detail_languages": {
+    "one": "言語",
+    "other": "言語"
+  },
+  "meta_detail_studios": {
+    "one": "製作",
+    "other": "製作"
+  },
+  "meta_detail_countries": {
+    "one": "製作国",
+    "other": "製作国"
+  },
+  "meta_detail_subtitles": {
+    "other": "字幕"
+  },
+  "meta_detail_captions": {
+    "other": "字幕 [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "エピソード"
+  },
+  "meta_detail_bonus_title": {
+    "other": "特典映像"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "おすすめ作品"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "このパックに含まれる作品"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} 作品"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} シーズン"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} 作品およびシーズン"
+  },
+  "userwishlist_page_header": {
+    "other": "マイリスト"
+  },
+  "userwishlist_slider_header": {
+    "other": "マイリスト"
+  },
+  "userwishlist_empty_header": {
+    "other": "お客様のマイリストには何も入っていません。"
+  },
+  "userwishlist_empty_content": {
+    "other": "作品を<a href=\"/\">チェック</a> してマイリストに追加してみてください。"
+  },
+  "userwishlist_button_add": {
+    "other": "マイリストに追加"
+  },
+  "userwishlist_button_remove": {
+    "other": "マイリスト"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "マイリスト"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "マイリスト"
+  },
+  "userdevices_page_header": {
+    "other": "視聴端末（デバイス）"
+  },
   "userdevices_page_content": {
     "one": "お使いになった視聴端末は自動的にここに追加されます。ご使用いただけるデバイスは１個に限ります。",
     "other": "お使いになった視聴端末は自動的にここに追加されます。最大{{.Count}} 個までご使用いただけます。"
   },
-  "userdevices_empty_content": { "other": "現在、登録されている視聴端末（デバイス）はありません。" },
-  "userdevices_header_type": { "other": "視聴端末の種類" },
-  "userdevices_header_description": { "other": "説明" },
-  "userdevices_device_added": { "other": "{{.Date}}に追加済み" },
-  "userdevices_device_actions_delete": { "other": "削除する" },
-  "userdevices_device_actions_cancel": { "other": "キャンセル" },
-  "userdevices_device_actions_confirm": { "other": "はい、視聴端末を削除します" },
-  "userdevices_device_deleted": { "other": "（削除済み）" },
-
-  "pricing_ownership_buy": { "other": "購入" },
-  "pricing_ownership_rent": { "other": "期間限定視聴（レンタル）" },
-
-  "classification_intro": { "other": "種別：" },
-
-  "cookie_banner_message": { "other": "当サイトはお客様のウェブ体験を向上させ るためにCookieを使用します。当サイトの 利用により<a href=\"/page/cookie-policy/\"> プライベートポリシー</a>に同意するもの とします。" },
-  "cookie_banner_accept": { "other": "同意する" },
-
-  "all_rights_reserved": { "other": "当サイトの掲載内容について無断転載・無断使用を固く禁じます。" },
-
-  "users_gender_none": { "other": "特定しない" },
-  "users_gender_female": { "other": "女性" },
-  "users_gender_male": { "other": "男性" },
-  "users_gender_diverse": { "other": "どちらでもない" },
-  "users_gender_other": { "other": "その他" },
-
-  "availability_coming_soon": { "other": "準備中" },
-  "availability_renting": { "other": "期間限定視聴（レンタル）中" },
-  "availability_not_available": { "other": "利用不可" },
-  "availability_in_watch_window": { "other": "利用可能" },
-  "availability_sold_out": { "other": "完売" },
-  "availability_available_till": { "other": "{{.ExpiryDate}} まで視聴可能" },
-  "availability_not_available_in_country": { "other": "視聴不可" },
-  "availability_available": { "other": "{{.ReleaseDate}} から視聴可能" },
-  "availability_expires": { "other": "視聴期限{{.Expiry}}まで" },
-  "availability_expired": { "other": "視聴期限切れ"},
-
-  "modal_cancel": { "other": "キャンセル" },
-
-  "play": { "other": "再生" },
-
-  "combined_auth_signin_prompt": { "other": "サインイン" },
-  "combined_auth_signup_prompt": { "other": "サインアップ" },
-  "combined_auth_terms": { "other": "<a href=\"/page/terms-and-conditions/\"target=\"_blank\">利用規約</a>に同意する。" },
-  "signup_terms": { "other": "<a href=\"/page/terms-and-conditions/\"target=\"_blank\">利用規約</a>に同意する。" },
-  "validation_terms_required": { "other": "利用規約に同意してください。" },
-  "shopping_error_item_limit_exceeded": { "other": "申し訳ありません。{{.Title}} は完売しました。" },
-
-  "app_badge_title": { "other": "アプリをダウンロードして、購入したコンテンツを表示してください。" },
-  "app_badge_ios": { "other": "AppStoreでダウンロード" },
-  "app_badge_android": { "other": "Google Playで入手する" },
-
+  "userdevices_empty_content": {
+    "other": "現在、登録されている視聴端末（デバイス）はありません。"
+  },
+  "userdevices_header_type": {
+    "other": "視聴端末の種類"
+  },
+  "userdevices_header_description": {
+    "other": "説明"
+  },
+  "userdevices_device_added": {
+    "other": "{{.Date}}に追加済み"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "削除する"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "キャンセル"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "はい、視聴端末を削除します"
+  },
+  "userdevices_device_deleted": {
+    "other": "（削除済み）"
+  },
+  "pricing_ownership_buy": {
+    "other": "購入"
+  },
+  "pricing_ownership_rent": {
+    "other": "期間限定視聴（レンタル）"
+  },
+  "classification_intro": {
+    "other": "種別："
+  },
+  "cookie_banner_message": {
+    "other": "当サイトはお客様のウェブ体験を向上させ るためにCookieを使用します。当サイトの 利用により<a href=\"/page/cookie-policy/\"> プライベートポリシー</a>に同意するもの とします。"
+  },
+  "cookie_banner_accept": {
+    "other": "同意する"
+  },
+  "all_rights_reserved": {
+    "other": "当サイトの掲載内容について無断転載・無断使用を固く禁じます。"
+  },
+  "users_gender_none": {
+    "other": "特定しない"
+  },
+  "users_gender_female": {
+    "other": "女性"
+  },
+  "users_gender_male": {
+    "other": "男性"
+  },
+  "users_gender_diverse": {
+    "other": "どちらでもない"
+  },
+  "users_gender_other": {
+    "other": "その他"
+  },
+  "availability_coming_soon": {
+    "other": "準備中"
+  },
+  "availability_renting": {
+    "other": "期間限定視聴（レンタル）中"
+  },
+  "availability_not_available": {
+    "other": "利用不可"
+  },
+  "availability_in_watch_window": {
+    "other": "利用可能"
+  },
+  "availability_sold_out": {
+    "other": "完売"
+  },
+  "availability_available_till": {
+    "other": "{{.ExpiryDate}} まで視聴可能"
+  },
+  "availability_not_available_in_country": {
+    "other": "視聴不可"
+  },
+  "availability_available": {
+    "other": "{{.ReleaseDate}} から視聴可能"
+  },
+  "availability_expires": {
+    "other": "視聴期限{{.Expiry}}まで"
+  },
+  "availability_expired": {
+    "other": "視聴期限切れ"
+  },
+  "modal_cancel": {
+    "other": "キャンセル"
+  },
+  "play": {
+    "other": "再生"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "サインイン"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "サインアップ"
+  },
+  "combined_auth_terms": {
+    "other": "<a href=\"/page/terms-and-conditions/\"target=\"_blank\">利用規約</a>に同意する。"
+  },
+  "signup_terms": {
+    "other": "<a href=\"/page/terms-and-conditions/\"target=\"_blank\">利用規約</a>に同意する。"
+  },
+  "validation_terms_required": {
+    "other": "利用規約に同意してください。"
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "申し訳ありません。{{.Title}} は完売しました。"
+  },
+  "app_badge_title": {
+    "other": "アプリをダウンロードして、購入したコンテンツを表示してください。"
+  },
+  "app_badge_ios": {
+    "other": "AppStoreでダウンロード"
+  },
+  "app_badge_android": {
+    "other": "Google Playで入手する"
+  },
   "shopping_price_title_plan": {
     "other": "価格"
   },
@@ -443,109 +910,260 @@
   "donate_button_text": {
     "other": "寄付"
   },
-  "wcag_skip_links_header": { "other": "アクセシビリティリンク" },
-  "wcag_skip_links_content": { "other": "コンテンツにスキップ" },
-
-  "wcag_homepage_h1": { "other": "ホームページ" },
-  "wcag_carousel_h2": { "other": "カルーセル" },
-  "wcag_collections_h2": { "other": "コレクション" },
-
-  "wcag_aria_label_footer": { "other": "フッター" },
-  "wcag_aria_label_nav_main": { "other": "主要" },
-  "wcag_aria_label_nav_sub": { "other": "サブ" },
-  "wcag_aria_label_toggle_nav": { "other": "ナビゲーションの切り替え" },
-  "wcag_aria_label_bundle_items": { "other": "バンドルアイテム" },
-  "wcag_aria_label_carousel": { "other": "カルーセル" },
-  "wcag_aria_label_page_collection": { "other": "ページコレクション" },
-  "wcag_aria_label_collection_list": { "other": "コレクションリスト" },
-  "wcag_aria_label_collection_slider": { "other": "コレクションスライダー" },
-  "wcag_aria_label_wishlist": { "other": "ウィッシュリスト" },
-  "wcag_aria_label_facebook": { "other": "Facebookでシェア" },
-  "wcag_aria_label_twitter": { "other": "Twitterで共有する" },
-  "wcag_aria_label_linkedin": { "other": "LinkedInで共有する" },
-  "wcag_aria_label_letterboxd": { "other": "Letterboxdで見る" },
-
-  "shopping_error_plan_already_owned": { "other": "あなたはすでにこの計画を持っています。" },
-  "shopping_error_plan_expired": { "other": "このプランはご利用いただけなくなりました。" },
-  "shopping_payment_method_header": { "other": "お支払い方法" },
-  "shopping_payment_method_credit_card": { "other": "クレジットカード" },
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  "shopping_error_stripe_unknown_error": { "other": "この支払いで問題が発生しました。 後でもう一度やり直してください。" },
-  "shopping_error_payment_complete_failed": { "other": "支払いは拒否されました。 このウィンドウを閉じて、再試行してください。" },
-
-  "header_banner": { "other": "ABCシネマ–第21回映画祭、2021年6月1日– 6日" },
-
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "一部のタイトルの購入、レンタル、視聴に必要なPINセットがありません。"},
-  "account_form_set_pin": { "other": "PINを設定する" },
-  "account_form_pin_changed": { "other": "更新しました" },
-  "account_form_change_pin": { "other": "PINを変更する" },
-
-  "user_set_pin_header": { "other": "PINを設定する" },
-  "user_set_pin_button": { "other": "PINを設定する" },
-  "user_submit_pin_heading": { "other": "この制限されたコンテンツの{{.Action}}にPINを入力してください" },
-  "user_error_wrong_pin_retry": { "other": "間違ったPINを入力しました" },
-  "user_submit_pin_button": { "other": "入力" },
-  "user_reset_pin_button": { "other": "PINをリセット" },
-
-  "validation_pincode1_required": { "other": "有効なPINコードを入力してください。" },
-  "validation_pincode2_required": { "other": "有効なPINコードを入力してください。" },
-  "validation_pincode1_pattern": { "other": "有効なPINコードを入力してください。" },
-  "validation_pincode2_pattern": { "other": "有効なPINコードを入力してください。" },
-  "validation_pincode2_match": { "other": "PINコードが一致しません。" },
-
-  "userdevices_delete_limits": { "other": "このリストから{{.Limit}}デバイスを{{.Period}}日ごとに削除できます。"},
-  "userdevices_delete_limit_reached": { "other": "この制限に達しており、現在デバイスを削除できません。 {{.Days}}日以内にデバイスを削除できます。" },
-  "shopping_card_new_subscription": { "other": "このカードは定期的に保存され、請求されます" },
-
-"changepincode_modal_header": { "other": "PINを変更する" },
-"changepincode_modal_currentpassword": { "other": "あなたの現在のパスワード" },
-"changepincode_modal_pincode1": { "other": "新しい4桁のPIN" },
-"changepincode_modal_pincode2": { "other": "新しい4桁のPINを確認します" },
-"changepincode_modal_submit": { "other": "PINを設定する" },
-"changepincode_modal_error_wrong_password": { "other": "そのパスワードは正しくありません。" },
-
-"user_set_pin_intro": { "other": "{{.Action}}制限付きコンテンツへのPINが必要です"},
-"user_error_wrong_pin_reset": { "other": "PINをリセットするには、ここをクリックしてください" },
-"user_error_too_many_pin_errors_help_page_link": { "other": "" },
-"shopping_error_age_restricted": { "other": "このコンテンツは年齢制限があります。" },
-"shopping_error_close_button": { "other": "わかった" }, 
-
-"usersubscriptions_subscription_expiry": { "other": "有効期限{{.Expiry}}" },
-"usersubscriptions_subscription_status_trialing": { "other": "トライアル期間" },
-"usersubscriptions_subscription_unsubscribe": { "other": "サブスクリプションをキャンセルする" },
-"usersubscriptions_unsubscribe_modal_cancel": { "other": "キャンセル" },
-"usersubscriptions_unsubscribe_modal_confirm": { "other": "はい、サブスクリプションをキャンセルします" },
-"usersubscriptions_unsubscribe_modal_title": { "other": "サブスクリプションをキャンセルしますか？" },
-"usersubscriptions_unsubscribe_modal_body": { "other": "これにより、{{.Name}}プランのサブスクリプションがキャンセルされます。 {{.Expiry}}の有効期限が切れるまで、プランのコンテンツを引き続き視聴できます。" },
-
-"signin_form_error_ip_throttled": { "other": "サインインに何度も失敗しました。 後でもう一度やり直してください。" },
-"signin_form_error_account_suspended": { "other": "あなたのアカウントは一時的に停止されています。 これがエラーであると思われる場合は、管理者に連絡してください。" },
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HDのみ" },
-  "pricing_quality_sd_only": { "other": "SDのみ" },
-
-  "shopping_card_save_card": { "other": "将来の使用のためにこのカードを保存します" },
-  "shopping_card_button_change": { "other": "保存したカードをすべて表示" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}}で終わる{{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "（有効期限{{.Card.Expiry}}）" },
-  "shopping_card_existing_expired": { "other": "（期限切れ）" },
-  "shopping_card_use_other": { "other": "新しいカードを使用する" },
-  "shopping_card_use_new_card": { "other": "カードを変更する" },
-  "shopping_card_update_reason_none": { "other": "クレジットカードを更新します。 サポートされているカードは、Visa、Mastercard、AmericanExpressです。" },
-  "shopping_info_ownership_plan": { "other": "サブスクリプション" },
-  "shopping_action_credit": { "other": "補充" },
-
-  "usersubscriptions_change_payment_method_change": { "other": "クレジットカードを変更する" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "クレジットカードの詳細を更新する" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "アップデート" },
-
-  "seasons":{
+  "wcag_skip_links_header": {
+    "other": "アクセシビリティリンク"
+  },
+  "wcag_skip_links_content": {
+    "other": "コンテンツにスキップ"
+  },
+  "wcag_homepage_h1": {
+    "other": "ホームページ"
+  },
+  "wcag_carousel_h2": {
+    "other": "カルーセル"
+  },
+  "wcag_collections_h2": {
+    "other": "コレクション"
+  },
+  "wcag_aria_label_footer": {
+    "other": "フッター"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "主要"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "サブ"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "ナビゲーションの切り替え"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "バンドルアイテム"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "カルーセル"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "ページコレクション"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "コレクションリスト"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "コレクションスライダー"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "ウィッシュリスト"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Facebookでシェア"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Twitterで共有する"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "LinkedInで共有する"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Letterboxdで見る"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "あなたはすでにこの計画を持っています。"
+  },
+  "shopping_error_plan_expired": {
+    "other": "このプランはご利用いただけなくなりました。"
+  },
+  "shopping_payment_method_header": {
+    "other": "お支払い方法"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "クレジットカード"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "この支払いで問題が発生しました。 後でもう一度やり直してください。"
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "支払いは拒否されました。 このウィンドウを閉じて、再試行してください。"
+  },
+  "header_banner": {
+    "other": "ABCシネマ–第21回映画祭、2021年6月1日– 6日"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "一部のタイトルの購入、レンタル、視聴に必要なPINセットがありません。"
+  },
+  "account_form_set_pin": {
+    "other": "PINを設定する"
+  },
+  "account_form_pin_changed": {
+    "other": "更新しました"
+  },
+  "account_form_change_pin": {
+    "other": "PINを変更する"
+  },
+  "user_set_pin_header": {
+    "other": "PINを設定する"
+  },
+  "user_set_pin_button": {
+    "other": "PINを設定する"
+  },
+  "user_submit_pin_heading": {
+    "other": "この制限されたコンテンツの{{.Action}}にPINを入力してください"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "間違ったPINを入力しました"
+  },
+  "user_submit_pin_button": {
+    "other": "入力"
+  },
+  "user_reset_pin_button": {
+    "other": "PINをリセット"
+  },
+  "validation_pincode1_required": {
+    "other": "有効なPINコードを入力してください。"
+  },
+  "validation_pincode2_required": {
+    "other": "有効なPINコードを入力してください。"
+  },
+  "validation_pincode1_pattern": {
+    "other": "有効なPINコードを入力してください。"
+  },
+  "validation_pincode2_pattern": {
+    "other": "有効なPINコードを入力してください。"
+  },
+  "validation_pincode2_match": {
+    "other": "PINコードが一致しません。"
+  },
+  "userdevices_delete_limits": {
+    "other": "このリストから{{.Limit}}デバイスを{{.Period}}日ごとに削除できます。"
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "この制限に達しており、現在デバイスを削除できません。 {{.Days}}日以内にデバイスを削除できます。"
+  },
+  "shopping_card_new_subscription": {
+    "other": "このカードは定期的に保存され、請求されます"
+  },
+  "changepincode_modal_header": {
+    "other": "PINを変更する"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "あなたの現在のパスワード"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "新しい4桁のPIN"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "新しい4桁のPINを確認します"
+  },
+  "changepincode_modal_submit": {
+    "other": "PINを設定する"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "そのパスワードは正しくありません。"
+  },
+  "user_set_pin_intro": {
+    "other": "{{.Action}}制限付きコンテンツへのPINが必要です"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "PINをリセットするには、ここをクリックしてください"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "このコンテンツは年齢制限があります。"
+  },
+  "shopping_error_close_button": {
+    "other": "わかった"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "有効期限{{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "トライアル期間"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "サブスクリプションをキャンセルする"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "キャンセル"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "はい、サブスクリプションをキャンセルします"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "サブスクリプションをキャンセルしますか？"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "これにより、{{.Name}}プランのサブスクリプションがキャンセルされます。 {{.Expiry}}の有効期限が切れるまで、プランのコンテンツを引き続き視聴できます。"
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "サインインに何度も失敗しました。 後でもう一度やり直してください。"
+  },
+  "signin_form_error_account_suspended": {
+    "other": "あなたのアカウントは一時的に停止されています。 これがエラーであると思われる場合は、管理者に連絡してください。"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HDのみ"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SDのみ"
+  },
+  "shopping_card_save_card": {
+    "other": "将来の使用のためにこのカードを保存します"
+  },
+  "shopping_card_button_change": {
+    "other": "保存したカードをすべて表示"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}}で終わる{{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "（有効期限{{.Card.Expiry}}）"
+  },
+  "shopping_card_existing_expired": {
+    "other": "（期限切れ）"
+  },
+  "shopping_card_use_other": {
+    "other": "新しいカードを使用する"
+  },
+  "shopping_card_use_new_card": {
+    "other": "カードを変更する"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "クレジットカードを更新します。 サポートされているカードは、Visa、Mastercard、AmericanExpressです。"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "サブスクリプション"
+  },
+  "shopping_action_credit": {
+    "other": "補充"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "クレジットカードを変更する"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "クレジットカードの詳細を更新する"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "アップデート"
+  },
+  "seasons": {
     "one": "ワンシーズン",
     "other": "{{.Count}}シーズン"
-  },"tvseason": {
+  },
+  "tvseason": {
     "other": "{{.ShowInfo.Title}}シーズン{{.Season.SeasonNumber}}"
   },
   "tvseason_html": {
@@ -561,31 +1179,70 @@
     "one": "1話",
     "other": "{{.Count}}エピソード"
   },
-
-  "user_error_too_many_pin_errors": { "other": "<p>問題が発生しているようです。</p> <p> PINをリセットするか、<a href=\"{{.HelpURL}}\" target=\"_blank\">ヘルプ</a>" },
-  "validation_pincode_required": { "other": "PINコードを入力してください。" },
-
-  "shopping_info_subtitle_sd": { "other": "SDビデオオンデマンド。" },
-  "shopping_info_subtitle_wallet": { "other": "ウォレットの資金は、ScreenPlusのコンテンツの購入またはレンタルに使用される場合があります。" },
- 
-  "shopping_info_sd_only": { "other": "Limited to SD playback only." },
-  "shopping_error_discount_worn_out": { "other": "そのプロモーションコードは使用できなくなります。" },
-
-  "activatedevice_page_header": { "other": "デバイスをアクティブ化" },
-  "activatedevice_page_content": { "other": "デバイスの指示に従ってPINコードを取得します。 アクティベートするには、コンピューターとデバイスの両方がインターネットに接続されている必要があります。" },
-  "activatedevice_form_pin": { "other": "ピンコード" },
-  "activatedevice_form_submit": { "other": "活性化" },
-  "activatedevice_form_error_invalid_code": { "other": "PINコードが見つかりません。もう一度やり直してください。" },
-  "activatedevice_form_error_pin_not_found": { "other": "PINコードが見つかりません。もう一度やり直してください。" },
-  "activatedevice_signin_prompt": { "other": "デバイスをアクティブ化する前にサインインしてください。" },
-  "activatedevice_page_activated": { "other": "{{.DeviceName}}を有効にしていただきありがとうございます。 これで、テレビまたはデバイスでライブラリを閲覧できるようになります。" },
-
-  "playlist_page_header": { "other": "プレイリスト" },
-  "playlist_sign_in_warning": { "other": "サインインしてテレビの生放送をご覧ください。"},
-  "playlist_share_title": { "other": "プレイリスト" },
-  "playlist_up_next_title": { "other": "次に" },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-  "shopping_card_change": { "other": "クレジットカードが正しくありませんか？ <a href = \"{{.SubscriptionsURL}}\">カードを更新するにはここをクリックしてください。</a>" },
-  "shopping_complete_credit_purchase": { "other": "{{.Title}}をご購入いただきありがとうございます。{{.CreditTotal}}がアカウントに追加されました。" }
+  "user_error_too_many_pin_errors": {
+    "other": "<p>問題が発生しているようです。</p> <p> PINをリセットするか、<a href=\"{{.HelpURL}}\" target=\"_blank\">ヘルプ</a>"
+  },
+  "validation_pincode_required": {
+    "other": "PINコードを入力してください。"
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SDビデオオンデマンド。"
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "ウォレットの資金は、ScreenPlusのコンテンツの購入またはレンタルに使用される場合があります。"
+  },
+  "shopping_info_sd_only": {
+    "other": "Limited to SD playback only."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "そのプロモーションコードは使用できなくなります。"
+  },
+  "activatedevice_page_header": {
+    "other": "デバイスをアクティブ化"
+  },
+  "activatedevice_page_content": {
+    "other": "デバイスの指示に従ってPINコードを取得します。 アクティベートするには、コンピューターとデバイスの両方がインターネットに接続されている必要があります。"
+  },
+  "activatedevice_form_pin": {
+    "other": "ピンコード"
+  },
+  "activatedevice_form_submit": {
+    "other": "活性化"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PINコードが見つかりません。もう一度やり直してください。"
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PINコードが見つかりません。もう一度やり直してください。"
+  },
+  "activatedevice_signin_prompt": {
+    "other": "デバイスをアクティブ化する前にサインインしてください。"
+  },
+  "activatedevice_page_activated": {
+    "other": "{{.DeviceName}}を有効にしていただきありがとうございます。 これで、テレビまたはデバイスでライブラリを閲覧できるようになります。"
+  },
+  "playlist_page_header": {
+    "other": "プレイリスト"
+  },
+  "playlist_sign_in_warning": {
+    "other": "サインインしてテレビの生放送をご覧ください。"
+  },
+  "playlist_share_title": {
+    "other": "プレイリスト"
+  },
+  "playlist_up_next_title": {
+    "other": "次に"
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "shopping_card_change": {
+    "other": "クレジットカードが正しくありませんか？ <a href = \"{{.SubscriptionsURL}}\">カードを更新するにはここをクリックしてください。</a>"
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "{{.Title}}をご購入いただきありがとうございます。{{.CreditTotal}}がアカウントに追加されました。"
+  }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Settings" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "in partnership with" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Settings"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "in partnership with"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
   "episode_name": {
     "other": "Epizodas"
   },
-
   "season_name": {
     "other": "Sezonas"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "vieną sezoną",
     "other": "{{.Count}} sezonai"
   },
@@ -38,192 +55,477 @@
     "one": "1 epizodas",
     "other": "{{.Count}} serijų"
   },
-
-  "date_day": { "other": "Diena" },
-  "date_month": { "other": "Mėnuo" },
-  "date_year": { "other": "Metai" },
-
-  "404_page_header": { "other": "Puslapis neegzistuoja..." },
-  "404_page_content": { "other": "<p>Apgailestaujame, jūsų nurodytu adresu puslapio neradome.</p><p>Tikėtina, kad pasikeitė puslapio adresas, puslapis buvo ištrintas arba įsivėlė rašybos klaida.</p><p>Rekomenduojame reikalingos informacijos ieškoti grįžus į pagrindinį puslapį.</p><p><a href=\"{{.URL}}\">Grįžti į pagrindinį puslapį</a></p>" },
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Prisijungti" },
-  "nav_signup": { "other": "Registruotis" },
-  "nav_signed_in_as": { "other": "Prisijungęs (-usi) kaip" },
-  "nav_library": { "other": "Įsigyti filmai" },
-  "nav_devices": { "other": "Mano įrenginiai" },
-  "nav_wishlist": { "other": "Noriu pamatyti" },
-  "nav_account": { "other": "Mano paskyra" },
-  "nav_signout": { "other": "Atsijungti" },
-  "play_trailer": { "other": "Anonsas" },
-  "runtime_hours": { "other": "val." },
-  "runtime_minutes": { "other": "min." },
-
-  "datetime_today": { "other": "šiandien {{.Date}}" },
-  "datetime_tomorrow": { "other": "rytoj {{.Date}}" },
-  "datetime_yesterday": { "other": "vakar {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "ankstesnis {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Paieška" },
-  "search_control_submit": { "other": "Pateikti paiešką" },
-
-  "play_button_watch": { "other" : "Žiūrėti dabar"},
-  "play_button_resume": { "other" : "Tęsti"},
-
-  "social_media_buttons_title": { "other": "Dalintis" },
-  "social_media_buttons_facebook": { "other": "Dalintis Facebook" },
-  "social_media_buttons_twitter": { "other": "Bendrinti Twitter" },
-  "social_media_buttons_linkedin": { "other": "Dalintis Linkedin" },
-  "social_media_buttons_email": { "other": "Bendrinkite el. paštu" },
-  "social_media_buttons_email_subject": { "other": "Nuorodos bendrinimas" },
-  "social_media_buttons_copied_link": { "other": "Nuoroda nukopijuota į mainų sritį!" },
-  "social_media_buttons_copy_link": { "other": "Nukopijuoti į iškarpinę" },
-
-  "accept_invite_page_header": { "other": "Sveiki " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Panašu, kad jau patvirtinote šį kvietimą, prašome <a href=\"{{.SigninURL}}\">prisijungti</a>. Pamiršus slaptažodį, galite <a href=\"{{.ForgotPasswordURL}}\">susikurti naują</a>." },
-  "acceptinvite_complete": { "other": "Ačiū, jūsų paskyra sukurta." },
-  "acceptinvite_form_submit": { "other": "Priimti kvietimą" },
-  "acceptinvite_agreement": { "other": "Spausdami „Priimti kvietimą“ patvirtinate, kad perskaitėte ir sutinkate su mūsų <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">tVartotojų taisyklėmis</a> bei <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">Privatumo politika</a>." },
-
-  "signup_page_header": { "other": "Registruotis" },
-  "signup_form_name": { "other": "Vardas" },
-  "signup_form_email": { "other": "El. pašto adresas" },
-  "signup_form_password": { "other": "Slaptažodis" },
-  "signup_form_password_confirmation": { "other": "Patvirtinkite slaptažodį" },
-  "signup_form_gender": { "other": "Lytis" },
-  "signup_form_dob": { "other": "Gimimo data" },
-  "signup_form_submit": { "other": "Pateikti" },
-
-  "signin_page_header": { "other": "Prisijungti" },
-  "signin_form_email": { "other": "El. pašto adresas" },
-  "signin_form_password": { "other": "Slaptažodis" },
-  "signin_form_remember": { "other": "Prisiminti mane" },
-  "signin_form_submit": { "other": "Pateikti" },
-  "signin_page_forgotpassword": { "other": "Pamiršote slaptažodį?" },
-  "signin_page_createnewaccount": { "other": "Neturite paskyros? Registruotis" },
-  "signup_page_alreadyhaveanaccount": { "other": "Turite paskyrą? Prisijungti" },
-  "signup_form_error_email_already_in_use": { "other": "Su šiuo el. paštu paskyra jau sukurta." },
-  "signin_form_error_incorrect_credentials": { "other": "Neteisingas vartotojo vardas arba slaptažodis." },
-  "signin_form_error_ip_throttled": { "other": "Per daug kartų nepavyko prisijungti. Pabandykite dar kartą vėliau." },
-  "signin_form_error_account_suspended": { "other": "Jūsų sąskaita laikinai sustabdyta. Jei manote, kad tai klaida, susisiekite su administratoriumi." },
-
-  "signup_form_error_forbidden": { "other": "Įvyko klaida." },
-
-  "combined_auth_continue": { "other": "Tęsti" },
-  "combined_auth_change": { "other": "keisti" },
-  "combined_auth_signin": { "other": "Prisijungti" },
-  "combined_auth_signup": { "other": "Registruotis" },
-  "combined_auth_signin_password": { "other": "Norėdami prisijungti prie savo paskyros įveskite slaptažodį." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Neteisingas slaptažodis." },
-  "combined_auth_error_forbidden": { "other": "Įvyko klaida." },
-  "combined_auth_error_too_many_requests": { "other": "Per daug užklausų. Prašome pabandyti vėliau." },
-
-  "forgotpassword_page_header": { "other": "Atkurti slaptažodį" },
-  "forgotpassword_form_email": { "other": "El. pašto adresas" },
-  "forgotpassword_form_submit": { "other": "Atkurti" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Paskyra su šiuo el. paštu neegzistuoja." },
-  "forgotpassword_form_error_account_suspended": { "other": "Paskyra laikinai užrakinta." },
-  "forgotpassword_complete": { "other": "Ačiū. Neužilgo gausite laišką dėl slaptažodžio atkūrimo." },
-  "forgotpassword_form_error_forbidden": { "other": "Įvyko klaida." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Per daug užklausų. Prašome pabandyti vėliau." },
-
-  "resetpassword_page_header": { "other": "Keisti slaptažodį" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Prašymas atkurti slaptažodį negalioja. <a href=\"{{.URL}}\">Prašome iš naujo užpildyti formą</a>." },
-  "resetpassword_form_password": { "other": "Naujas slaptažodis" },
-  "resetpassword_form_password2": { "other": "Patvirtinkite naują slaptažodį" },
-  "resetpassword_form_submit": { "other": "Keisti" },
-  "resetpassword_complete": { "other": "Ačiū. Jūsų slaptažodis pakeistas, jūs prisijungėte prie savo paskyros." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Prašymas atkurti slaptažodį negalioja. Prašome vėliau bandyti dar kartą." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Slaptažodžio atkūrimo kodas nebegalioja. Prašome kreiptis dėl naujo kodo." },
-  "resetpassword_form_error_too_many_requests": { "other": "Per daug užklausų. Prašome pabandyti vėliau." },
-
-  "account_page_header": { "other": "Mano paskyra" },
-  "account_form_name": { "other": "Vardas" },
-  "account_form_email": { "other": "El. pašto adresas" },
-  "account_form_password": { "other": "Slaptažodis" },
-  "account_form_change_password": { "other": "Keisti" },
-  "account_form_gender": { "other": "Lytis" },
-  "account_form_dob": { "other": "Gimimo data" },
-  "account_form_submit": { "other": "Atnaujinti" },
-  "account_form_submitted": { "other": "Atnaujinta" },
-  "account_form_password_changed": { "other": "Atnaujinta" },
-  "account_form_error_incorrect_password": { "other": "Neteisingas slaptažodis." },
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "Neturite PIN kodo, kurio reikia norint įsigyti, išsinuomoti ir žiūrėti kai kuriuos kūrinius."},
-  "account_form_set_pin": { "other": "Nustatyti PIN kodą" },
-  "account_form_pin_changed": { "other": "Atnaujinta" },
-  "account_form_change_pin": { "other": "Pakeiskite PIN kodą" },
-
-  "user_set_pin_header": { "other": "Nustatykite savo PIN kodą" },
-  "user_set_pin_button": { "other": "Nustatyti PIN kodą" },
-  "user_submit_pin_heading": { "other": "Įveskite PIN kodą, kad galėtumėte {{.Action}} naudoti šį apribotą turinį" },
-  "user_error_wrong_pin_retry": { "other": "Oi, įvedėte neteisingą PIN kodą" },
-  "user_error_too_many_pin_errors": { "other": "<p>Panašu, kad turite problemų.</p><p>Iš naujo nustatykite PIN kodą arba susisiekite su mumis dėl</p><a href=\"{{.HelpURL}}\" target=\"_blank\">pagalbos</a>" },
-  "user_submit_pin_button": { "other": "Įeikite" },
-  "user_reset_pin_button": { "other": "Iš naujo nustatyti PIN kodą" },
-
-  "signup_form_optin": {"other": "Prenumeruokite mūsų naujienlaiškį"},
-
-  "passwordconfirmation_modal_header": { "other": "Patvirtinkite slaptažodį" },
-  "passwordconfirmation_modal_label": { "other": "Norint išsaugoti pakeitimus, prašome įvesti slaptažodį" },
-  "passwordconfirmation_modal_confirm": { "other": "Patvirtinti" },
-
-  "changepassword_modal_header": { "other": "Keisti slaptažodį" },
-  "changepassword_modal_currentpassword": { "other": "Dabartinis slaptažodis" },
-  "changepassword_modal_password": { "other": "Naujas slaptažodis" },
-  "changepassword_modal_password2": { "other": "Pakartokite naują slaptažodį" },
-  "changepassword_modal_submit": { "other": "Atnaujinti" },
-  "changepassword_modal_error_incorrect_password": { "other": "Neteisingas slaptažodis." },
-
-  "userlibrary_page_header": { "other": "Įsigyti filmai" },
-  "userlibrary_empty_header":  { "other": "Įrašų nėra" },
-  "userlibrary_empty_content": { "other": "Rinkitės filmus iš <a href=\"{{.HomeURL}}\">programos</a>." },
-
-  "searchresults_page_header": { "other": "Paieškos rezultatai" },
-  "searchresults_load_more": { "other": "Rodyti {{.Count}} daugiau" },
+  "date_day": {
+    "other": "Diena"
+  },
+  "date_month": {
+    "other": "Mėnuo"
+  },
+  "date_year": {
+    "other": "Metai"
+  },
+  "404_page_header": {
+    "other": "Puslapis neegzistuoja..."
+  },
+  "404_page_content": {
+    "other": "<p>Apgailestaujame, jūsų nurodytu adresu puslapio neradome.</p><p>Tikėtina, kad pasikeitė puslapio adresas, puslapis buvo ištrintas arba įsivėlė rašybos klaida.</p><p>Rekomenduojame reikalingos informacijos ieškoti grįžus į pagrindinį puslapį.</p><p><a href=\"{{.URL}}\">Grįžti į pagrindinį puslapį</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Prisijungti"
+  },
+  "nav_signup": {
+    "other": "Registruotis"
+  },
+  "nav_signed_in_as": {
+    "other": "Prisijungęs (-usi) kaip"
+  },
+  "nav_library": {
+    "other": "Įsigyti filmai"
+  },
+  "nav_devices": {
+    "other": "Mano įrenginiai"
+  },
+  "nav_wishlist": {
+    "other": "Noriu pamatyti"
+  },
+  "nav_account": {
+    "other": "Mano paskyra"
+  },
+  "nav_signout": {
+    "other": "Atsijungti"
+  },
+  "play_trailer": {
+    "other": "Anonsas"
+  },
+  "runtime_hours": {
+    "other": "val."
+  },
+  "runtime_minutes": {
+    "other": "min."
+  },
+  "datetime_today": {
+    "other": "šiandien {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "rytoj {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "vakar {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "ankstesnis {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Paieška"
+  },
+  "search_control_submit": {
+    "other": "Pateikti paiešką"
+  },
+  "play_button_watch": {
+    "other": "Žiūrėti dabar"
+  },
+  "play_button_resume": {
+    "other": "Tęsti"
+  },
+  "social_media_buttons_title": {
+    "other": "Dalintis"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Dalintis Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Bendrinti Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Dalintis Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Bendrinkite el. paštu"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Nuorodos bendrinimas"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Nuoroda nukopijuota į mainų sritį!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Nukopijuoti į iškarpinę"
+  },
+  "accept_invite_page_header": {
+    "other": "Sveiki "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Panašu, kad jau patvirtinote šį kvietimą, prašome <a href=\"{{.SigninURL}}\">prisijungti</a>. Pamiršus slaptažodį, galite <a href=\"{{.ForgotPasswordURL}}\">susikurti naują</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Ačiū, jūsų paskyra sukurta."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Priimti kvietimą"
+  },
+  "acceptinvite_agreement": {
+    "other": "Spausdami „Priimti kvietimą“ patvirtinate, kad perskaitėte ir sutinkate su mūsų <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">tVartotojų taisyklėmis</a> bei <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">Privatumo politika</a>."
+  },
+  "signup_page_header": {
+    "other": "Registruotis"
+  },
+  "signup_form_name": {
+    "other": "Vardas"
+  },
+  "signup_form_email": {
+    "other": "El. pašto adresas"
+  },
+  "signup_form_password": {
+    "other": "Slaptažodis"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Patvirtinkite slaptažodį"
+  },
+  "signup_form_gender": {
+    "other": "Lytis"
+  },
+  "signup_form_dob": {
+    "other": "Gimimo data"
+  },
+  "signup_form_submit": {
+    "other": "Pateikti"
+  },
+  "signin_page_header": {
+    "other": "Prisijungti"
+  },
+  "signin_form_email": {
+    "other": "El. pašto adresas"
+  },
+  "signin_form_password": {
+    "other": "Slaptažodis"
+  },
+  "signin_form_remember": {
+    "other": "Prisiminti mane"
+  },
+  "signin_form_submit": {
+    "other": "Pateikti"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Pamiršote slaptažodį?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Neturite paskyros? Registruotis"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Turite paskyrą? Prisijungti"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Su šiuo el. paštu paskyra jau sukurta."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Neteisingas vartotojo vardas arba slaptažodis."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Per daug kartų nepavyko prisijungti. Pabandykite dar kartą vėliau."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Jūsų sąskaita laikinai sustabdyta. Jei manote, kad tai klaida, susisiekite su administratoriumi."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Įvyko klaida."
+  },
+  "combined_auth_continue": {
+    "other": "Tęsti"
+  },
+  "combined_auth_change": {
+    "other": "keisti"
+  },
+  "combined_auth_signin": {
+    "other": "Prisijungti"
+  },
+  "combined_auth_signup": {
+    "other": "Registruotis"
+  },
+  "combined_auth_signin_password": {
+    "other": "Norėdami prisijungti prie savo paskyros įveskite slaptažodį."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Neteisingas slaptažodis."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Įvyko klaida."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Per daug užklausų. Prašome pabandyti vėliau."
+  },
+  "forgotpassword_page_header": {
+    "other": "Atkurti slaptažodį"
+  },
+  "forgotpassword_form_email": {
+    "other": "El. pašto adresas"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Atkurti"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Paskyra su šiuo el. paštu neegzistuoja."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Paskyra laikinai užrakinta."
+  },
+  "forgotpassword_complete": {
+    "other": "Ačiū. Neužilgo gausite laišką dėl slaptažodžio atkūrimo."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Įvyko klaida."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Per daug užklausų. Prašome pabandyti vėliau."
+  },
+  "resetpassword_page_header": {
+    "other": "Keisti slaptažodį"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Prašymas atkurti slaptažodį negalioja. <a href=\"{{.URL}}\">Prašome iš naujo užpildyti formą</a>."
+  },
+  "resetpassword_form_password": {
+    "other": "Naujas slaptažodis"
+  },
+  "resetpassword_form_password2": {
+    "other": "Patvirtinkite naują slaptažodį"
+  },
+  "resetpassword_form_submit": {
+    "other": "Keisti"
+  },
+  "resetpassword_complete": {
+    "other": "Ačiū. Jūsų slaptažodis pakeistas, jūs prisijungėte prie savo paskyros."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Prašymas atkurti slaptažodį negalioja. Prašome vėliau bandyti dar kartą."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Slaptažodžio atkūrimo kodas nebegalioja. Prašome kreiptis dėl naujo kodo."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Per daug užklausų. Prašome pabandyti vėliau."
+  },
+  "account_page_header": {
+    "other": "Mano paskyra"
+  },
+  "account_form_name": {
+    "other": "Vardas"
+  },
+  "account_form_email": {
+    "other": "El. pašto adresas"
+  },
+  "account_form_password": {
+    "other": "Slaptažodis"
+  },
+  "account_form_change_password": {
+    "other": "Keisti"
+  },
+  "account_form_gender": {
+    "other": "Lytis"
+  },
+  "account_form_dob": {
+    "other": "Gimimo data"
+  },
+  "account_form_submit": {
+    "other": "Atnaujinti"
+  },
+  "account_form_submitted": {
+    "other": "Atnaujinta"
+  },
+  "account_form_password_changed": {
+    "other": "Atnaujinta"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Neteisingas slaptažodis."
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Neturite PIN kodo, kurio reikia norint įsigyti, išsinuomoti ir žiūrėti kai kuriuos kūrinius."
+  },
+  "account_form_set_pin": {
+    "other": "Nustatyti PIN kodą"
+  },
+  "account_form_pin_changed": {
+    "other": "Atnaujinta"
+  },
+  "account_form_change_pin": {
+    "other": "Pakeiskite PIN kodą"
+  },
+  "user_set_pin_header": {
+    "other": "Nustatykite savo PIN kodą"
+  },
+  "user_set_pin_button": {
+    "other": "Nustatyti PIN kodą"
+  },
+  "user_submit_pin_heading": {
+    "other": "Įveskite PIN kodą, kad galėtumėte {{.Action}} naudoti šį apribotą turinį"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Oi, įvedėte neteisingą PIN kodą"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Panašu, kad turite problemų.</p><p>Iš naujo nustatykite PIN kodą arba susisiekite su mumis dėl</p><a href=\"{{.HelpURL}}\" target=\"_blank\">pagalbos</a>"
+  },
+  "user_submit_pin_button": {
+    "other": "Įeikite"
+  },
+  "user_reset_pin_button": {
+    "other": "Iš naujo nustatyti PIN kodą"
+  },
+  "signup_form_optin": {
+    "other": "Prenumeruokite mūsų naujienlaiškį"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Patvirtinkite slaptažodį"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Norint išsaugoti pakeitimus, prašome įvesti slaptažodį"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Patvirtinti"
+  },
+  "changepassword_modal_header": {
+    "other": "Keisti slaptažodį"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Dabartinis slaptažodis"
+  },
+  "changepassword_modal_password": {
+    "other": "Naujas slaptažodis"
+  },
+  "changepassword_modal_password2": {
+    "other": "Pakartokite naują slaptažodį"
+  },
+  "changepassword_modal_submit": {
+    "other": "Atnaujinti"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Neteisingas slaptažodis."
+  },
+  "userlibrary_page_header": {
+    "other": "Įsigyti filmai"
+  },
+  "userlibrary_empty_header": {
+    "other": "Įrašų nėra"
+  },
+  "userlibrary_empty_content": {
+    "other": "Rinkitės filmus iš <a href=\"{{.HomeURL}}\">programos</a>."
+  },
+  "searchresults_page_header": {
+    "other": "Paieškos rezultatai"
+  },
+  "searchresults_load_more": {
+    "other": "Rodyti {{.Count}} daugiau"
+  },
   "searchresults_total": {
     "one": "Radome 1 \"{{.Query}}\" rezultatą.",
     "other": "Radome {{.Count}} \"{{.Query}}\" rezultatus."
   },
-  "searchresults_empty_header":  { "other": "Užklausai neradome nė vieno rezultato \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Pradėkite naują paiešką arba <a href=\"{{.HomeURL}}\">peržiūrėkite mūsų programą</a>." },
-
-  "validation_name_required": { "other": "Prašome įvesti savo vardą." },
-  "validation_email_required": { "other": "Prašome įvesti savo el. pašto adresą." },
-  "validation_email_email": { "other": "Prašome įvesti galiojantį el. pašto adresą." },
-  "validation_currentpassword_required": { "other": "Prašome įvesti esamą slaptažodį." },
-  "validation_password_required": { "other": "Prašome įvesti slaptažodį." },
-  "validation_password2_required": { "other": "Prašome patvirtinti slaptažodį." },
-  "validation_password2_match": { "other": "Jūsų slaptažodžiai nesutampa." },
-  "validation_password_minlength": { "other": "Prašome įvesti mažiausiai {{.Count}} ženklus." },
-  "validation_promocode_required": { "other": "Prašome įvesti nuolaidos kodą." },
-  "validation_pincode_required": { "other": "Įveskite PIN kodą." },
-  "validation_gender_required": { "other": "Prašome pažymėti lytį, su kuria tapatinatės." },
-  "validation_dob_required": { "other": "Prašome įrašyti savo gimimo datą." },
-  "validation_dob_date": { "other": "Prašome įrašyti teisingą gimimo datą." },
-
-  "shopping_info_subtitle_hd": { "other": "Vaizdo įrašas." },
-  "shopping_info_subtitle_sd": { "other": "SD Video on Demand." },
-  "shopping_info_subtitle_wallet": { "other": "Lėšos jūsų piniginėje gali būti naudojama bet kokio turinio įsigijimui ar nuomai." },
-  "shopping_info_subtitle_help": { "other": "Informacija apie sistemos techninius reikalavimus." },
-  "shopping_info_ownership_buy": { "other": "Pirkti" },
-  "shopping_info_ownership_rent": { "other": "Išsinuomoti" },
-
-  "shopping_info_sd_only": { "other": "Tik SD atkūrimas." },
-  "shopping_info_release_date_title": { "other": "Peržiūra galima nuo {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Galite išsinuomoti dabar, tačiau peržiūrėti galėsite tik nuo nurodytos datos." },
-  "shopping_info_release_date_explanation_buy": { "other": "Galite pirkti dabar, tačiau peržiūrėti galėsite tik nuo nurodytos datos." },
-
-  "shopping_info_available_until_date_title": { "other": "Peržiūra galima iki {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Po šios datos peržiūra bus nebegalima." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Po šios datos peržiūra bus nebegalima." },
-
-  "duration_hour": { "one": "1 valandą", "other": "{{.Count}} valandos" },
-  "duration_day": { "one": "1 diena", "other": "{{.Count}} dienos" },
-  "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} nuoma " },
-  "shopping_info_watch_window_duration": { "other": "{{.Count}} val. peržiūros laikas. " },
+  "searchresults_empty_header": {
+    "other": "Užklausai neradome nė vieno rezultato \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Pradėkite naują paiešką arba <a href=\"{{.HomeURL}}\">peržiūrėkite mūsų programą</a>."
+  },
+  "validation_name_required": {
+    "other": "Prašome įvesti savo vardą."
+  },
+  "validation_email_required": {
+    "other": "Prašome įvesti savo el. pašto adresą."
+  },
+  "validation_email_email": {
+    "other": "Prašome įvesti galiojantį el. pašto adresą."
+  },
+  "validation_currentpassword_required": {
+    "other": "Prašome įvesti esamą slaptažodį."
+  },
+  "validation_password_required": {
+    "other": "Prašome įvesti slaptažodį."
+  },
+  "validation_password2_required": {
+    "other": "Prašome patvirtinti slaptažodį."
+  },
+  "validation_password2_match": {
+    "other": "Jūsų slaptažodžiai nesutampa."
+  },
+  "validation_password_minlength": {
+    "other": "Prašome įvesti mažiausiai {{.Count}} ženklus."
+  },
+  "validation_promocode_required": {
+    "other": "Prašome įvesti nuolaidos kodą."
+  },
+  "validation_pincode_required": {
+    "other": "Įveskite PIN kodą."
+  },
+  "validation_gender_required": {
+    "other": "Prašome pažymėti lytį, su kuria tapatinatės."
+  },
+  "validation_dob_required": {
+    "other": "Prašome įrašyti savo gimimo datą."
+  },
+  "validation_dob_date": {
+    "other": "Prašome įrašyti teisingą gimimo datą."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "Vaizdo įrašas."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video on Demand."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Lėšos jūsų piniginėje gali būti naudojama bet kokio turinio įsigijimui ar nuomai."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Informacija apie sistemos techninius reikalavimus."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "Pirkti"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "Išsinuomoti"
+  },
+  "shopping_info_sd_only": {
+    "other": "Tik SD atkūrimas."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Peržiūra galima nuo {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Galite išsinuomoti dabar, tačiau peržiūrėti galėsite tik nuo nurodytos datos."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Galite pirkti dabar, tačiau peržiūrėti galėsite tik nuo nurodytos datos."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Peržiūra galima iki {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Po šios datos peržiūra bus nebegalima."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Po šios datos peržiūra bus nebegalima."
+  },
+  "duration_hour": {
+    "one": "1 valandą",
+    "other": "{{.Count}} valandos"
+  },
+  "duration_day": {
+    "one": "1 diena",
+    "other": "{{.Count}} dienos"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} nuoma "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} val. peržiūros laikas. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Įsigytą filmą savo paskyroje galėsite žiūrėti {{.ValueUnit}}. ",
     "other": "Įsigytą filmą savo paskyroje galėsite žiūrėti {{.ValueUnit}}. "
@@ -248,65 +550,151 @@
     "one": "Paspaudus mygtuką „Žiūrėti“ atsidarys peržiūros langas. Per 1 valandą galėsite peržiūrėti filmą tiek kartų, kiek norėsite.",
     "other": "Paspaudus mygtuką „Žiūrėti“ atsidarys peržiūros langas. Per {{.Count}} valandas galėsite peržiūrėti filmą tiek kartų, kiek norėsite."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Nuolaida" },
-
-  "shopping_enter_card_prompt": { "other": "Norėdami patvirtinti {{.Verb}}, įveskite savo mokėjimo kortelės duomenis." },
-
-  "shopping_terms": { "other": "Patvirtindamas pirkimą, sutinku su <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">Vartotojų taisyklėmis</a>."},
-  "shopping_discount_applied": { "other": "Pritaikyta {{.DiscountAmount}} nuolaida." },
-  "shopping_discount_apply": { "other": "Taikyti" },
-  "shopping_discount_code": { "other": "Įveskite nuolaidos kodą." },
-  "shopping_discount_have_code": { "other": "Turiu nuolaidos kodą" },
-
-  "shopping_price_you_pay": { "other": "Mokėti" },
-  "shopping_price_nothing": { "other": "Nereikia" },
-  "shopping_price_free": { "other": "Nemokamas" },
-
-  "shopping_auth_directions": { "other": "Būtina prisijungti. Prašome įvesti savo el. pašto adresą." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} jau yra prie jūsų „Įsigytų filmų“." },
-
-  "shopping_error_missing_card": { "other": "Prašome įvesti savo mokėjimo kortelės duomenis." },
-  "shopping_error_title": { "other": "Įvyko klaida" },
-  "shopping_error_incorrect_cvc": { "other": "Prašome įvesti teisingą kortelės saugos kodą (CVV)." },
-  "shopping_error_invalid_cvc": { "other": "Prašome įvesti teisingą kortelės saugos kodą (CVV)." },
-  "shopping_error_incorrect_number": { "other": "Prašome įvesti teisingą mokėjimo kortelės numerį." },
-  "shopping_error_invalid_number": { "other": "Prašome įvesti teisingą mokėjimo kortelės numerį." },
-  "shopping_error_card_declined": { "other": "Mokėjimo kortelė nepriimta." },
-  "shopping_error_invalid_expiry_month": { "other": "Prašome įvesti teisingą kortelės galiojimo datą." },
-  "shopping_error_invalid_expiry_year": { "other": "Prašome įvesti teisingą kortelės galiojimo datą." },
-  "shopping_error_expired_card": { "other": "Mokėjimo kortelės galiojimo laikas baigėsi." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Jūsų {{.Ownership}} nepatvirtintas. Privalote būti mokėjimo kortelę išdavusioje šalyje. Prašome naudoti kitą kortelę." },
-  "shopping_error_proxy_detected": { "other": "Jūsų {{.Ownership}} nepatvirtintas. Naudojate blokavimo programą arba tarpinį serverį. Prašome išjungti šias programas ir bandyti iš naujo." },
-
-  "shopping_error_discount_worn_out": { "other": "Kad reklamos kodas nebegali būti naudojamas." },
-  "shopping_error_discount_blank": { "other": "Prašome įvesti nuolaidos kodą." },
-  "shopping_error_discount_not_applied": { "other": "Prašome įvesti galiojantį nuolaidos kodą." },
-  "shopping_error_discount_invalid": { "other": "Prašome įvesti galiojantį nuolaidos kodą." },
-  "shopping_error_discount_disabled": { "other": "Prašome įvesti galiojantį nuolaidos kodą." },
-  "shopping_error_discount_already_applied": { "other": "Šiam apsipirkimui jau panaudojote nuolaidos kodą." },
-  "shopping_error_discount_already_redeemed": { "other": "Nuolaidos kodas jau panaudotas." },
-  "shopping_error_discount_used_previously": { "other": "Nuolaidos kodas jau panaudotas." },
-  "shopping_error_discount_max_limit": { "other": "Įvestas nuolaidos kodas jau panaudotas." },
-  "shopping_error_discount_expired": { "other": "Nuolaidos kodas nebegalioja." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Nuolaidos kodas perkant negalioja." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Nuolaidos kodas nuomojant negalioja." },
-  "shopping_error_discount_invalid_item": { "other": "Nuolaidos kodas negalioja šiam filmui." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Nuolaidos kodas negalioja jūsų gyvenamojoje šalyje." },
-  "shopping_error_discounts_not_allowed": { "other": "Nuolaidos kodo panaudoti negalima." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Nuolaidos kodas negalioja rinkiniams." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Mokėjimo kortelė nepriimta. Prašome bandyti dar kartą." },
-
-  "shopping_complete_rental": { "other": "Pirkinys sėkmingas!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Nuolaida"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Norėdami patvirtinti {{.Verb}}, įveskite savo mokėjimo kortelės duomenis."
+  },
+  "shopping_terms": {
+    "other": "Patvirtindamas pirkimą, sutinku su <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">Vartotojų taisyklėmis</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "Pritaikyta {{.DiscountAmount}} nuolaida."
+  },
+  "shopping_discount_apply": {
+    "other": "Taikyti"
+  },
+  "shopping_discount_code": {
+    "other": "Įveskite nuolaidos kodą."
+  },
+  "shopping_discount_have_code": {
+    "other": "Turiu nuolaidos kodą"
+  },
+  "shopping_price_you_pay": {
+    "other": "Mokėti"
+  },
+  "shopping_price_nothing": {
+    "other": "Nereikia"
+  },
+  "shopping_price_free": {
+    "other": "Nemokamas"
+  },
+  "shopping_auth_directions": {
+    "other": "Būtina prisijungti. Prašome įvesti savo el. pašto adresą."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} jau yra prie jūsų „Įsigytų filmų“."
+  },
+  "shopping_error_missing_card": {
+    "other": "Prašome įvesti savo mokėjimo kortelės duomenis."
+  },
+  "shopping_error_title": {
+    "other": "Įvyko klaida"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Prašome įvesti teisingą kortelės saugos kodą (CVV)."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Prašome įvesti teisingą kortelės saugos kodą (CVV)."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Prašome įvesti teisingą mokėjimo kortelės numerį."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Prašome įvesti teisingą mokėjimo kortelės numerį."
+  },
+  "shopping_error_card_declined": {
+    "other": "Mokėjimo kortelė nepriimta."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Prašome įvesti teisingą kortelės galiojimo datą."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Prašome įvesti teisingą kortelės galiojimo datą."
+  },
+  "shopping_error_expired_card": {
+    "other": "Mokėjimo kortelės galiojimo laikas baigėsi."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Jūsų {{.Ownership}} nepatvirtintas. Privalote būti mokėjimo kortelę išdavusioje šalyje. Prašome naudoti kitą kortelę."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Jūsų {{.Ownership}} nepatvirtintas. Naudojate blokavimo programą arba tarpinį serverį. Prašome išjungti šias programas ir bandyti iš naujo."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Kad reklamos kodas nebegali būti naudojamas."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Prašome įvesti nuolaidos kodą."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Prašome įvesti galiojantį nuolaidos kodą."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Prašome įvesti galiojantį nuolaidos kodą."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Prašome įvesti galiojantį nuolaidos kodą."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Šiam apsipirkimui jau panaudojote nuolaidos kodą."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Nuolaidos kodas jau panaudotas."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Nuolaidos kodas jau panaudotas."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Įvestas nuolaidos kodas jau panaudotas."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Nuolaidos kodas nebegalioja."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Nuolaidos kodas perkant negalioja."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Nuolaidos kodas nuomojant negalioja."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Nuolaidos kodas negalioja šiam filmui."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Nuolaidos kodas negalioja jūsų gyvenamojoje šalyje."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Nuolaidos kodo panaudoti negalima."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Nuolaidos kodas negalioja rinkiniams."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Mokėjimo kortelė nepriimta. Prašome bandyti dar kartą."
+  },
+  "shopping_complete_rental": {
+    "other": "Pirkinys sėkmingas!"
+  },
   "shopping_complete_rental_period": {
     "one": "Per ateinančią dieną įrašą galite žiūrėti tiek kartu, kiek norite.",
     "other": "Per {{.Count}} dienas įrašą peržiūrėti galite tiek kartų, kiek norite. "
   },
-  "shopping_complete_purchase": { "other": "Jūs įsigijote filmą {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Jūs įsigijote filmą {{.Title}}. Jūsų paskyra papildyta {{.CreditTotal}}." },
-  "shopping_complete_purchase_coming_soon": { "other": "Filmą galėsite žiūrėti nuo {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Kvitą jums išsiuntėme el. paštu." },
-  "shopping_complete_library_link": { "other": "Pradėkite žiūrėti bet kurį iš savo įsigytų filmų." },
+  "shopping_complete_purchase": {
+    "other": "Jūs įsigijote filmą {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Jūs įsigijote filmą {{.Title}}. Jūsų paskyra papildyta {{.CreditTotal}}."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Filmą galėsite žiūrėti nuo {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Kvitą jums išsiuntėme el. paštu."
+  },
+  "shopping_complete_library_link": {
+    "other": "Pradėkite žiūrėti bet kurį iš savo įsigytų filmų."
+  },
   "shopping_complete_plan": {
     "other": "{{ .Title }} buvo sėkmingas."
   },
@@ -326,159 +714,370 @@
     "one": "Filmą galėsite žiūrėti nuo {{.Date}}, o filmo peržiūra galios vieną dieną.",
     "other": "Filmą galėsite žiūrėti nuo {{.Date}}, o filmo peržiūra galios {{.Count}} dienas."
   },
-
-  "shopping_action_rent": { "other": "Nuomoti" },
-  "shopping_action_buy": { "other": "Pirkti" },
-
-  "meta_detail_cast_title": { "other": "Aktoriai" },
-  "meta_detail_crew_title": { "other": "Komanda" },
-  "meta_detail_languages": { "one": "Kalba", "other": "Kalbos" },
-  "meta_detail_studios": { "one": "Kompanija", "other": "Kompanijos" },
-  "meta_detail_countries": { "one": "Šalis", "other": "Šalys" },
-  "meta_detail_subtitles": { "other": "Subtitrai" },
-  "meta_detail_captions": { "other": "Subtitrai [CC]" },
-  "meta_detail_episodes_title": { "other": "Epizodai" },
-  "meta_detail_bonus_title": { "other": "Specialus papildomas turinys" },
-  "meta_detail_recommendations_title": { "other": "Taip pat gali patikti" },
-  "meta_detail_bundle_items_title": { "other": "Šiame rinkinyje rasite" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} filmų (-us)" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} sezonus (-ų)" },
-  "bundle_items_mixed": { "other": "{{.Count}} filmus (-ų) ir sezonus (-ų)" },
-  "userwishlist_page_header": { "other": "Noriu pamatyti" },
-  "userwishlist_slider_header": { "other": "Noriu pamatyti" },
-  "userwishlist_empty_header":  { "other": "Sąrašas tuščias." },
-  "userwishlist_empty_content": { "other": "Rinkitės filmus <a href=\"{{.HomeURL}}\">iš programos</a>." },
-  "userwishlist_button_add": { "other": "Pridėti prie „Noriu pamatyti“" },
-  "userwishlist_button_remove": { "other": "Noriu pamatyti" },
-  "userwishlist_button_add_compact": { "other": "Noriu pamatyti" },
-  "userwishlist_button_remove_compact": { "other": "Noriu pamatyti" },
-
-  "activatedevice_page_header": { "other": "Aktyvuoti įrenginį" },
-  "activatedevice_page_content": { "other": "Vadovaukitės savo prietaiso instrukcijomis, kad gautumėte PIN kodą. Jūsų kompiuteris ir įrenginys turi būti prijungtas prie interneto, kad suaktyvintumėte." },
-  "activatedevice_form_pin": { "other": "PIN kodas" },
-  "activatedevice_form_submit": { "other": "Aktyvuokite" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN kodas nerastas, bandykite dar kartą." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN kodas nerastas, bandykite dar kartą." },
-  "activatedevice_signin_prompt": { "other": "Prisijunkite prieš įjungdami savo prietaisą." },
-  "activatedevice_page_activated": { "other": "Dėkojame, kad suaktyvinote {{.DeviceName}}. Dabar turėtumėte galėti naršyti biblioteką televizoriuje arba įrenginyje." },
-
-  "userdevices_page_header": { "other": "Įrenginiai" },
+  "shopping_action_rent": {
+    "other": "Nuomoti"
+  },
+  "shopping_action_buy": {
+    "other": "Pirkti"
+  },
+  "meta_detail_cast_title": {
+    "other": "Aktoriai"
+  },
+  "meta_detail_crew_title": {
+    "other": "Komanda"
+  },
+  "meta_detail_languages": {
+    "one": "Kalba",
+    "other": "Kalbos"
+  },
+  "meta_detail_studios": {
+    "one": "Kompanija",
+    "other": "Kompanijos"
+  },
+  "meta_detail_countries": {
+    "one": "Šalis",
+    "other": "Šalys"
+  },
+  "meta_detail_subtitles": {
+    "other": "Subtitrai"
+  },
+  "meta_detail_captions": {
+    "other": "Subtitrai [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Epizodai"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Specialus papildomas turinys"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Taip pat gali patikti"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Šiame rinkinyje rasite"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} filmų (-us)"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} sezonus (-ų)"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} filmus (-ų) ir sezonus (-ų)"
+  },
+  "userwishlist_page_header": {
+    "other": "Noriu pamatyti"
+  },
+  "userwishlist_slider_header": {
+    "other": "Noriu pamatyti"
+  },
+  "userwishlist_empty_header": {
+    "other": "Sąrašas tuščias."
+  },
+  "userwishlist_empty_content": {
+    "other": "Rinkitės filmus <a href=\"{{.HomeURL}}\">iš programos</a>."
+  },
+  "userwishlist_button_add": {
+    "other": "Pridėti prie „Noriu pamatyti“"
+  },
+  "userwishlist_button_remove": {
+    "other": "Noriu pamatyti"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Noriu pamatyti"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Noriu pamatyti"
+  },
+  "activatedevice_page_header": {
+    "other": "Aktyvuoti įrenginį"
+  },
+  "activatedevice_page_content": {
+    "other": "Vadovaukitės savo prietaiso instrukcijomis, kad gautumėte PIN kodą. Jūsų kompiuteris ir įrenginys turi būti prijungtas prie interneto, kad suaktyvintumėte."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN kodas"
+  },
+  "activatedevice_form_submit": {
+    "other": "Aktyvuokite"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN kodas nerastas, bandykite dar kartą."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN kodas nerastas, bandykite dar kartą."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Prisijunkite prieš įjungdami savo prietaisą."
+  },
+  "activatedevice_page_activated": {
+    "other": "Dėkojame, kad suaktyvinote {{.DeviceName}}. Dabar turėtumėte galėti naršyti biblioteką televizoriuje arba įrenginyje."
+  },
+  "userdevices_page_header": {
+    "other": "Įrenginiai"
+  },
   "userdevices_page_content": {
     "one": "Čia automatiškai atsiras jūsų naudojami įrenginiai. Įrenginių skaičius ribojimas iki vieno.",
     "few": "Čia automatiškai atsiras jūsų naudojami įrenginiai. Įrenginių skaičius ribojimas iki {{.Count}}."
   },
-  "userdevices_empty_content": { "other": "Šiuo metu esate užregistravę 0 įrenginių." },
-  "userdevices_header_type": { "other": "Įrenginio tipas" },
-  "userdevices_header_description": { "other": "Apibūdinimas" },
-  "userdevices_device_added": { "other": "Pridėtas {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Pašalinti" },
-  "userdevices_device_actions_cancel": { "other": "Atšaukti" },
-  "userdevices_device_actions_confirm": { "other": "Taip, pašalinti įrenginį" },
-  "userdevices_device_deleted": { "other": "(Pašalintas)" },
-  "userdevices_delete_limits": { "other": "Iš šio sąrašo galite pašalinti {{.Limit}} įrenginį (-ius) kas {{.Period}} d." },
-  "userdevices_delete_limit_reached": { "other": "Pasiekėte šį limitą ir šiuo metu negalite pašalinti jokių įrenginių. Įrenginį galite ištrinti po {{.Days}} d." },
-
-  "playlist_page_header": { "other": "Grojaraštis" },
-  "playlist_sign_in_warning": { "other": "Jei norite žiūrėti tiesioginę televiziją, prisijunkite."},
-  "playlist_share_title": { "other": "Grojaraštis" },
-  "playlist_up_next_title": { "other": "Kitas" },
-
-  "pricing_ownership_buy": { "other": "Pirkti" },
-  "pricing_ownership_rent": { "other": "Nuomoti" },
-
-  "classification_intro": { "other": "Kategorija: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Šioje svetainėje naudojame slapukus, siekdami pagerinti jūsų vartojimo patirtį. Lankydamiesi svetainėje sutinkate su mūsų <a href=\"{{.CookiePolicyURL}}\">slapukų politika</a>." },
-  "cookie_banner_accept": { "other": "Sutinku" },
-
-  "all_rights_reserved": { "other": "Visos teisės saugomos. Svetainėje esančią informaciją kopijuoti leidžiama tik gavus mūsų sutikimą." },
-
-  "users_gender_none": { "other": "Nenurodyti" },
-  "users_gender_female": { "other": "Moteris" },
-  "users_gender_male": { "other": "Vyras" },
-  "users_gender_diverse": { "other": "Nedvinarė" },
-  "users_gender_other": { "other": "Kita" },
-
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "Tik HD" },
-  "pricing_quality_sd_only": { "other": "Tik SD" },
-
-  "shopping_card_save_card": { "other": "Išsaugokite šią kortelę būsimam naudojimui" },
-  "shopping_card_button_change": { "other": "Rodyti visas išsaugotas korteles" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} baigiasi {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(pasibaigia {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(pasibaigęs)" },
-  "shopping_card_use_other": { "other": "Naudokite naują kortelę" },
-  "shopping_card_use_new_card": { "other": "Keisti kortelę" },
-  "shopping_card_update_reason_none": { "other": "Atnaujinkite savo kredito kortelę. Palaikomos kortelės yra „Visa“, „Mastercard“ ir „American Express“." },
-  "shopping_card_new_subscription": { "other": "Ši kortelė bus išsaugota ir reguliariai apmokestinama" },
-  "shopping_card_change": { "other": "Netinkama kredito kortelė? <a href=\"{{.SubscriptionsURL}}\">Jei norite atnaujinti kortelę, spustelėkite čia.</a>" },
-
-  "shopping_info_ownership_plan": { "other": "Prenumerata" },
-
-  "shopping_action_credit": { "other": "Prisipilti" },
-
-
-  "shopping_info_rental_period_coming_soon": { "other": "nuo išleidimo datos ir laiko." },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Pakeiskite kredito kortelę" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Atnaujinkite kredito kortelės duomenis" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Atnaujinkite" },
-
-  "usersubscriptions_subscription_expiry": { "other": "Baigiasi {{.Expiry}}" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Bandomasis laikotarpis" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Atšaukti mano prenumeratą" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Atšaukti" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Taip, atšaukite mano prenumeratą" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Atšaukti prenumeratą?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "Taip bus atšaukta {{.Name}} plano prenumerata. Vis tiek galėsite žiūrėti plano turinį, kol baigsis {{.Expiry}}." },
-
-
-
-  "availability_coming_soon": { "other": "Jau greitai" },
-  "availability_renting": { "other": "Nuomojama" },
-  "availability_not_available": { "other": "Peržiūra negalima" },
-  "availability_in_watch_window": { "other": "Peržiūra galima" },
-  "availability_sold_out": { "other": "Peržiūra nebegalima" },
-  "availability_available_till": { "other": "Peržiūra galima iki {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Jūsų šalyje peržiūra negalima" },
-  "availability_available": { "other": "Peržiūra galima nuo {{.ReleaseDate}}" },
-  "availability_expires": { "other": "pasibaigia {{.Expiry}}" },
-  "availability_expired": { "other": "pasibaigęs"},
-
-  "modal_cancel": { "other": "Atšaukti" },
-
-  "play": { "other": "Žiūrėti" },
-
-  "combined_auth_signin_prompt": { "other": "Prisijungti" },
-  "combined_auth_signup_prompt": { "other": "Registruotis" },
-  "combined_auth_terms": { "other": "Sutinku su <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Vartotojų taisyklėmis</a>." },
-  "signup_terms": { "other": "Sutinku su <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Vartotojų taisyklėmis</a>." },
-  "validation_terms_required": { "other": "Privalote sutikti su Vartotojų taisyklėmis." },
-  "shopping_error_item_limit_exceeded": { "other": "Apgailestaujame, filmo {{.Title}} peržiūra nebegalima." },
-
-  "changepincode_modal_header": { "other": "Pakeiskite savo PIN kodą" },
-  "changepincode_modal_currentpassword": { "other": "Jūsų dabartinis slaptažodis" },
-  "changepincode_modal_pincode1": { "other": "Jūsų naujas 4 skaitmenų PIN kodas" },
-  "changepincode_modal_pincode2": { "other": "Patvirtinkite naują 4 skaitmenų PIN kodą" },
-  "changepincode_modal_submit": { "other": "Nustatyti PIN kodą" },
-  "changepincode_modal_error_wrong_password": { "other": "Tas slaptažodis neteisingas." },
-
-  "user_set_pin_intro": { "other": "Norėdami {{.Action}} apriboti turinį, jums reikia PIN kodo"},
-  "user_error_wrong_pin_reset": { "other": "Spustelėkite čia, kad iš naujo nustatytumėte PIN kodą" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Šiam turiniui taikomas amžiaus apribojimas." },
-  "shopping_error_close_button": { "other": "OK" },
-
-  "app_badge_title": { "other": "Atsisiųskite programą, kad peržiūrėtumėte įsigytą turinį!" },
-  "app_badge_ios": { "other": "Atsisiųskite iš „App Store“." },
-  "app_badge_android": { "other": "Gaukite jį iš „Google Play“." },
-
+  "userdevices_empty_content": {
+    "other": "Šiuo metu esate užregistravę 0 įrenginių."
+  },
+  "userdevices_header_type": {
+    "other": "Įrenginio tipas"
+  },
+  "userdevices_header_description": {
+    "other": "Apibūdinimas"
+  },
+  "userdevices_device_added": {
+    "other": "Pridėtas {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Pašalinti"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Atšaukti"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Taip, pašalinti įrenginį"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Pašalintas)"
+  },
+  "userdevices_delete_limits": {
+    "other": "Iš šio sąrašo galite pašalinti {{.Limit}} įrenginį (-ius) kas {{.Period}} d."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Pasiekėte šį limitą ir šiuo metu negalite pašalinti jokių įrenginių. Įrenginį galite ištrinti po {{.Days}} d."
+  },
+  "playlist_page_header": {
+    "other": "Grojaraštis"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Jei norite žiūrėti tiesioginę televiziją, prisijunkite."
+  },
+  "playlist_share_title": {
+    "other": "Grojaraštis"
+  },
+  "playlist_up_next_title": {
+    "other": "Kitas"
+  },
+  "pricing_ownership_buy": {
+    "other": "Pirkti"
+  },
+  "pricing_ownership_rent": {
+    "other": "Nuomoti"
+  },
+  "classification_intro": {
+    "other": "Kategorija: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Šioje svetainėje naudojame slapukus, siekdami pagerinti jūsų vartojimo patirtį. Lankydamiesi svetainėje sutinkate su mūsų <a href=\"{{.CookiePolicyURL}}\">slapukų politika</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Sutinku"
+  },
+  "all_rights_reserved": {
+    "other": "Visos teisės saugomos. Svetainėje esančią informaciją kopijuoti leidžiama tik gavus mūsų sutikimą."
+  },
+  "users_gender_none": {
+    "other": "Nenurodyti"
+  },
+  "users_gender_female": {
+    "other": "Moteris"
+  },
+  "users_gender_male": {
+    "other": "Vyras"
+  },
+  "users_gender_diverse": {
+    "other": "Nedvinarė"
+  },
+  "users_gender_other": {
+    "other": "Kita"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "Tik HD"
+  },
+  "pricing_quality_sd_only": {
+    "other": "Tik SD"
+  },
+  "shopping_card_save_card": {
+    "other": "Išsaugokite šią kortelę būsimam naudojimui"
+  },
+  "shopping_card_button_change": {
+    "other": "Rodyti visas išsaugotas korteles"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} baigiasi {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(pasibaigia {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(pasibaigęs)"
+  },
+  "shopping_card_use_other": {
+    "other": "Naudokite naują kortelę"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Keisti kortelę"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Atnaujinkite savo kredito kortelę. Palaikomos kortelės yra „Visa“, „Mastercard“ ir „American Express“."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Ši kortelė bus išsaugota ir reguliariai apmokestinama"
+  },
+  "shopping_card_change": {
+    "other": "Netinkama kredito kortelė? <a href=\"{{.SubscriptionsURL}}\">Jei norite atnaujinti kortelę, spustelėkite čia.</a>"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Prenumerata"
+  },
+  "shopping_action_credit": {
+    "other": "Prisipilti"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "nuo išleidimo datos ir laiko."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Pakeiskite kredito kortelę"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Atnaujinkite kredito kortelės duomenis"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Atnaujinkite"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Baigiasi {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Bandomasis laikotarpis"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Atšaukti mano prenumeratą"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Atšaukti"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Taip, atšaukite mano prenumeratą"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Atšaukti prenumeratą?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Taip bus atšaukta {{.Name}} plano prenumerata. Vis tiek galėsite žiūrėti plano turinį, kol baigsis {{.Expiry}}."
+  },
+  "availability_coming_soon": {
+    "other": "Jau greitai"
+  },
+  "availability_renting": {
+    "other": "Nuomojama"
+  },
+  "availability_not_available": {
+    "other": "Peržiūra negalima"
+  },
+  "availability_in_watch_window": {
+    "other": "Peržiūra galima"
+  },
+  "availability_sold_out": {
+    "other": "Peržiūra nebegalima"
+  },
+  "availability_available_till": {
+    "other": "Peržiūra galima iki {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Jūsų šalyje peržiūra negalima"
+  },
+  "availability_available": {
+    "other": "Peržiūra galima nuo {{.ReleaseDate}}"
+  },
+  "availability_expires": {
+    "other": "pasibaigia {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "pasibaigęs"
+  },
+  "modal_cancel": {
+    "other": "Atšaukti"
+  },
+  "play": {
+    "other": "Žiūrėti"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Prisijungti"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Registruotis"
+  },
+  "combined_auth_terms": {
+    "other": "Sutinku su <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Vartotojų taisyklėmis</a>."
+  },
+  "signup_terms": {
+    "other": "Sutinku su <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">Vartotojų taisyklėmis</a>."
+  },
+  "validation_terms_required": {
+    "other": "Privalote sutikti su Vartotojų taisyklėmis."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Apgailestaujame, filmo {{.Title}} peržiūra nebegalima."
+  },
+  "changepincode_modal_header": {
+    "other": "Pakeiskite savo PIN kodą"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Jūsų dabartinis slaptažodis"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Jūsų naujas 4 skaitmenų PIN kodas"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Patvirtinkite naują 4 skaitmenų PIN kodą"
+  },
+  "changepincode_modal_submit": {
+    "other": "Nustatyti PIN kodą"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Tas slaptažodis neteisingas."
+  },
+  "user_set_pin_intro": {
+    "other": "Norėdami {{.Action}} apriboti turinį, jums reikia PIN kodo"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Spustelėkite čia, kad iš naujo nustatytumėte PIN kodą"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Šiam turiniui taikomas amžiaus apribojimas."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "app_badge_title": {
+    "other": "Atsisiųskite programą, kad peržiūrėtumėte įsigytą turinį!"
+  },
+  "app_badge_ios": {
+    "other": "Atsisiųskite iš „App Store“."
+  },
+  "app_badge_android": {
+    "other": "Gaukite jį iš „Google Play“."
+  },
   "shopping_price_title_plan": {
     "other": "Kaina"
   },
@@ -550,41 +1149,100 @@
   "donate_button_text": {
     "other": "Paaukoti"
   },
-  "wcag_skip_links_header": { "other": "Prieinamumo nuorodos" },
-  "wcag_skip_links_content": { "other": "Pereiti prie turinio" },
-
-  "wcag_homepage_h1": { "other": "Pagrindinis puslapis" },
-  "wcag_carousel_h2": { "other": "Karuselė" },
-  "wcag_collections_h2": { "other": "Kolekcijos" },
-
-  "wcag_aria_label_footer": { "other": "Poraštė" },
-  "wcag_aria_label_nav_main": { "other": "Pagrindinis" },
-  "wcag_aria_label_nav_sub": { "other": "Subrendę" },
-  "wcag_aria_label_toggle_nav": { "other": "Perjungti navigaciją" },
-  "wcag_aria_label_bundle_items": { "other": "Supakuoti daiktai" },
-  "wcag_aria_label_carousel": { "other": "Karuselė" },
-  "wcag_aria_label_page_collection": { "other": "Puslapių kolekcija" },
-  "wcag_aria_label_collection_list": { "other": "Kolekcijos sąrašas" },
-  "wcag_aria_label_collection_slider": { "other": "Kolekcijos slankiklis" },
-  "wcag_aria_label_wishlist": { "other": "Norų sąrašas" },
-  "wcag_aria_label_facebook": { "other": "Dalintis Facebook" },
-  "wcag_aria_label_twitter": { "other": "Bendrinti Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Bendrinkite „LinkedIn“." },
-  "wcag_aria_label_letterboxd": { "other": "Žiūrėti „Letterboxd“." },
-
-  "shopping_error_plan_already_owned": { "other": "Jūs jau turite šį planą." },
-  "shopping_error_plan_expired": { "other": "Šis planas nebepasiekiamas." },
-  "shopping_payment_method_header": { "other": "Mokėjimo metodai" },
-  "shopping_payment_method_credit_card": { "other": "Kreditinė kortelė" },
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  "shopping_error_stripe_unknown_error": { "other": "Kažkas nutiko su šiuo mokėjimu. Pabandykite dar kartą vėliau." },
-  "shopping_error_payment_complete_failed": { "other": "Mokėjimas buvo atmestas. Uždarykite šį langą ir bandykite dar kartą." },
-
-  "validation_pincode1_required": { "other": "Įveskite galiojantį PIN kodą." },
-  "validation_pincode2_required": { "other": "Įveskite galiojantį PIN kodą." },
-  "validation_pincode1_pattern": { "other": "Įveskite galiojantį PIN kodą." },
-  "validation_pincode2_pattern": { "other": "Įveskite galiojantį PIN kodą." },
-  "validation_pincode2_match": { "other": "PIN kodas nesutampa." },
-
-  "header_banner": { "other": "ABC Cinemas – 21-asis kino festivalis, 2021 m. birželio 1–6 d" }
+  "wcag_skip_links_header": {
+    "other": "Prieinamumo nuorodos"
+  },
+  "wcag_skip_links_content": {
+    "other": "Pereiti prie turinio"
+  },
+  "wcag_homepage_h1": {
+    "other": "Pagrindinis puslapis"
+  },
+  "wcag_carousel_h2": {
+    "other": "Karuselė"
+  },
+  "wcag_collections_h2": {
+    "other": "Kolekcijos"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Poraštė"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Pagrindinis"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Subrendę"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Perjungti navigaciją"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Supakuoti daiktai"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Karuselė"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Puslapių kolekcija"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Kolekcijos sąrašas"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Kolekcijos slankiklis"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Norų sąrašas"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Dalintis Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Bendrinti Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Bendrinkite „LinkedIn“."
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Žiūrėti „Letterboxd“."
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Jūs jau turite šį planą."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Šis planas nebepasiekiamas."
+  },
+  "shopping_payment_method_header": {
+    "other": "Mokėjimo metodai"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Kreditinė kortelė"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Kažkas nutiko su šiuo mokėjimu. Pabandykite dar kartą vėliau."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Mokėjimas buvo atmestas. Uždarykite šį langą ir bandykite dar kartą."
+  },
+  "validation_pincode1_required": {
+    "other": "Įveskite galiojantį PIN kodą."
+  },
+  "validation_pincode2_required": {
+    "other": "Įveskite galiojantį PIN kodą."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Įveskite galiojantį PIN kodą."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Įveskite galiojantį PIN kodą."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN kodas nesutampa."
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21-asis kino festivalis, 2021 m. birželio 1–6 d"
+  }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1,24 +1,41 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Instellingen" },
-  "powered_by": { "other": "Aangedreven door" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.shift72.com" },
-  "in_partnership_with": { "other": "in samenwerking met" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Instellingen"
+  },
+  "powered_by": {
+    "other": "Aangedreven door"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "in samenwerking met"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
   "episode_name": {
     "other": "Aflevering"
   },
-
   "season_name": {
     "other": "Seizoen"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "one seizoen",
     "other": "{{.Count}} seizoen"
   },
@@ -38,192 +55,477 @@
     "one": "1 Aflevering",
     "other": "{{.Count}} Aflevering"
   },
-
-  "date_day": { "other": "Dag" },
-  "date_month": { "other": "Maand" },
-  "date_year": { "other": "Jaar" },
-
-  "404_page_header": { "other": "Deze pagina bestaat niet." },
-  "404_page_content": { "other": "<p>Sorry, het lijkt erop dat de pagina die u zoekt niet bestaat.</p><p>De pagina is misschien verplaatst of verwijderd, of misschien heeft u iets verkeerd gespeld.</p><p>Probeer terug te gaan naar de startpagina om te vinden wat u zoekt.</p><p><a href=\"{{.URL}}\">Terug naar de Startpagina</a></p>" },
-
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "nav_signin": { "other": "Log in" },
-  "nav_signup": { "other": "Maak een account aan" },
-  "nav_signed_in_as": { "other": "Ingelogd als" },
-  "nav_library": { "other": "Mijn Bibliotheek" },
-  "nav_devices": { "other": "Mijn Apparaten" },
-  "nav_wishlist": { "other": "Mijn Lijst" },
-  "nav_account": { "other": "Mijn Account" },
-  "nav_signout": { "other": "Log uit" },
-  "play_trailer": { "other": "Aanhangwagen" },
-  "runtime_hours": { "other": "u" },
-  "runtime_minutes": { "other": "min." },
-
-  "datetime_today": { "other": "Vandaag {{.Date}}" },
-  "datetime_tomorrow": { "other": "Morgen {{.Date}}" },
-  "datetime_yesterday": { "other": "Gisteren {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "Afgelopen {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Zoek" },
-  "search_control_submit": { "other": "Zoekopdracht indienen" },
-
-  "play_button_watch": { "other" : "Kijk nu"},
-  "play_button_resume": { "other" : "Ga verder"},
-
-  "social_media_buttons_title": { "other": "Deel" },
-  "social_media_buttons_facebook": { "other": "Delen op Facebook" },
-  "social_media_buttons_twitter": { "other": "Delen op Twitter" },
-  "social_media_buttons_linkedin": { "other": "Deel op Linkedin" },
-  "social_media_buttons_email": { "other": "Deel via e-mail" },
-  "social_media_buttons_email_subject": { "other": "Link delen" },
-  "social_media_buttons_copied_link": { "other": "Link gekopieerd naar klembord!" },
-  "social_media_buttons_copy_link": { "other": "Kopieer naar klembord" },
-
-  "accept_invite_page_header": { "other": "Welkom " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Het lijkt erop dat u deze uitnodiging al hebt gebruikt. U dient zich hier <a href=\"{{.SigninURL}}\">in te loggen</a>. <a href=\"{{.ForgotPasswordURL}}\">Wachtwoord vergeten?</a>." },
-  "acceptinvite_complete": { "other": "Bedankt. Uw account is aangemaakt." },
-  "acceptinvite_form_submit": { "other": "Aanvaard uitnodiging" },
-  "acceptinvite_agreement": { "other": "Door te klikken op «Aanvaard uitnodiging», verklaart u dat u onze <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; voorwaarden</a> en ons<a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">privacybeleid</a> begrepen heeft en dat u ermee akkoord gaat." },
-
-  "signup_page_header": { "other": "Maak een nieuw account aan" },
-  "signup_form_name": { "other": "Naam" },
-  "signup_form_email": { "other": "E-mailadres" },
-  "signup_form_password": { "other": "Wachtwoord" },
-  "signup_form_password_confirmation": { "other": "Bevestig uw wachtwoord" },
-  "signup_form_gender": { "other": "Geslacht" },
-  "signup_form_dob": { "other": "Geboortedatum" },
-  "signup_form_submit": { "other": "Dien in" },
-
-  "signin_page_header": { "other": "Log in" },
-  "signin_form_email": { "other": "E-mailadres" },
-  "signin_form_password": { "other": "Wachtwoord" },
-  "signin_form_remember": { "other": "Onthoud me" },
-  "signin_form_submit": { "other": "Dien in" },
-  "signin_page_forgotpassword": { "other": "Wachtwoord vergeten?" },
-  "signin_page_createnewaccount": { "other": "Heeft u nog geen account? Maak hier een nieuw account aan." },
-  "signup_page_alreadyhaveanaccount": { "other": "Heeft u al een account? Log hier in." },
-  "signup_form_error_email_already_in_use": { "other": "Dit e-mailadres is al in gebruik." },
-  "signin_form_error_incorrect_credentials": { "other": "De gebruikersnaam of het wachtwoord is niet correct." },
-  "signin_form_error_ip_throttled": { "other": "U heeft te vaak niet ingelogd. Probeer het later opnieuw." },
-  "signin_form_error_account_suspended": { "other": "Uw account is tijdelijk opgeschort. Neem contact op met een beheerder als u denkt dat dit een fout is." },
-
-  "signup_form_error_forbidden": { "other": "Er is een fout opgetreden." },
-
-  "combined_auth_continue": { "other": "Ga verder" },
-  "combined_auth_change": { "other": "verander" },
-  "combined_auth_signin": { "other": "Log in" },
-  "combined_auth_signup": { "other": "Maak een account aan" },
-  "combined_auth_signin_password": { "other": "Vul uw wachtwoord in om in te loggen." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Het wachtwoord is niet correct." },
-  "combined_auth_error_forbidden": { "other": "Er is een fout opgetreden." },
-  "combined_auth_error_too_many_requests": { "other": "Te veel verzoeken, probeer het later opnieuw." },
-
-  "forgotpassword_page_header": { "other": "Stel uw wachtwoord opnieuw in" },
-  "forgotpassword_form_email": { "other": "E-mailadres" },
-  "forgotpassword_form_submit": { "other": "Stel opnieuw in" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Er bestaat geen account dat overeenkomt met dit e-mailadres." },
-  "forgotpassword_form_error_account_suspended": { "other": "Dit account is opgeschort" },
-  "forgotpassword_complete": { "other": "Bedankt. Er zou binnenkort een e-mail over het opnieuw instellen van uw wachtwoord in uw inbox moeten verschijnen." },
-  "forgotpassword_form_error_forbidden": { "other": "Er is een fout opgetreden." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Te veel verzoeken, probeer het later opnieuw." },
-
-  "resetpassword_page_header": { "other": "Verander uw wachtwoord" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Het lijkt erop dat het verzoek voor het opnieuw instellen van uw wachtwoord ongeldig is, vul het <a href=\"{{.URL}}\">Wachtwoord vergeten</a> formulier opnieuw in." },
-  "resetpassword_form_password": { "other": "Nieuw wachtwoord" },
-  "resetpassword_form_password2": { "other": "Bevestig uw nieuw wachtwoord" },
-  "resetpassword_form_submit": { "other": "Verander" },
-  "resetpassword_complete": { "other": "Bedankt. Uw wachtwoord is veranderd en u bent ingelogd." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Het verzoek om uw wachtwoord opnieuw in te stellen is ongeldig. Probeer het later nog eens." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Het token om het wachtwoord opnieuw in te stellen is ongeldig. Probeer het later nog eens." },
-  "resetpassword_form_error_too_many_requests": { "other": "Te veel verzoeken, probeer het later opnieuw." },
-
-  "account_page_header": { "other": "Mijn Account" },
-  "account_form_name": { "other": "Naam" },
-  "account_form_email": { "other": "E-mailadres" },
-  "account_form_password": { "other": "Wachtwoord" },
-  "account_form_change_password": { "other": "Verander" },
-  "account_form_gender": { "other": "Gender" },
-  "account_form_dob": { "other": "Geboortedatum" },
-  "account_form_submit": { "other": "Bijwerken" },
-  "account_form_submitted": { "other": "Bijgewerkt" },
-  "account_form_password_changed": { "other": "Bijgewerkt" },
-  "account_form_error_incorrect_password": { "other": "Dit wachtwoord is niet correct." },
-  "account_form_pin_code": { "other": "PIN" },
-  "account_form_pin_code_not_set": { "other": "Je hebt geen pincode die je nodig hebt voor het kopen, huren en kijken van sommige titels."},
-  "account_form_set_pin": { "other": "Pincode instellen" },
-  "account_form_pin_changed": { "other": "Bijgewerkt" },
-  "account_form_change_pin": { "other": "Wijziging PIN" },
-
-  "user_set_pin_header": { "other": "Stel je PIN" },
-  "user_set_pin_button": { "other": "Stel PIN" },
-  "user_submit_pin_heading": { "other": "Voer uw pincode in om {{.Action}} deze beperkte inhoud " },
-  "user_error_wrong_pin_retry": { "other": "Oeps, je hebt een verkeerde pincode ingevoerd" },
-  "user_error_too_many_pin_errors": { "other": "<p>Het lijkt erop dat je problemen hebt.</p><p>Reset uw pincode of neem contact met ons op voor: <a href=\"{{.HelpURL}}\" target=\"_blank\">helpen</a>" },
-  "user_submit_pin_button": { "other": "Binnenkomen" },
-  "user_reset_pin_button": { "other": "Resetten PIN" },
-
-  "signup_form_optin": {"other": "Schrijf u in voor onze nieuwsbrief" },
-
-  "passwordconfirmation_modal_header": { "other": "Bevestig uw wachtwoord" },
-  "passwordconfirmation_modal_label": { "other": "Gelieve uw wachtwoord in te voeren om de veranderingen bij te werken." },
-  "passwordconfirmation_modal_confirm": { "other": "Bevestigen" },
-
-  "changepassword_modal_header": { "other": "Verander uw wachtwoord" },
-  "changepassword_modal_currentpassword": { "other": "Uw huidig wachtwoord" },
-  "changepassword_modal_password": { "other": "Uw nieuw wachtwoord" },
-  "changepassword_modal_password2": { "other": "Bevestig uw nieuw wachtwoord" },
-  "changepassword_modal_submit": { "other": "Bijwerken" },
-  "changepassword_modal_error_incorrect_password": { "other": "Dit wachtwoord is niet correct." },
-
-  "userlibrary_page_header": { "other": "Mijn Bibliotheek" },
-  "userlibrary_empty_header":  { "other": "Uw bibliotheek is leeg." },
-  "userlibrary_empty_content": { "other": "U kunt uw bibliotheek aanvullen met <a href=\"{{.HomeURL}}\">onze geweldige selectie films</a>" },
-
-  "searchresults_page_header": { "other": "Zoekresultaten" },
-  "searchresults_load_more": { "other": "Laad {{.Count}} meer" },
+  "date_day": {
+    "other": "Dag"
+  },
+  "date_month": {
+    "other": "Maand"
+  },
+  "date_year": {
+    "other": "Jaar"
+  },
+  "404_page_header": {
+    "other": "Deze pagina bestaat niet."
+  },
+  "404_page_content": {
+    "other": "<p>Sorry, het lijkt erop dat de pagina die u zoekt niet bestaat.</p><p>De pagina is misschien verplaatst of verwijderd, of misschien heeft u iets verkeerd gespeld.</p><p>Probeer terug te gaan naar de startpagina om te vinden wat u zoekt.</p><p><a href=\"{{.URL}}\">Terug naar de Startpagina</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Log in"
+  },
+  "nav_signup": {
+    "other": "Maak een account aan"
+  },
+  "nav_signed_in_as": {
+    "other": "Ingelogd als"
+  },
+  "nav_library": {
+    "other": "Mijn Bibliotheek"
+  },
+  "nav_devices": {
+    "other": "Mijn Apparaten"
+  },
+  "nav_wishlist": {
+    "other": "Mijn Lijst"
+  },
+  "nav_account": {
+    "other": "Mijn Account"
+  },
+  "nav_signout": {
+    "other": "Log uit"
+  },
+  "play_trailer": {
+    "other": "Aanhangwagen"
+  },
+  "runtime_hours": {
+    "other": "u"
+  },
+  "runtime_minutes": {
+    "other": "min."
+  },
+  "datetime_today": {
+    "other": "Vandaag {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "Morgen {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "Gisteren {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "Afgelopen {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Zoek"
+  },
+  "search_control_submit": {
+    "other": "Zoekopdracht indienen"
+  },
+  "play_button_watch": {
+    "other": "Kijk nu"
+  },
+  "play_button_resume": {
+    "other": "Ga verder"
+  },
+  "social_media_buttons_title": {
+    "other": "Deel"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Delen op Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Delen op Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Deel op Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Deel via e-mail"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Link delen"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link gekopieerd naar klembord!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Kopieer naar klembord"
+  },
+  "accept_invite_page_header": {
+    "other": "Welkom "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Het lijkt erop dat u deze uitnodiging al hebt gebruikt. U dient zich hier <a href=\"{{.SigninURL}}\">in te loggen</a>. <a href=\"{{.ForgotPasswordURL}}\">Wachtwoord vergeten?</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Bedankt. Uw account is aangemaakt."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Aanvaard uitnodiging"
+  },
+  "acceptinvite_agreement": {
+    "other": "Door te klikken op «Aanvaard uitnodiging», verklaart u dat u onze <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; voorwaarden</a> en ons<a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">privacybeleid</a> begrepen heeft en dat u ermee akkoord gaat."
+  },
+  "signup_page_header": {
+    "other": "Maak een nieuw account aan"
+  },
+  "signup_form_name": {
+    "other": "Naam"
+  },
+  "signup_form_email": {
+    "other": "E-mailadres"
+  },
+  "signup_form_password": {
+    "other": "Wachtwoord"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Bevestig uw wachtwoord"
+  },
+  "signup_form_gender": {
+    "other": "Geslacht"
+  },
+  "signup_form_dob": {
+    "other": "Geboortedatum"
+  },
+  "signup_form_submit": {
+    "other": "Dien in"
+  },
+  "signin_page_header": {
+    "other": "Log in"
+  },
+  "signin_form_email": {
+    "other": "E-mailadres"
+  },
+  "signin_form_password": {
+    "other": "Wachtwoord"
+  },
+  "signin_form_remember": {
+    "other": "Onthoud me"
+  },
+  "signin_form_submit": {
+    "other": "Dien in"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Wachtwoord vergeten?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Heeft u nog geen account? Maak hier een nieuw account aan."
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Heeft u al een account? Log hier in."
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Dit e-mailadres is al in gebruik."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "De gebruikersnaam of het wachtwoord is niet correct."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "U heeft te vaak niet ingelogd. Probeer het later opnieuw."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Uw account is tijdelijk opgeschort. Neem contact op met een beheerder als u denkt dat dit een fout is."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Er is een fout opgetreden."
+  },
+  "combined_auth_continue": {
+    "other": "Ga verder"
+  },
+  "combined_auth_change": {
+    "other": "verander"
+  },
+  "combined_auth_signin": {
+    "other": "Log in"
+  },
+  "combined_auth_signup": {
+    "other": "Maak een account aan"
+  },
+  "combined_auth_signin_password": {
+    "other": "Vul uw wachtwoord in om in te loggen."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Het wachtwoord is niet correct."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Er is een fout opgetreden."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Te veel verzoeken, probeer het later opnieuw."
+  },
+  "forgotpassword_page_header": {
+    "other": "Stel uw wachtwoord opnieuw in"
+  },
+  "forgotpassword_form_email": {
+    "other": "E-mailadres"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Stel opnieuw in"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Er bestaat geen account dat overeenkomt met dit e-mailadres."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Dit account is opgeschort"
+  },
+  "forgotpassword_complete": {
+    "other": "Bedankt. Er zou binnenkort een e-mail over het opnieuw instellen van uw wachtwoord in uw inbox moeten verschijnen."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Er is een fout opgetreden."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Te veel verzoeken, probeer het later opnieuw."
+  },
+  "resetpassword_page_header": {
+    "other": "Verander uw wachtwoord"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Het lijkt erop dat het verzoek voor het opnieuw instellen van uw wachtwoord ongeldig is, vul het <a href=\"{{.URL}}\">Wachtwoord vergeten</a> formulier opnieuw in."
+  },
+  "resetpassword_form_password": {
+    "other": "Nieuw wachtwoord"
+  },
+  "resetpassword_form_password2": {
+    "other": "Bevestig uw nieuw wachtwoord"
+  },
+  "resetpassword_form_submit": {
+    "other": "Verander"
+  },
+  "resetpassword_complete": {
+    "other": "Bedankt. Uw wachtwoord is veranderd en u bent ingelogd."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Het verzoek om uw wachtwoord opnieuw in te stellen is ongeldig. Probeer het later nog eens."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Het token om het wachtwoord opnieuw in te stellen is ongeldig. Probeer het later nog eens."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Te veel verzoeken, probeer het later opnieuw."
+  },
+  "account_page_header": {
+    "other": "Mijn Account"
+  },
+  "account_form_name": {
+    "other": "Naam"
+  },
+  "account_form_email": {
+    "other": "E-mailadres"
+  },
+  "account_form_password": {
+    "other": "Wachtwoord"
+  },
+  "account_form_change_password": {
+    "other": "Verander"
+  },
+  "account_form_gender": {
+    "other": "Gender"
+  },
+  "account_form_dob": {
+    "other": "Geboortedatum"
+  },
+  "account_form_submit": {
+    "other": "Bijwerken"
+  },
+  "account_form_submitted": {
+    "other": "Bijgewerkt"
+  },
+  "account_form_password_changed": {
+    "other": "Bijgewerkt"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Dit wachtwoord is niet correct."
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Je hebt geen pincode die je nodig hebt voor het kopen, huren en kijken van sommige titels."
+  },
+  "account_form_set_pin": {
+    "other": "Pincode instellen"
+  },
+  "account_form_pin_changed": {
+    "other": "Bijgewerkt"
+  },
+  "account_form_change_pin": {
+    "other": "Wijziging PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Stel je PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Stel PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Voer uw pincode in om {{.Action}} deze beperkte inhoud "
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Oeps, je hebt een verkeerde pincode ingevoerd"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Het lijkt erop dat je problemen hebt.</p><p>Reset uw pincode of neem contact met ons op voor: <a href=\"{{.HelpURL}}\" target=\"_blank\">helpen</a>"
+  },
+  "user_submit_pin_button": {
+    "other": "Binnenkomen"
+  },
+  "user_reset_pin_button": {
+    "other": "Resetten PIN"
+  },
+  "signup_form_optin": {
+    "other": "Schrijf u in voor onze nieuwsbrief"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Bevestig uw wachtwoord"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Gelieve uw wachtwoord in te voeren om de veranderingen bij te werken."
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Bevestigen"
+  },
+  "changepassword_modal_header": {
+    "other": "Verander uw wachtwoord"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Uw huidig wachtwoord"
+  },
+  "changepassword_modal_password": {
+    "other": "Uw nieuw wachtwoord"
+  },
+  "changepassword_modal_password2": {
+    "other": "Bevestig uw nieuw wachtwoord"
+  },
+  "changepassword_modal_submit": {
+    "other": "Bijwerken"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Dit wachtwoord is niet correct."
+  },
+  "userlibrary_page_header": {
+    "other": "Mijn Bibliotheek"
+  },
+  "userlibrary_empty_header": {
+    "other": "Uw bibliotheek is leeg."
+  },
+  "userlibrary_empty_content": {
+    "other": "U kunt uw bibliotheek aanvullen met <a href=\"{{.HomeURL}}\">onze geweldige selectie films</a>"
+  },
+  "searchresults_page_header": {
+    "other": "Zoekresultaten"
+  },
+  "searchresults_load_more": {
+    "other": "Laad {{.Count}} meer"
+  },
   "searchresults_total": {
     "one": "Vond 1 resultaat voor \"{{.Query}}\".",
     "other": "Vond {{.Count}} resultaten voor \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "Geen zoekresultaten gevonden voor \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Probeer een andere zoekopdracht of <a href=\"{{.HomeURL}}\">blader door onze inhoud</a> om te vinden wat u zoekt." },
-
-  "validation_name_required": { "other": "Voer uw naam in." },
-  "validation_email_required": { "other": "Voer uw e-mailadres in." },
-  "validation_email_email": { "other": "Voer een geldig e-mailadres in." },
-  "validation_currentpassword_required": { "other": "Voer uw huidige wachtwoord in." },
-  "validation_password_required": { "other": "Voer een wachtwoord in." },
-  "validation_password2_required": { "other": "Bevestig uw wachtwoord." },
-  "validation_password2_match": { "other": "Uw wachtwoorden komen niet overeen." },
-  "validation_password_minlength": { "other": "Gebruik ten minste {{.Count}} tekens." },
-  "validation_promocode_required": { "other": "Voer een promotiecode in." },
-  "validation_pincode_required": { "other": "Voer een pincode in." },
-  "validation_gender_required": { "other": "Selecteer het gender waar u zich het meest mee identificeert." },
-  "validation_dob_required": { "other": "Voer uw geboortedatum in." },
-  "validation_dob_date": { "other": "Voer een geldige geboortedatum in." },
-
-  "shopping_info_subtitle_hd": { "other": "HD Video op aanvraag." },
-  "shopping_info_subtitle_sd": { "other": "SD Video op aanvraag." },
-  "shopping_info_subtitle_wallet": { "other": "Tegoeden in uw portemonnee kunnen worden gebruikt voor de aankoop of huur van inhoud op ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "Meer info over de systeemvereisten" },
-  "shopping_info_ownership_buy": { "other": "koop" },
-  "shopping_info_ownership_rent": { "other": "huur" },
-
-  "shopping_info_sd_only": { "other": "Beperkt tot  SD playback alleen." },
-  "shopping_info_release_date_title": { "other": "Komt uit op {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "U kunt deze film nu al huren, maar u kunt hem pas vanaf dan bekijken." },
-  "shopping_info_release_date_explanation_buy": { "other": "U kunt deze film nu al kopen, maar u kunt hem pas vanaf dan bekijken." },
-
-  "shopping_info_available_until_date_title": { "other": "Beschikbaar tot {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "U zult de inhoud hierna niet meer kunnen bekijken." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "U zult de inhoud hierna niet meer kunnen bekijken." },
-
-  "duration_hour": { "one": "1 uur", "other": "{{.Count}} uur" },
-  "duration_day": { "one": "1 dag", "other": "{{.Count}} dagen" },
-  "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} bekijken " },
-  "shopping_info_watch_window_duration": { "other": "{{.Count}} uur (her)bekijken. " },
+  "searchresults_empty_header": {
+    "other": "Geen zoekresultaten gevonden voor \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Probeer een andere zoekopdracht of <a href=\"{{.HomeURL}}\">blader door onze inhoud</a> om te vinden wat u zoekt."
+  },
+  "validation_name_required": {
+    "other": "Voer uw naam in."
+  },
+  "validation_email_required": {
+    "other": "Voer uw e-mailadres in."
+  },
+  "validation_email_email": {
+    "other": "Voer een geldig e-mailadres in."
+  },
+  "validation_currentpassword_required": {
+    "other": "Voer uw huidige wachtwoord in."
+  },
+  "validation_password_required": {
+    "other": "Voer een wachtwoord in."
+  },
+  "validation_password2_required": {
+    "other": "Bevestig uw wachtwoord."
+  },
+  "validation_password2_match": {
+    "other": "Uw wachtwoorden komen niet overeen."
+  },
+  "validation_password_minlength": {
+    "other": "Gebruik ten minste {{.Count}} tekens."
+  },
+  "validation_promocode_required": {
+    "other": "Voer een promotiecode in."
+  },
+  "validation_pincode_required": {
+    "other": "Voer een pincode in."
+  },
+  "validation_gender_required": {
+    "other": "Selecteer het gender waar u zich het meest mee identificeert."
+  },
+  "validation_dob_required": {
+    "other": "Voer uw geboortedatum in."
+  },
+  "validation_dob_date": {
+    "other": "Voer een geldige geboortedatum in."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Video op aanvraag."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video op aanvraag."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Tegoeden in uw portemonnee kunnen worden gebruikt voor de aankoop of huur van inhoud op ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Meer info over de systeemvereisten"
+  },
+  "shopping_info_ownership_buy": {
+    "other": "koop"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "huur"
+  },
+  "shopping_info_sd_only": {
+    "other": "Beperkt tot  SD playback alleen."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Komt uit op {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "U kunt deze film nu al huren, maar u kunt hem pas vanaf dan bekijken."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "U kunt deze film nu al kopen, maar u kunt hem pas vanaf dan bekijken."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Beschikbaar tot {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "U zult de inhoud hierna niet meer kunnen bekijken."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "U zult de inhoud hierna niet meer kunnen bekijken."
+  },
+  "duration_hour": {
+    "one": "1 uur",
+    "other": "{{.Count}} uur"
+  },
+  "duration_day": {
+    "one": "1 dag",
+    "other": "{{.Count}} dagen"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} bekijken "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} uur (her)bekijken. "
+  },
   "shopping_info_watch_window_explanation_film": {
     "one": "Eenmaal gehuurd, zal de film gedurende {{.ValueUnit}} beschikbaar zijn in uw bibliotheek. ",
     "other": "Eenmaal gehuurd, zal de film gedurende {{.ValueUnit}} beschikbaar zijn in uw bibliotheek. "
@@ -248,69 +550,154 @@
     "one": "Zodra u op play drukt, begint de serie en heeft u 1 uur de tijd om deze zo vaak als u wilt te bekijken.",
     "other": "Zodra u op play drukt, begint de serie en heeft u {{.Count}} uur de tijd om deze zo vaak als u wilt te bekijken."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Bonus" },
-
-  "shopping_enter_card_prompt": { "other": "Vul hieronder uw kredietkaartgegevens in om uw {{.Verb}} af te ronden." },
-
-  "shopping_terms": { "other": "Door deze transactie af te ronden, ga ik akkoord met de <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">voorwaarden</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} korting toegepast." },
-  "shopping_discount_apply": { "other": "Toepassen" },
-  "shopping_discount_code": { "other": "Voer een promotiecode in." },
-  "shopping_discount_have_code": { "other": "Ik heb een promotiecode." },
-
-  "shopping_price_you_pay": { "other": "U betaalt" },
-  "shopping_price_nothing": { "other": "Niets" },
-  "shopping_price_free": { "other": "Gratis" },
-
-  "shopping_auth_directions": { "other": "U heeft eerst een account nodig. Gelieve uw e-mailadres in te vullen." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} staat al in uw bibliotheek." },
-
-  "shopping_error_missing_card": { "other": "Gelieve uw kredietkaartgegevens in te vullen." },
-  "shopping_error_title": { "other": "Er is een fout opgetreden." },
-  "shopping_error_incorrect_cvc": { "other": "Gelieve een geldige veiligheidscode (CVC) in te voeren." },
-  "shopping_error_invalid_cvc": { "other": "Gelieve een geldige veiligheidscode (CVC) in te voeren." },
-  "shopping_error_incorrect_number": { "other": "Gelieve een geldig kaartnummer in te voeren." },
-  "shopping_error_invalid_number": { "other": "Gelieve een geldig kaartnummer in te voeren." },
-  "shopping_error_card_declined": { "other": "De kredietkaart is geweigerd." },
-  "shopping_error_invalid_expiry_month": { "other": "Gelieve een geldige vervaldatum in te vullen." },
-  "shopping_error_invalid_expiry_year": { "other": "Gelieve een geldige vervaldatum in te vullen." },
-  "shopping_error_expired_card": { "other": "De kredietkaart is vervallen." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Uw {{.Ownership}} is niet voltooid. U moet zich in het land van afgifte van uw kredietkaart bevinden. Gelieve een andere kaart te gebruiken voor de betaling." },
-  "shopping_error_proxy_detected": { "other": "Uw {{.Ownership}} is niet voltooid. We hebben ontdekt dat u een unblocker of proxy gebruikt. Schakel alstublieft een van deze diensten uit en probeer het opnieuw." },
-
-  "shopping_error_discount_worn_out": { "other": "Die promotiecode kan niet meer worden gebruikt." },
-  "shopping_error_discount_blank": { "other": "Gelieve een promotiecode in te voeren." },
-  "shopping_error_discount_not_applied": { "other": "Gelieve een geldige promotiecode in te voeren." },
-  "shopping_error_discount_invalid": { "other": "Gelieve een geldige promotiecode in te voeren." },
-  "shopping_error_discount_disabled": { "other": "Gelieve een geldige promotiecode in te voeren." },
-  "shopping_error_discount_already_applied": { "other": "Er is al een promotiecode gebruikt geweest voor deze sessie." },
-  "shopping_error_discount_already_redeemed": { "other": "Deze promotiecode werd reeds gebruikt." },
-  "shopping_error_discount_used_previously": { "other": "Deze promotiecode werd reeds gebruikt." },
-  "shopping_error_discount_max_limit": { "other": "Deze promotiecode kan niet langer gebruikt worden." },
-  "shopping_error_discount_expired": { "other": "Deze promotiecode is vervallen." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Deze promotiecode kan niet gebruikt worden bij een aankoop." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Deze promotiecode kan niet gebruikt worden bij het huren." },
-  "shopping_error_discount_invalid_item": { "other": "Deze promotiecode kan niet gebruikt worden voor dit artikel." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Deze promotiecode kan niet gebruikt worden in uw land." },
-  "shopping_error_discounts_not_allowed": { "other": "Deze promotiecode kan niet gebruikt worden." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Deze promotiecode kan niet gebruikt worden voor bundels." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "De kredietkaart is geweigerd. Gelieve opnieuw te proberen." },
-
-  "shopping_complete_rental": { "other": "Gelukt !" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Bonus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Vul hieronder uw kredietkaartgegevens in om uw {{.Verb}} af te ronden."
+  },
+  "shopping_terms": {
+    "other": "Door deze transactie af te ronden, ga ik akkoord met de <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">voorwaarden</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} korting toegepast."
+  },
+  "shopping_discount_apply": {
+    "other": "Toepassen"
+  },
+  "shopping_discount_code": {
+    "other": "Voer een promotiecode in."
+  },
+  "shopping_discount_have_code": {
+    "other": "Ik heb een promotiecode."
+  },
+  "shopping_price_you_pay": {
+    "other": "U betaalt"
+  },
+  "shopping_price_nothing": {
+    "other": "Niets"
+  },
+  "shopping_price_free": {
+    "other": "Gratis"
+  },
+  "shopping_auth_directions": {
+    "other": "U heeft eerst een account nodig. Gelieve uw e-mailadres in te vullen."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} staat al in uw bibliotheek."
+  },
+  "shopping_error_missing_card": {
+    "other": "Gelieve uw kredietkaartgegevens in te vullen."
+  },
+  "shopping_error_title": {
+    "other": "Er is een fout opgetreden."
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Gelieve een geldige veiligheidscode (CVC) in te voeren."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Gelieve een geldige veiligheidscode (CVC) in te voeren."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Gelieve een geldig kaartnummer in te voeren."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Gelieve een geldig kaartnummer in te voeren."
+  },
+  "shopping_error_card_declined": {
+    "other": "De kredietkaart is geweigerd."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Gelieve een geldige vervaldatum in te vullen."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Gelieve een geldige vervaldatum in te vullen."
+  },
+  "shopping_error_expired_card": {
+    "other": "De kredietkaart is vervallen."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Uw {{.Ownership}} is niet voltooid. U moet zich in het land van afgifte van uw kredietkaart bevinden. Gelieve een andere kaart te gebruiken voor de betaling."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Uw {{.Ownership}} is niet voltooid. We hebben ontdekt dat u een unblocker of proxy gebruikt. Schakel alstublieft een van deze diensten uit en probeer het opnieuw."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Die promotiecode kan niet meer worden gebruikt."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Gelieve een promotiecode in te voeren."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Gelieve een geldige promotiecode in te voeren."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Gelieve een geldige promotiecode in te voeren."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Gelieve een geldige promotiecode in te voeren."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Er is al een promotiecode gebruikt geweest voor deze sessie."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Deze promotiecode werd reeds gebruikt."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Deze promotiecode werd reeds gebruikt."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Deze promotiecode kan niet langer gebruikt worden."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Deze promotiecode is vervallen."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Deze promotiecode kan niet gebruikt worden bij een aankoop."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Deze promotiecode kan niet gebruikt worden bij het huren."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Deze promotiecode kan niet gebruikt worden voor dit artikel."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Deze promotiecode kan niet gebruikt worden in uw land."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Deze promotiecode kan niet gebruikt worden."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Deze promotiecode kan niet gebruikt worden voor bundels."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "De kredietkaart is geweigerd. Gelieve opnieuw te proberen."
+  },
+  "shopping_complete_rental": {
+    "other": "Gelukt !"
+  },
   "shopping_complete_rental_period": {
     "one": "U kunt het item nu de volgende dag zo vaak als u wenst herbekijken.",
     "other": "U kunt het item nu de komende {{.Count}} dagen zo vaak als u wenst herbekijken."
   },
-  "shopping_complete_purchase": { "other": "Bedankt voor uw aankoop van {{.Title}}" },
-  "shopping_complete_credit_purchase": { "other": "Bedankt voor uw aankoop van {{.Title}}. {{.CreditTotal}} is toegevoegd aan uw account." },
-  "shopping_complete_purchase_coming_soon": { "other": "U kunt de film bekijken vanaf {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Er werd een ontvangstbewijs naar uw e-mailadres verstuurd." },
-  "shopping_complete_library_link": { "other": "Begin nu met het bekijken van een van de {{.BundleItems}} in je bibliotheek." },
+  "shopping_complete_purchase": {
+    "other": "Bedankt voor uw aankoop van {{.Title}}"
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Bedankt voor uw aankoop van {{.Title}}. {{.CreditTotal}} is toegevoegd aan uw account."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "U kunt de film bekijken vanaf {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Er werd een ontvangstbewijs naar uw e-mailadres verstuurd."
+  },
+  "shopping_complete_library_link": {
+    "other": "Begin nu met het bekijken van een van de {{.BundleItems}} in je bibliotheek."
+  },
   "shopping_complete_plan": {
     "other": "Uw aankoop van {{ .Title }} was succesvol."
   },
-  
   "shopping_complete_rental_watch_window_start": {
     "one": "U kunt nu binnen de volgende dag beginnen met kijken.",
     "other": "U kunt nu binnen de komende {{.Count}} dagen beginnen met kijken."
@@ -327,158 +714,370 @@
     "one": "U kunt het gehuurde item vanaf {{.Date}} bekijken. De titel blijft 1 dag beschikbaar.",
     "other": "U kunt het gehuurde item vanaf {{.Date}} bekijken. De titel blijft {{.Count}} dagen beschikbaar."
   },
-
-  "shopping_action_rent": { "other": "Huur" },
-  "shopping_action_buy": { "other": "Koop" },
-
-  "meta_detail_cast_title": { "other": "Gips" },
-  "meta_detail_crew_title": { "other": "Bemanning" },
-  "meta_detail_languages": { "one": "Taal", "other": "Talen" },
-  "meta_detail_studios": { "one": "Studio", "other": "Studios" },
-  "meta_detail_countries": { "one": "Land", "other": "Landen" },
-  "meta_detail_subtitles": { "other": "Ondertitels" },
-  "meta_detail_captions": { "other": "Ondertitels [CC]" },
-  "meta_detail_episodes_title": { "other": "Afleveringen" },
-  "meta_detail_bonus_title": { "other": "Bonusinhoud" },
-  "meta_detail_recommendations_title": { "other": "Dit vindt u misschien ook leuk" },
-  "meta_detail_bundle_items_title": { "other": "Inhoud van de bundel" },
-
-  "bundle_items_all_films": { "other": "{{.Count}} films" },
-  "bundle_items_all_seasons": { "other": "{{.Count}} seizoenen" },
-  "bundle_items_mixed": { "other": "{{.Count}} films and seizoenen" },
-  "userwishlist_page_header": { "other": "Mijn Lijst" },
-  "userwishlist_slider_header": { "other": "Mijn Lijst" },
-  "userwishlist_empty_header":  { "other": "Uw lijst is leeg." },
-  "userwishlist_empty_content": { "other": "U kunt uw lijst aanvullen met <a href=\"{{.HomeURL}}\">onze geweldige selectie films</a>." },
-  "userwishlist_button_add": { "other": "Toevoegen aan Mijn Lijst" },
-  "userwishlist_button_remove": { "other": "Mijn Lijst" },
-  "userwishlist_button_add_compact": { "other": "Mijn Lijst" },
-  "userwishlist_button_remove_compact": { "other": "Mijn Lijst" },
-
-  "activatedevice_page_header": { "other": "Apparaat activeren" },
-  "activatedevice_page_content": { "other": "Volg de instructies op uw apparaat om een ​​pincode te krijgen. Uw computer en apparaat moeten beide met internet zijn verbonden om te activeren." },
-  "activatedevice_form_pin": { "other": "PIN Code" },
-  "activatedevice_form_submit": { "other": "Activeren" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN Code niet gevonden, probeer het opnieuw." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN Code niet gevonden, probeer het opnieuw." },
-  "activatedevice_signin_prompt": { "other": "Meld u aan voordat u uw apparaat activeert." },
-  "activatedevice_page_activated": { "other": "Bedankt voor het activeren {{.DeviceName}}. U zou nu op uw televisie of apparaat door uw bibliotheek moeten kunnen bladeren." },
-
-  "userdevices_page_header": { "other": "Apparaten" },
+  "shopping_action_rent": {
+    "other": "Huur"
+  },
+  "shopping_action_buy": {
+    "other": "Koop"
+  },
+  "meta_detail_cast_title": {
+    "other": "Gips"
+  },
+  "meta_detail_crew_title": {
+    "other": "Bemanning"
+  },
+  "meta_detail_languages": {
+    "one": "Taal",
+    "other": "Talen"
+  },
+  "meta_detail_studios": {
+    "one": "Studio",
+    "other": "Studios"
+  },
+  "meta_detail_countries": {
+    "one": "Land",
+    "other": "Landen"
+  },
+  "meta_detail_subtitles": {
+    "other": "Ondertitels"
+  },
+  "meta_detail_captions": {
+    "other": "Ondertitels [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Afleveringen"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Bonusinhoud"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Dit vindt u misschien ook leuk"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Inhoud van de bundel"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} films"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} seizoenen"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} films and seizoenen"
+  },
+  "userwishlist_page_header": {
+    "other": "Mijn Lijst"
+  },
+  "userwishlist_slider_header": {
+    "other": "Mijn Lijst"
+  },
+  "userwishlist_empty_header": {
+    "other": "Uw lijst is leeg."
+  },
+  "userwishlist_empty_content": {
+    "other": "U kunt uw lijst aanvullen met <a href=\"{{.HomeURL}}\">onze geweldige selectie films</a>."
+  },
+  "userwishlist_button_add": {
+    "other": "Toevoegen aan Mijn Lijst"
+  },
+  "userwishlist_button_remove": {
+    "other": "Mijn Lijst"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Mijn Lijst"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Mijn Lijst"
+  },
+  "activatedevice_page_header": {
+    "other": "Apparaat activeren"
+  },
+  "activatedevice_page_content": {
+    "other": "Volg de instructies op uw apparaat om een ​​pincode te krijgen. Uw computer en apparaat moeten beide met internet zijn verbonden om te activeren."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN Code"
+  },
+  "activatedevice_form_submit": {
+    "other": "Activeren"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN Code niet gevonden, probeer het opnieuw."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN Code niet gevonden, probeer het opnieuw."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Meld u aan voordat u uw apparaat activeert."
+  },
+  "activatedevice_page_activated": {
+    "other": "Bedankt voor het activeren {{.DeviceName}}. U zou nu op uw televisie of apparaat door uw bibliotheek moeten kunnen bladeren."
+  },
+  "userdevices_page_header": {
+    "other": "Apparaten"
+  },
   "userdevices_page_content": {
     "one": "Apparaten worden hier automatisch toegevoegd wanneer u ze gebruikt. U kunt 1 apparaat gebruiken.",
     "other": "Apparaten worden hier automatisch toegevoegd wanneer u ze gebruikt. U kunt {{.Count}} apparaten gebruiken."
   },
-  "userdevices_empty_content": { "other": "U heeft momenteel 0 geregistreerde apparaten." },
-  "userdevices_header_type": { "other": "Type apparaat" },
-  "userdevices_header_description": { "other": "Beschrijving" },
-  "userdevices_device_added": { "other": "Op {{.Date}} toegevoegd" },
-  "userdevices_device_actions_delete": { "other": "Verwijderen" },
-  "userdevices_device_actions_cancel": { "other": "Annuleren" },
-  "userdevices_device_actions_confirm": { "other": "Ja, verwijder apparaat" },
-  "userdevices_device_deleted": { "other": "(Verwijderd)" },
-  "userdevices_delete_limits": { "other": "U kunt elke {{.Period}} dag(en) {{.Limit}} apparaat(en) uit deze lijst verwijderen" },
-  "userdevices_delete_limit_reached": { "other": "U heeft deze limiet bereikt en kan momenteel geen apparaten verwijderen. U kunt een apparaat verwijderen op {{.Days}} dag(en)" },
-
-  "playlist_page_header": { "other": "Afspeellijst" },
-  "playlist_sign_in_warning": { "other": "Log in om live tv te kijken."},
-  "playlist_share_title": { "other": "Afspeellijst" },
-  "playlist_up_next_title": { "other": "Volgende" },
-
-  "pricing_ownership_buy": { "other": "Koop" },
-  "pricing_ownership_rent": { "other": "Huur" },
-
-  "classification_intro": { "other": "Classificatie: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Deze site gebruikt cookies om uw surfervaring te verbeteren. Door deze site te gebruiken, gaat u akkoord met <a href=\"{{.CookiePolicyURL}}\">het gebruik van cookies</a>." },
-  "cookie_banner_accept": { "other": "Akkoord" },
-
-  "all_rights_reserved": { "other": "Alle rechten voorbehouden. Niets van deze site mag worden gereproduceerd zonder onze schriftelijke toestemming." },
-
-  "users_gender_none": { "other": "Niet gespecificeerd" },
-  "users_gender_female": { "other": "Vrouw" },
-  "users_gender_male": { "other": "Man" },
-  "users_gender_diverse": { "other": "Non-binair" },
-  "users_gender_other": { "other": "Ander" },
-
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HD alleen" },
-  "pricing_quality_sd_only": { "other": "SD alleen" },
-
-  "shopping_card_save_card": { "other": "Bewaar deze kaart voor toekomstig gebruik" },
-  "shopping_card_button_change": { "other": "Alle opgeslagen kaarten weergeven" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} eindigend in {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(verloopt {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(verlopen)" },
-  "shopping_card_use_other": { "other": "Gebruik een nieuwe kaart" },
-  "shopping_card_use_new_card": { "other": "Kaart wijzigen" },
-  "shopping_card_update_reason_none": { "other": "Werk uw creditcard bij. Ondersteunde kaarten zijn Visa, Mastercard en American Express" },
-  "shopping_card_new_subscription": { "other": "Deze kaart wordt bewaard en regelmatig belast" },
-  "shopping_card_change": { "other": "Creditcard niet correct? <a href=\"{{.SubscriptionsURL}}\">Klik hier om uw kaart bij te werken.</a>" },
-
-  "shopping_info_ownership_plan": { "other": "Abonnement" },
-
-  "shopping_action_credit": { "other": "Opwaarderen" },
-
-  "shopping_info_rental_period_coming_soon": { "other": "vanaf de releasedatum." },
-
-
-  "usersubscriptions_change_payment_method_change": { "other": "Creditcard wijzigen " },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Creditcardgegevens bijwerken" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Bijwerken" },
-
-  "usersubscriptions_subscription_expiry": { "other": "uVerloopt  {{.Expiry}}" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Proeftijd" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Mijn abonnement opzeggen" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Annuleren" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Ja, zeg mijn abonnement op" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Annuleer abonnement" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "Hiermee wordt het abonnement op {{.Name}} maak plannen opgezegd. U kunt de inhoud van het abonnement nog steeds bekijken totdat deze verloopt {{.Expiry}}" },
-
-
-  "availability_coming_soon": { "other": "Binnenkort" },
-  "availability_renting": { "other": "Huren" },
-  "availability_not_available": { "other": "Niet beschikbaar" },
-  "availability_in_watch_window": { "other": "Beschikbaar" },
-  "availability_sold_out": { "other": "Uitverkocht" },
-  "availability_available_till": { "other": "Beschikbaar tot {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Niet beschikbaar" },
-  "availability_available": { "other": "Beschikbaar vanaf {{.ReleaseDate}}" },
-  "availability_expires": { "other": "verloopt {{.Expiry}}" },
-  "availability_expired": { "other": "verlopen"},
-
-  "modal_cancel": { "other": "Annuleren" },
-
-  "play": { "other": "Play" },
-
-  "combined_auth_signin_prompt": { "other": "Log in" },
-  "combined_auth_signup_prompt": { "other": "Registreren" },
-  "combined_auth_terms": { "other": "Ik ga akkoord met alle <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; voorwaarden</a>." },
-  "signup_terms": { "other": "Ik ga akkoord met alle <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; voorwaarden</a>." },
-  "validation_terms_required": { "other": "U moet akkoord gaan met de voorwaarden." },
-  "shopping_error_item_limit_exceeded": { "other": "Jammer genoeg is {{.Title}} uitverkocht." },
-
-  "changepincode_modal_header": { "other": "Verander jouw PIN" },
-  "changepincode_modal_currentpassword": { "other": "je huidige wachtwoord" },
-  "changepincode_modal_pincode1": { "other": "Jij bent nieuw  4 digit PIN" },
-  "changepincode_modal_pincode2": { "other": "Bevestig je nieuwe 4 digit PIN" },
-  "changepincode_modal_submit": { "other": "Set PIN" },
-  "changepincode_modal_error_wrong_password": { "other": "Dat wachtwoord is onjuist." },
-
-  "user_set_pin_intro": { "other": "U heeft een pincode nodig om {{.Action}} beperkte inhoud"},
-  "user_error_wrong_pin_reset": { "other": "Klik hier om uw pincode opnieuw in te stellen" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Deze inhoud is leeftijdsgebonden." },
-  "shopping_error_close_button": { "other": "Oke" },
-
-  "app_badge_title": { "other": "Download de app om uw gekochte inhoud te bekijken!" },
-  "app_badge_ios": { "other": "Te downloaden in de App Store" },
-  "app_badge_android": { "other": "Verkrijg het via Google Play" },
-
+  "userdevices_empty_content": {
+    "other": "U heeft momenteel 0 geregistreerde apparaten."
+  },
+  "userdevices_header_type": {
+    "other": "Type apparaat"
+  },
+  "userdevices_header_description": {
+    "other": "Beschrijving"
+  },
+  "userdevices_device_added": {
+    "other": "Op {{.Date}} toegevoegd"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Verwijderen"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Annuleren"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Ja, verwijder apparaat"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Verwijderd)"
+  },
+  "userdevices_delete_limits": {
+    "other": "U kunt elke {{.Period}} dag(en) {{.Limit}} apparaat(en) uit deze lijst verwijderen"
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "U heeft deze limiet bereikt en kan momenteel geen apparaten verwijderen. U kunt een apparaat verwijderen op {{.Days}} dag(en)"
+  },
+  "playlist_page_header": {
+    "other": "Afspeellijst"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Log in om live tv te kijken."
+  },
+  "playlist_share_title": {
+    "other": "Afspeellijst"
+  },
+  "playlist_up_next_title": {
+    "other": "Volgende"
+  },
+  "pricing_ownership_buy": {
+    "other": "Koop"
+  },
+  "pricing_ownership_rent": {
+    "other": "Huur"
+  },
+  "classification_intro": {
+    "other": "Classificatie: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Deze site gebruikt cookies om uw surfervaring te verbeteren. Door deze site te gebruiken, gaat u akkoord met <a href=\"{{.CookiePolicyURL}}\">het gebruik van cookies</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Akkoord"
+  },
+  "all_rights_reserved": {
+    "other": "Alle rechten voorbehouden. Niets van deze site mag worden gereproduceerd zonder onze schriftelijke toestemming."
+  },
+  "users_gender_none": {
+    "other": "Niet gespecificeerd"
+  },
+  "users_gender_female": {
+    "other": "Vrouw"
+  },
+  "users_gender_male": {
+    "other": "Man"
+  },
+  "users_gender_diverse": {
+    "other": "Non-binair"
+  },
+  "users_gender_other": {
+    "other": "Ander"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD alleen"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD alleen"
+  },
+  "shopping_card_save_card": {
+    "other": "Bewaar deze kaart voor toekomstig gebruik"
+  },
+  "shopping_card_button_change": {
+    "other": "Alle opgeslagen kaarten weergeven"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} eindigend in {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(verloopt {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(verlopen)"
+  },
+  "shopping_card_use_other": {
+    "other": "Gebruik een nieuwe kaart"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Kaart wijzigen"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Werk uw creditcard bij. Ondersteunde kaarten zijn Visa, Mastercard en American Express"
+  },
+  "shopping_card_new_subscription": {
+    "other": "Deze kaart wordt bewaard en regelmatig belast"
+  },
+  "shopping_card_change": {
+    "other": "Creditcard niet correct? <a href=\"{{.SubscriptionsURL}}\">Klik hier om uw kaart bij te werken.</a>"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Abonnement"
+  },
+  "shopping_action_credit": {
+    "other": "Opwaarderen"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "vanaf de releasedatum."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Creditcard wijzigen "
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Creditcardgegevens bijwerken"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Bijwerken"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "uVerloopt  {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Proeftijd"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Mijn abonnement opzeggen"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Annuleren"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Ja, zeg mijn abonnement op"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Annuleer abonnement"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Hiermee wordt het abonnement op {{.Name}} maak plannen opgezegd. U kunt de inhoud van het abonnement nog steeds bekijken totdat deze verloopt {{.Expiry}}"
+  },
+  "availability_coming_soon": {
+    "other": "Binnenkort"
+  },
+  "availability_renting": {
+    "other": "Huren"
+  },
+  "availability_not_available": {
+    "other": "Niet beschikbaar"
+  },
+  "availability_in_watch_window": {
+    "other": "Beschikbaar"
+  },
+  "availability_sold_out": {
+    "other": "Uitverkocht"
+  },
+  "availability_available_till": {
+    "other": "Beschikbaar tot {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Niet beschikbaar"
+  },
+  "availability_available": {
+    "other": "Beschikbaar vanaf {{.ReleaseDate}}"
+  },
+  "availability_expires": {
+    "other": "verloopt {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "verlopen"
+  },
+  "modal_cancel": {
+    "other": "Annuleren"
+  },
+  "play": {
+    "other": "Play"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Log in"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Registreren"
+  },
+  "combined_auth_terms": {
+    "other": "Ik ga akkoord met alle <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; voorwaarden</a>."
+  },
+  "signup_terms": {
+    "other": "Ik ga akkoord met alle <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terms &amp; voorwaarden</a>."
+  },
+  "validation_terms_required": {
+    "other": "U moet akkoord gaan met de voorwaarden."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Jammer genoeg is {{.Title}} uitverkocht."
+  },
+  "changepincode_modal_header": {
+    "other": "Verander jouw PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "je huidige wachtwoord"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Jij bent nieuw  4 digit PIN"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Bevestig je nieuwe 4 digit PIN"
+  },
+  "changepincode_modal_submit": {
+    "other": "Set PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Dat wachtwoord is onjuist."
+  },
+  "user_set_pin_intro": {
+    "other": "U heeft een pincode nodig om {{.Action}} beperkte inhoud"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Klik hier om uw pincode opnieuw in te stellen"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Deze inhoud is leeftijdsgebonden."
+  },
+  "shopping_error_close_button": {
+    "other": "Oke"
+  },
+  "app_badge_title": {
+    "other": "Download de app om uw gekochte inhoud te bekijken!"
+  },
+  "app_badge_ios": {
+    "other": "Te downloaden in de App Store"
+  },
+  "app_badge_android": {
+    "other": "Verkrijg het via Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Prijs"
   },
@@ -550,41 +1149,100 @@
   "donate_button_text": {
     "other": "Doneren"
   },
-  "wcag_skip_links_header": { "other": "Toegankelijkheidslinks" },
-  "wcag_skip_links_content": { "other": "Skip naar Inhoudd" },
-
-  "wcag_homepage_h1": { "other": "Startpagina" },
-  "wcag_carousel_h2": { "other": "Carrousel" },
-  "wcag_collections_h2": { "other": "Collecties" },
-
-  "wcag_aria_label_footer": { "other": "voettekst" },
-  "wcag_aria_label_nav_main": { "other": "Hoofd" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Navigatie wisselen" },
-  "wcag_aria_label_bundle_items": { "other": "Bundelartikelen" },
-  "wcag_aria_label_carousel": { "other": "Carrousel" },
-  "wcag_aria_label_page_collection": { "other": "Page Collecties" },
-  "wcag_aria_label_collection_list": { "other": "Collecties List" },
-  "wcag_aria_label_collection_slider": { "other": "Collecties Slider" },
-  "wcag_aria_label_wishlist": { "other": "verlanglijst" },
-  "wcag_aria_label_facebook": { "other": "Delen op Facebook" },
-  "wcag_aria_label_twitter": { "other": "Delen op Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Delen op LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Uitzicht op Letterboxd" },
-
-  "shopping_error_plan_already_owned": { "other": "Je hebt dit abonnement al." },
-  "shopping_error_plan_expired": { "other": "Dit abonnement is niet langer beschikbaar." },
-  "shopping_payment_method_header": { "other": "Betaalmethoden" },
-  "shopping_payment_method_credit_card": { "other": "Kredietkaart" },
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  "shopping_error_stripe_unknown_error": { "other": "Er is iets misgegaan met deze betaling. Probeer het later opnieuw." },
-  "shopping_error_payment_complete_failed": { "other": "De betaling is geweigerd. Sluit dit venster en probeer het opnieuw." },
-
-  "validation_pincode1_required": { "other": "Voer een geldig PIN code." },
-  "validation_pincode2_required": { "other": "Voer een geldig PIN code." },
-  "validation_pincode1_pattern": { "other": "Voer een geldig PIN code." },
-  "validation_pincode2_pattern": { "other": "Voer een geldig PIN code." },
-  "validation_pincode2_match": { "other": "PIN code komt niet overeen." },
-
-  "header_banner": { "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021" }
+  "wcag_skip_links_header": {
+    "other": "Toegankelijkheidslinks"
+  },
+  "wcag_skip_links_content": {
+    "other": "Skip naar Inhoudd"
+  },
+  "wcag_homepage_h1": {
+    "other": "Startpagina"
+  },
+  "wcag_carousel_h2": {
+    "other": "Carrousel"
+  },
+  "wcag_collections_h2": {
+    "other": "Collecties"
+  },
+  "wcag_aria_label_footer": {
+    "other": "voettekst"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Hoofd"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Navigatie wisselen"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Bundelartikelen"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Carrousel"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Page Collecties"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Collecties List"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Collecties Slider"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "verlanglijst"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Delen op Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Delen op Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Delen op LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Uitzicht op Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Je hebt dit abonnement al."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Dit abonnement is niet langer beschikbaar."
+  },
+  "shopping_payment_method_header": {
+    "other": "Betaalmethoden"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Kredietkaart"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Er is iets misgegaan met deze betaling. Probeer het later opnieuw."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "De betaling is geweigerd. Sluit dit venster en probeer het opnieuw."
+  },
+  "validation_pincode1_required": {
+    "other": "Voer een geldig PIN code."
+  },
+  "validation_pincode2_required": {
+    "other": "Voer een geldig PIN code."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Voer een geldig PIN code."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Voer een geldig PIN code."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN code komt niet overeen."
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021"
+  }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1,592 +1,1248 @@
 {
-    "site_owner": { "other": "ABC Cinemas" },
-    "settings_title": { "other": "Innstillinger" },
-    "powered_by": { "other": "Drevet av" },
-    "powered_by_name": { "other": "Shift72" },
-    "powered_by_url": { "other": "https://www.shift72.com" },
-    "in_partnership_with": { "other": "i samarbeid med" },
-    "festival_scope": { "other": "Festival Scope" },
-    "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-    "en": { "other": "English" },
-    "fr": { "other": "French" },
-  
-    "episode_name": {
-      "other": "Episode"
-    },
-  
-    "season_name": {
-      "other": "Sesong"
-    },
-  
-    "seasons":{
-      "one": "one årstid",
-      "other": "{{.Count}} årstid"
-    },
-    "tvseason": {
-      "other": "{{.ShowInfo.Title}} Serie {{.Season.SeasonNumber}}"
-    },
-    "tvseason_html": {
-      "other": "{{.ShowInfo.Title}} <span>Serie {{.Season.SeasonNumber}}</span>"
-    },
-    "tvepisode": {
-      "other": "{{.Episode.Title}}"
-    },
-    "tvseason_number": {
-      "other": "Serie {{.Season.SeasonNumber}}"
-    },
-    "episode_count": {
-      "one": "1 Episode",
-      "other": "{{.Count}} Episodes"
-    },
-  
-    "date_day": { "other": "Dag" },
-    "date_month": { "other": "Måned" },
-    "date_year": { "other": "År" },
-  
-    "404_page_header": { "other": "Siden finnes ikke..." },
-    "404_page_content": { "other": "<p>Beklager, det ser ut til at siden du forsøker å finne ikke eksisterer.</p><p>Den kan ha blitt flyttet eller slettet, eller kanskje adressen har blitt feilstavet.</p><p>Forsøk å gå tilbake til startsiden for å finne hva du leter etter.</p><p><a href=\"{{.URL}}\">Tilbake til startsiden</a></p>" },
-  
-  
-    "nav_homepage": { "other": "ABC Cinemas" },
-    "nav_signin": { "other": "Logg inn" },
-    "nav_signup": { "other": "Opprett konto" },
-    "nav_signed_in_as": { "other": "Logget inn som" },
-    "nav_library": { "other": "Mine filmer" },
-    "nav_devices": { "other": "Mine enheter" },
-    "nav_wishlist": { "other": "Min liste" },
-    "nav_account": { "other": "Min konto" },
-    "nav_signout": { "other": "Logg ut" },
-    "play_trailer": { "other": "Trailer" },
-    "runtime_hours": { "other": "t" },
-    "runtime_minutes": { "other": "min" },
-  
-    "datetime_today": { "other": "i dag {{.Date}}" },
-    "datetime_tomorrow": { "other": "i morgen {{.Date}}" },
-    "datetime_yesterday": { "other": "i går {{.Date}}" },
-    "datetime_next": { "other": "{{.Date}}" },
-    "datetime_last": { "other": "forrige {{.Date}}" },
-  
-    "search_control_placeholder": { "other": "Søk" },
-    "search_control_submit": { "other": "Søk" },
-  
-    "play_button_watch": { "other" : "Spill av"},
-    "play_button_resume": { "other" : "Fortsett"},
-  
-    "social_media_buttons_title": { "other": "Del" },
-    "social_media_buttons_facebook": { "other": "Del på Facebook" },
-    "social_media_buttons_twitter": { "other": "Del på Twitter" },
-    "social_media_buttons_linkedin": { "other": "Del på Linkedin" },
-    "social_media_buttons_email": { "other": "Del via e-post" },
-    "social_media_buttons_email_subject": { "other": "Linkdeling" },
-    "social_media_buttons_copied_link": { "other": "Linken er kopiert til utklippstavlen!" },
-    "social_media_buttons_copy_link": { "other": "Kopiere til utklippstavle" },
-
-    "accept_invite_page_header": { "other": "Velkommen " },
-    "acceptinvite_form_invalid_reset_password_token": { "other": "Det ser ut til at du allerede har godtatt denne invitasjonen, forsøk i stedet å <a href=\"{{.SigninURL}}\">logge inn</a>. Hvis du har glemt passordet kan du også <a href=\"{{.ForgotPasswordURL}}\">tilbakestille passordet</a>." },
-    "acceptinvite_complete": { "other": "Takk! Din konto er opprettet." },
-    "acceptinvite_form_submit": { "other": "Godta invitasjon" },
-    "acceptinvite_agreement": { "other": "Ved å klikke på Godta invitasjon bekrefter du at du har lest og forstått våre <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">vilkår og betingelser</a>, og våre <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">retningslinjer for personvern</a>." },
-  
-    "signup_page_header": { "other": "Opprett ny konto" },
-    "signup_form_name": { "other": "Navn" },
-    "signup_form_email": { "other": "E-post" },
-    "signup_form_password": { "other": "Passord" },
-    "signup_form_password_confirmation": { "other": "Bekreft passordet ditt" },
-    "signup_form_gender": { "other": "Kjønn" },
-    "signup_form_dob": { "other": "Fødselsdato" },
-    "signup_form_submit": { "other": "Send" },
-  
-    "signin_page_header": { "other": "Logg inn" },
-    "signin_form_email": { "other": "E-post" },
-    "signin_form_password": { "other": "Passord" },
-    "signin_form_remember": { "other": "Husk meg" },
-    "signin_form_submit": { "other": "Send" },
-    "signin_page_forgotpassword": { "other": "Glemt passordet ditt?" },
-    "signin_page_createnewaccount": { "other": "Har du ikke en konto? Opprett en ny konto." },
-    "signup_page_alreadyhaveanaccount": { "other": "Har du allerede en konto? Logg inn." },
-    "signup_form_error_email_already_in_use": { "other": "E-postadressen er allerede i bruk." },
-    "signin_form_error_incorrect_credentials": { "other": "Brukernavn eller passord er feil." },
-    "signin_form_error_ip_throttled": { "other": "Du har mislyktes i å logge på for mange ganger. Prøv igjen senere." },
-    "signin_form_error_account_suspended": { "other": "Kontoen din er midlertidig stengt. Ta kontakt med en administrator hvis du mener dette er feil." },
-  
-    "signup_form_error_forbidden": { "other": "Det har oppstått en feil." },
-  
-    "combined_auth_continue": { "other": "Fortsett" },
-    "combined_auth_change": { "other": "Endre" },
-    "combined_auth_signin": { "other": "Logg inn" },
-    "combined_auth_signup": { "other": "Opprett konto" },
-    "combined_auth_signin_password": { "other": "Vennligst skriv inn passordet ditt for å logge på kontoen din." },
-    "combined_auth_signin_error_incorrect_credentials": { "other": "Passordet stemmer ikke." },
-    "combined_auth_error_forbidden": { "other": "Det har oppstått en feil." },
-    "combined_auth_error_too_many_requests": { "other": "For mange forespørsler. Vær snill å prøv senere." },
-  
-    "forgotpassword_page_header": { "other": "Tilbakestill passord" },
-    "forgotpassword_form_email": { "other": "E-postadresse" },
-    "forgotpassword_form_submit": { "other": "Tilbakestill" },
-    "forgotpassword_form_error_email_doesnt_exist": { "other": "Vi finner ingen kontoer tilknyttet den e-postadressen." },
-    "forgotpassword_form_error_account_suspended": { "other": "Denne kontoen er suspendert." },
-    "forgotpassword_complete": { "other": "Takk skal du ha! Du mottar straks en e-post for å tilbakestille passordet." },
-    "forgotpassword_form_error_forbidden": { "other": "Det har oppstått en feil." },
-    "forgotpassword_form_error_too_many_requests": { "other": "For mange forespørsler. Vær snill å prøv senere." },
-  
-    "resetpassword_page_header": { "other": "Endre passord" },
-    "resetpassword_form_invalid_reset_password_token": { "other": "Det ser ut til at denne forespørselen er ugyldig, vennligst fyll ut skjemaet om <a href=\"{{.URL}}\">tilbakestilling av passord </a> på nytt." },
-    "resetpassword_form_password": { "other": "Nytt passord" },
-    "resetpassword_form_password2": { "other": "Bekreft ditt nye passord" },
-    "resetpassword_form_submit": { "other": "Change" },
-    "resetpassword_complete": { "other": "Takk skal du ha! Ditt passord har blitt endret, og du er nå logget inn." },
-    "resetpassword_form_error_invalid_reset_password_token": { "other": "Forespørselen om tilbakestilling av passord er ikke gyldig. Vennligst prøv igjen senere." },
-    "resetpassword_form_error_reset_password_token_expired": { "other": "Forespørselen om tilbakestilling av passord har gått ut på tid. Vennligst prøv på nytt." },
-    "resetpassword_form_error_too_many_requests": { "other": "For mange forespørsler. Vær snill å prøv senere." },
-  
-    "account_page_header": { "other": "Min konto" },
-    "account_form_name": { "other": "Navn" },
-    "account_form_email": { "other": "E-post" },
-    "account_form_password": { "other": "Passord" },
-    "account_form_change_password": { "other": "Endre" },
-    "account_form_gender": { "other": "Kjønn" },
-    "account_form_dob": { "other": "Fødselsdato" },
-    "account_form_submit": { "other": "Oppdater" },
-    "account_form_submitted": { "other": "Oppdatert" },
-    "account_form_password_changed": { "other": "Oppdatert" },
-    "account_form_error_incorrect_password": { "other": "Passordet stemmer ikke." },
-  
-    "signup_form_optin": {"other": "Meld deg på vårt gratis nyhetsbrev"},
-  
-    "passwordconfirmation_modal_header": { "other": "Bekreft passordet ditt" },
-    "passwordconfirmation_modal_label": { "other": "Vennligst skriv inn passordet ditt for å gjennomføre endringene" },
-    "passwordconfirmation_modal_confirm": { "other": "Bekreft" },
-  
-    "changepassword_modal_header": { "other": "Endre passord" },
-    "changepassword_modal_currentpassword": { "other": "Nåværende passord" },
-    "changepassword_modal_password": { "other": "Nytt passord" },
-    "changepassword_modal_password2": { "other": "Bekreft ditt nye passord" },
-    "changepassword_modal_submit": { "other": "Oppdater" },
-    "changepassword_modal_error_incorrect_password": { "other": "Passordet stemmer ikke." },
-  
-    "userlibrary_page_header": { "other": "Mine filmer" },
-    "userlibrary_empty_header":  { "other": "Ditt bibliotek er tomt." },
-    "userlibrary_empty_content": { "other": "Finn nye filmer ved å <a href=\"{{.HomeURL}}\">bla gjennom </a>vårt store utvalg." },
-  
-    "searchresults_page_header": { "other": "Søkeresultater" },
-    "searchresults_load_more": { "other": "Last inn {{.Count}} til" },
-    "searchresults_total": {
-      "one": "Fant {{.Count}} treff for \"{{.Query}}\".",
-      "other": "Fant ett treff for \"{{.Query}}\"."
-    },
-    "searchresults_empty_header":  { "other": "Fant ingen treff for \"{{.Query}}\"" },
-    "searchresults_empty_content": { "other": "Prøv et nytt søk, eller <a href=\"{{.HomeURL}}\">bla gjennom filmene våre</a> for å finne det du leter etter." },
-  
-    "validation_name_required": { "other": "Vennligst skriv inn navnet ditt." },
-    "validation_email_required": { "other": "Vennligst skriv inn e-postadressen din." },
-    "validation_email_email": { "other": "Vennligst bruk en gyldig e-postadresse." },
-    "validation_currentpassword_required": { "other": "Vennligst skriv inn ditt nåværende passord." },
-    "validation_password_required": { "other": "Vennligst oppgi et passord." },
-    "validation_password2_required": { "other": "Vennligst bekreft passordet ditt." },
-    "validation_password2_match": { "other": "Passordene dine samsvarer ikke." },
-    "validation_password_minlength": { "other": "Passordet må være på minst {{.Count}} tegn." },
-    "validation_promocode_required": { "other": "Vennligst skriv inn en promo-kode." },
-    "validation_pincode_required": { "other": "Please enter a PIN code." },
-    "validation_gender_required": { "other": "Vennligst velg kjønnet du identifiserer deg mest med." },
-    "validation_dob_required": { "other": "Vennligst skriv inn fødselsdatoen din." },
-    "validation_dob_date": { "other": "Vennligst skriv inn en gyldig fødselsdato." },
-  
-    "shopping_info_subtitle_hd": { "other": "HD Video on Demand" },
-    "shopping_info_subtitle_sd": { "other": "SD Video on Demand." },
-    "shopping_info_subtitle_wallet": { "other": "Funds in your Wallet may be used for the purchase or rental of any content on ScreenPlus." },
-    "shopping_info_subtitle_help": { "other": "Se her for systemkrav." },
-    "shopping_info_ownership_buy": { "other": "Kjøp" },
-    "shopping_info_ownership_rent": { "other": "Lei" },
-  
-    "shopping_info_sd_only": { "other": "Bare begrenset til SD-avspilling." },
-    "shopping_info_release_date_title": { "other": "Tilgjengelig fra {{.Date}}. " },
-    "shopping_info_release_date_explanation_rent": { "other": "Du kan leie den nå, men du får ikke sett den før da." },
-    "shopping_info_release_date_explanation_buy": { "other": "Du kan kjøpe den nå, men du får ikke sett den før da." },
-  
-    "shopping_info_available_until_date_title": { "other": "Tilgjengelig til {{.Date}}. " },
-    "shopping_info_available_until_date_explanation_rent": { "other": "Du vil ikke kunne se innholdet etter dette." },
-    "shopping_info_available_until_date_explanation_buy": { "other": "Du vil ikke kunne se innholdet etter dette." },
-  
-    "duration_hour": { "one": "1 time", "other": "{{.Count}} timer" },
-    "duration_day": { "one": "1 dag", "other": "{{.Count}} dager" },
-    "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} leie " },
-    "shopping_info_watch_window_duration": { "other": "{{.Count}} timers avspillingsvindu. " },
-    "shopping_info_watch_window_explanation_film": {
-      "one": "Ved leie av film, vil den være tilgjengelig i kontoen din i {{.ValueUnit}}. ",
-      "other": "Ved leie av film, vil den være tilgjengelig i kontoen din i {{.ValueUnit}}. "
-    },
-    "shopping_info_watch_window_explanation2_film": {
-      "one": "Avspillingsvinduet starter i det du starter filmen, og du har da {{.Count}} timer til å se den så mange ganger du ønsker.",
-      "other": "Avspillingsvinduet starter i det du starter filmen, og du har da én time til å se den så mange ganger du ønsker."
-    },
-    "shopping_info_watch_window_explanation_bundle": {
-      "one": "Ved leie av en samling filmer, vil de være tilgjengelig i kontoen din i {{.Count}} dager. ",
-      "other": "Ved leie av en samling filmer, vil de være tilgjengelig i kontoen din i én dag. "
-    },
-    "shopping_info_watch_window_explanation2_bundle": {
-      "one": "Avspillingsvinduet starter i det du starter en film, og du har da {{.Count}} timer til å se den så mange ganger du ønsker.",
-      "other": "Avspillingsvinduet starter i det du starter en film, og du har da én time til å se den så mange ganger du ønsker."
-    },
-    "shopping_info_watch_window_explanation_season": {
-      "one": "Når den er leid, vil sesongen din være tilgjengelig på kontoen din i en dag. ",
-      "other": "Når den er leid, vil sesongen din være tilgjengelig på kontoen din i en {{.Count}} dag. "
-    },
-    "shopping_info_watch_window_explanation2_season": {
-      "one": "Avspillingsvinduet for en episode starter i det du starter den, og du har da {{.Count}} timer til å se den så mange ganger du ønsker.",
-      "other": "Avspillingsvinduet for en episode starter i det du starter den, og du har da én time til å se den så mange ganger du ønsker."
-    },
-    "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% bonus" },
-  
-    "shopping_enter_card_prompt": { "other": "Skriv inn kredittkortopplysningene dine nedenfor for å fullføre ditt {{.Verb}}." },
-  
-    "shopping_terms": { "other": "Ved å fullføre denne transaksjonen godtar jeg<a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">vilkår og betingelser</a>."},
-    "shopping_discount_applied": { "other": "{{.DiscountAmount}} rabatt brukt." },
-    "shopping_discount_apply": { "other": "Søke om" },
-    "shopping_discount_code": { "other": "Tast inn en promo-kode. " },
-    "shopping_discount_have_code": { "other": "Jeg har en promo-kode. " },
-  
-    "shopping_price_you_pay": { "other": "Du betaler" },
-    "shopping_price_nothing": { "other": "Ingenting" },
-    "shopping_price_free": { "other": "Gratis" },
-  
-    "shopping_auth_directions": { "other": "En konto er nødvendig først. Vennligst skriv inn e-postadressen din." },
-  
-    "shopping_error_in_library": { "other": "{{.Title}} er allerede tilgjengelig i biblioteket ditt." },
-  
-    "shopping_error_missing_card": { "other": "Fyll inn dine kredittkortdetaljer." },
-    "shopping_error_title": { "other": "En feil har oppstått." },
-    "shopping_error_incorrect_cvc": { "other": "Skriv inn en gyldig CVV-kode." },
-    "shopping_error_invalid_cvc": { "other": "Skriv inn en gyldig CVV-kode." },
-    "shopping_error_incorrect_number": { "other": "Skriv inn et gyldig kredittkortnummer." },
-    "shopping_error_invalid_number": { "other": "Skriv inn et gyldig kredittkortnummer." },
-    "shopping_error_card_declined": { "other": "Kredittkortet ble avvist." },
-    "shopping_error_invalid_expiry_month": { "other": "Skriv inn en gyldig utløpsdato." },
-    "shopping_error_invalid_expiry_year": { "other": "Skriv inn en gyldig utløpsdato." },
-    "shopping_error_expired_card": { "other": "Kredittkortet er utløpt." },
-    "shopping_error_creditcard_country_mismatch": { "other": "Ditt {{.Ownership}} er ikke fullført. Du må befinne deg i landet kredittkortet ditt ble utstedt. Vennligst bruk et annet kort for å gjennomføre betalingen." },
-    "shopping_error_proxy_detected": { "other": "Ditt {{.Ownership}} er ikke fullført. Det ble oppdaget bruk av en unblocker eller en proxytjeneste. Vennligst slå av noen av disse tjenestene og prøv på nytt." },
-  
-    "shopping_error_discount_worn_out": { "other": "Den kampanjekoden kan ikke lenger brukes." },
-    "shopping_error_discount_blank": { "other": "Vennligst skriv inn en promo-kode." },
-    "shopping_error_discount_not_applied": { "other": "Vennligst skriv inn en gyldig promo-kode." },
-    "shopping_error_discount_invalid": { "other": "Vennligst skriv inn en gyldig promo-kode." },
-    "shopping_error_discount_disabled": { "other": "Vennligst skriv inn en gyldig promo-kode." },
-    "shopping_error_discount_already_applied": { "other": "En promo-kode har allerede blitt benyttet for denne økten." },
-    "shopping_error_discount_already_redeemed": { "other": "Promo-koden har allerede blitt brukt." },
-    "shopping_error_discount_used_previously": { "other": "Promo-koden har allerede blitt brukt." },
-    "shopping_error_discount_max_limit": { "other": "Promo-koden kan ikke lenger benyttes." },
-    "shopping_error_discount_expired": { "other": "Denne promo-koden er utløpt." },
-    "shopping_error_discount_invalid_ownership_buy": { "other": "Denne promo-koden kan ikke bli brukt til kjøp." },
-    "shopping_error_discount_invalid_ownership_rent": { "other": "Denne promo-koden kan ikke bli brukt til leie." },
-    "shopping_error_discount_invalid_item": { "other": "Promo-koden kan ikke benyttes for denne filmen." },
-    "shopping_error_discount_invalid_pricing_region": { "other": "Promo-koden kan ikke benyttes i ditt land." },
-    "shopping_error_discounts_not_allowed": { "other": "Denne promo-koden kan ikke benyttes." },
-    "shopping_error_discount_disallowed_on_bundles": { "other": "Denne promo-koden kan ikke benyttes til samlinger." },
-    "shopping_error_payment_intent_authentication_failure": { "other": "Kredittkortet har blitt avvist. Vennligst prøv igjen." },
-  
-    "shopping_complete_rental": { "other": "Vellykket!" },
-    "shopping_complete_rental_period": {
-      "one": "Du kan nå se filmen så mange ganger du ønsker de neste {{.Count}} dagene.",
-      "other": "Du kan se filmen så mange ganger du ønsker den neste dagen."
-    },
-    "shopping_complete_purchase": { "other": "Takk for at du kjøpte {{.Title}}." },
-    "shopping_complete_credit_purchase": { "other": "Takk for at du kjøpte {{.Title}}, {{.CreditTotal}} har blitt lagt til kontoen din." },
-    "shopping_complete_purchase_coming_soon": { "other": "Du kan se filmen fra {{.Date}}." },
-    "shopping_complete_receipt": { "other": "En kvittering har blitt sendt til deg per e-post." },
-    "shopping_complete_library_link": { "other": "Start med å se noe fra {{.BundleItems}} i biblioteket ditt nå." },
-    "shopping_complete_plan": {
-      "other": "Kjøpet av {{ .Title }} var vellykket."
-    },
-    "shopping_complete_rental_watch_window_start": {
-      "one": "Du kan nå se den om {{.Count}} dager.",
-      "other": "You are now able to start watching it within the next {{.Count}} days."
-    },
-    "shopping_complete_rental_watch_window_end": {
-      "one": "Når du starter avspillingen, vil du ha {{.Count}} timer til å se filmen så mange ganger du vil.",
-      "other": "Når du starter avspillingen, vil du ha én time til å se filmen så mange ganger du vil."
-    },
-    "shopping_complete_rental_coming_soon": {
-      "one": "Du vil kunne se filmen fra {{.Date}}, og din leieperiode er aktiv i {{.Count}} dager.",
-      "other": "Du vil kunne se filmen fra {{.Date}}, og din leieperiode er aktiv i én dag."
-    },
-    "shopping_complete_rental_coming_soon_watch_window_start": {
-      "one": "Du vil kunne se filmen fra {{.Date}}, og din leieperiode er aktiv i {{.Count}} dager.",
-      "other": "Du vil kunne se filmen fra {{.Date}}, og din leieperiode er aktiv i én dag."
-    },
-  
-    "shopping_action_rent": { "other": "Leie" },
-    "shopping_action_buy": { "other": "Kjøpe" },
-  
-    "meta_detail_cast_title": { "other": "Medvirkende" },
-    "meta_detail_crew_title": { "other": "Filmteam" },
-    "meta_detail_languages": { "one": "Språk", "other": "Språk" },
-    "meta_detail_studios": { "one": "Distributører", "other": "Distributør" },
-    "meta_detail_countries": { "one": "Land", "other": "Land" },
-    "meta_detail_subtitles": { "other": "Undertekster" },
-    "meta_detail_captions": { "other": "Undertekster [CC]" },
-    "meta_detail_episodes_title": { "other": "Episoder" },
-    "meta_detail_bonus_title": { "other": "Bonusinnhold" },
-    "meta_detail_recommendations_title": { "other": "Relaterte filmer" },
-    "meta_detail_bundle_items_title": { "other": "Innholdet i denne samlingen" },
-  
-    "bundle_items_all_films": { "other": "{{.Count}} filmer" },
-    "bundle_items_all_seasons": { "other": "{{.Count}} sesonger" },
-    "bundle_items_mixed": { "other": "{{.Count}} filmer og sesonger" },
-    "userwishlist_page_header": { "other": "Min liste" },
-    "userwishlist_slider_header": { "other": "Min liste" },
-    "userwishlist_empty_header":  { "other": "Listen er tom." },
-    "userwishlist_empty_content": { "other": "Fyll den ved å <a href=\"{{.HomeURL}}\">bla gjennom</a> vårt store utvalg!" },
-    "userwishlist_button_add": { "other": "Legg til i listen min" },
-    "userwishlist_button_remove": { "other": "Min liste" },
-    "userwishlist_button_add_compact": { "other": "Min liste" },
-    "userwishlist_button_remove_compact": { "other": "Min liste" },
-  
-    "activatedevice_page_header": { "other": "Aktiver enheten" },
-    "activatedevice_page_content": { "other": "Følg instruksjonene på enheten for å få en PIN-kode. Datamaskinen og enheten må begge være koblet til internett for å aktiveres." },
-    "activatedevice_form_pin": { "other": "PIN Code" },
-    "activatedevice_form_submit": { "other": "aktivere" },
-    "activatedevice_form_error_invalid_code": { "other": "Finner ikke PIN-koden, prøv igjen." },
-    "activatedevice_form_error_pin_not_found": { "other": "Finner ikke PIN-koden, prøv igjen." },
-    "activatedevice_signin_prompt": { "other": "Logg på før du aktiverer enheten." },
-    "activatedevice_page_activated": { "other": "Takk for at du aktiverer {{.DeviceName}}. Du skal nå kunne bla gjennom biblioteket ditt på TV-en eller enheten." },
-  
-    "userdevices_page_header": { "other": "Enheter" },
-    "userdevices_page_content": {
-      "one": "Enheter vil automatisk bli lagt til her når du bruker dem. Du er begrenset til {{.Count}} enheter.",
-      "other": "Enheter vil automatisk bli lagt til her når du bruker dem. Du er begrenset til én enhet."
-    },
-    "userdevices_empty_content": { "other": "Du har for øyeblikket 0 registrerte enheter." },
-    "userdevices_header_type": { "other": "Enhetstype" },
-    "userdevices_header_description": { "other": "Beskrivelse" },
-    "userdevices_device_added": { "other": "Lagt til {{.Date}}" },
-    "userdevices_device_actions_delete": { "other": "Fjern" },
-    "userdevices_device_actions_cancel": { "other": "Avbryt" },
-    "userdevices_device_actions_confirm": { "other": "Ja, fjern enhet" },
-    "userdevices_device_deleted": { "other": "(Fjernet)" },
-  
-    "playlist_page_header": { "other": "Spilleliste" },
-    "playlist_sign_in_warning": { "other": "Logg på for å se direktesendt TV."},
-    "playlist_share_title": { "other": "Spilleliste" },
-    "playlist_up_next_title": { "other": "Neste" },
-  
-    "pricing_ownership_buy": { "other": "Kjøp" },
-    "pricing_ownership_rent": { "other": "Lei" },
-  
-    "classification_intro": { "other": "Aldersgrense: " },
-    "classification_divider": { "other": " - " },
-    "classification_outro": { "other": "" },
-  
-    "cookie_banner_message": { "other": "Dette nettstedet bruker informasjonskapsler for å forbedre din opplevelse. Ved å bruke dette nettstedet aksepterer du <a href=\"{{.CookiePolicyURL}}\">bruk av informasjonskapsler</a>." },
-    "cookie_banner_accept": { "other": "Aksepterer" },
-  
-    "all_rights_reserved": { "other": "Alle rettigheter forbeholdes. Ingen deler av dette nettstedet kan reproduseres uten skriftlig tillatelse." },
-  
-    "users_gender_none": { "other": "Ikke valgt" },
-    "users_gender_female": { "other": "Kvinne" },
-    "users_gender_male": { "other": "Mann" },
-    "users_gender_diverse": { "other": "Ikke-binær" },
-    "users_gender_other": { "other": "Uspesifisert" },
-  
-    "pricing_quality_hd": { "other": "HD" },
-    "pricing_quality_sd": { "other": "SD" },
-    "pricing_quality_hd_only": { "other": "HD kun" },
-    "pricing_quality_sd_only": { "other": "SD kun" },
-  
-    "shopping_card_save_card": { "other": "Lagre dette kortet for fremtidig bruk" },
-    "shopping_card_button_change": { "other": "Vis alle lagrede kort" },
-    "shopping_card_existing_description": { "other": "{{.Card.Brand}} slutter om {{.Card.Number}}" },
-    "shopping_card_existing_expiry": { "other": "(utløper {{.Card.Expiry}})" },
-    "shopping_card_existing_expired": { "other": "(utløpt)" },
-    "shopping_card_use_other": { "other": "Bruk et nytt kort" },
-    "shopping_card_use_new_card": { "other": "Bytt kort" },
-  
-    "shopping_info_ownership_plan": { "other": "Intekening" },
-  
-    "shopping_action_credit": { "other": "fylle opp" },
-    "shopping_info_rental_period_coming_soon": { "other": "fra datoen og tidspunktet for utgivelsen." },
-  
-    "usersubscriptions_change_payment_method_change": { "other": "Bytt kredittkort" },
-    "usersubscriptions_change_payment_method_modal_title": { "other": "Oppdater kredittkortdetaljer" },
-    "usersubscriptions_change_payment_method_modal_submit": { "other": "Oppdater" },
-  
-    "usersubscriptions_subscription_expiry": { "other": "Utløper" },
-    "usersubscriptions_subscription_status_trialing": { "other": "Prøveperiode" },
-    "usersubscriptions_subscription_unsubscribe": { "other": "Si opp abonnementet mitt" },
-    "usersubscriptions_unsubscribe_modal_cancel": { "other": "Avbryt" },
-    "usersubscriptions_unsubscribe_modal_confirm": { "other": "Ja, kanseller abonnementet mitt" },
-    "usersubscriptions_unsubscribe_modal_title": { "other": "Avbestille abonnementet?" },
-    "usersubscriptions_unsubscribe_modal_body": { "other": "Dette vil kansellere abonnementet på {{.Name}} Du vil fortsatt kunne se innholdet i planen til den utløper {{.Expiry}}." },
-    
-    "shopping_card_update_reason_none": { "other": "Oppdater kredittkortet ditt. Støttede kort er Visa, Mastercard og American Expresse" },
-  
-    "availability_coming_soon": { "other": "Kommer snart" },
-    "availability_renting": { "other": "Kan leies" },
-    "availability_not_available": { "other": "Ikke tilgjengelig" },
-    "availability_in_watch_window": { "other": "Tilgjengelig" },
-    "availability_sold_out": { "other": "Utsolgt" },
-    "availability_available_till": { "other": "Tilgjengelig til {{.ExpiryDate}}" },
-    "availability_not_available_in_country": { "other": "Ikke tilgjengelig" },
-    "availability_available": { "other": "Tilgjengelig fra {{.ReleaseDate}}" },
-  
-    "modal_cancel": { "other": "Avbryt" },
-  
-    "play": { "other": "Spill av" },
-  
-    "combined_auth_signin_prompt": { "other": "Logg inn" },
-    "combined_auth_signup_prompt": { "other": "Opprett konto" },
-    "combined_auth_terms": { "other": "Jeg godtar alle <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">vilkår og betingelser</a>." },
-    "signup_terms": { "other": "Jeg godtar alle <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">vilkår og betingelser</a>." },
-    "validation_terms_required": { "other": "Du må godta vilkårene og betingelsene." },
-    "shopping_error_item_limit_exceeded": { "other": "Dessverre er det utsolgt for visninger av {{.Title}}." },
-
-    "shopping_card_change": { "other": "Kredittkortet er feil? <a href=\"{{.SubscriptionsURL}}\">Klikk her for å oppdatere kortet ditt.</a>" },
-
-    "user_error_too_many_pin_errors": { "other": "<p>Ser ut som du har problemer.</p><p>Tilbakestill PIN-koden eller kontakt oss for <a href=\"{{.HelpURL}}\" target=\"_blank\">hjelp</a>" },
-
-    "app_badge_title": { "other": "Last ned appen for å se innholdet du har kjøpt!" },
-    "app_badge_ios": { "other": "Last ned på App Store" },
-    "app_badge_android": { "other": "Få den på Google Play" },
-
-    "shopping_price_title_plan": {
-      "other": "Pris"
-    },
-    "shopping_price_plan_note": {
-      "zero": "Lades hvert {{ .Interval }} .",
-      "one": "Belastet hvert {{ .Interval }} etter at den 24-timers gratis prøveperioden er over.",
-      "other": "Belastet hvert {{ .Interval }} etter at {{ .Count }} dager avsluttes."
-    },
-    "shopping_price_plan_note_interval": {
-      "one": "{{ .Interval }}",
-      "other": "{{ .Count }} {{ .Interval }}"
-    },
-    "shopping_enter_card_prompt_plan": {
-      "other": "Skriv inn kredittkortopplysningene dine nedenfor for å starte abonnementet."
-    },
-    "shopping_action_plan": {
-      "other": "Fullstendig"
-    },
-    "shopping_complete_subscription": {
-      "other": "Abonnementskjøpet var vellykket. Du abonnerer nå på {{ .Title }} ."
-    },
-    "shopping_complete_subscription_browse": {
-      "other": "<a href=\"/\">Bla deg gjerne rundt</a> på siden, eller <a href=\"/search.html\">søk</a> etter noe spesifikt."
-    },
-    "shopping_info_plan_offer": {
-      "one": "{{ .Interval }} automatisk hver .Interval",
-      "other": "{{ .Count }} automatisk hver {{ .Interval }}"
-    },
-    "shopping_info_trial_period_offer": {
-      "one": "Prøv din gratis 24-timers prøveversjon nå!",
-      "other": "Prøv din gratis {{ .Count }} day prøveversjon!"
-    },
-    "plans_page_header": {
-      "other": "Tilgjengelige planer"
-    },
-    "plan_label_owned": {
-      "other": "Du eier denne planen"
-    },
-    "plan_expiry_date": {
-      "other": "Salg stenger:"
-    },
-    "plan_read_more": {
-      "other": "Finne ut mer"
-    },
-    "plan_page_read_more": {
-      "other": "Les mer"
-    },
-    "plan_page_header_text": {
-      "other": "Nyt {{ .Name }}"
-    },
-    "page_plan_explore_intro": {
-      "other": "ELLER"
-    },
-    "page_plan_explore_link": {
-      "other": "Utforsk andre pass"
-    },
-    "plan_showcase_page_ownership_button_buy": {
-      "other": "Kjøp nå"
-    },
-    "plan_free_link_text": {
-      "other": "Registrer deg gratis"
-    },
-    "awards_in_competition": {
-      "other": "I konkurranse"
-    },
-    "awards_winner": {
-      "other": "Vinner"
-    },
-    "donate_button_text": {
-      "other": "Doneren"
-    },
-
-    "wcag_skip_links_header": { "other": "Tilgjengelighetslenker" },
-    "wcag_skip_links_content": { "other": "Hopp til innholdet" },
-  
-    "wcag_homepage_h1": { "other": "Hjemmeside" },
-    "wcag_carousel_h2": { "other": "Karusell" },
-    "wcag_collections_h2": { "other": "Samlinger" },
-  
-    "wcag_aria_label_footer": { "other": "Bunntekst" },
-    "wcag_aria_label_nav_main": { "other": "Hoved" },
-    "wcag_aria_label_nav_sub": { "other": "Sub" },
-    "wcag_aria_label_toggle_nav": { "other": "Slå på navigering" },
-    "wcag_aria_label_bundle_items": { "other": "Bunt varers" },
-    "wcag_aria_label_carousel": { "other": "Karusell" },
-    "wcag_aria_label_page_collection": { "other": "Page Karusell" },
-    "wcag_aria_label_collection_list": { "other": "Karusell List" },
-    "wcag_aria_label_collection_slider": { "other": "Karusell Slider" },
-    "wcag_aria_label_wishlist": { "other": "Ønskeliste" },
-    "wcag_aria_label_facebook": { "other": "Dele påFacebook" },
-    "wcag_aria_label_twitter": { "other": "Dele på Twitter" },
-    "wcag_aria_label_linkedin": { "other": "Dele på LinkedIn" },
-    "wcag_aria_label_letterboxd": { "other": "Dele på Letterboxd" },
-    
-    "shopping_error_plan_already_owned": { "other": "Du har allerede denne planen." },
-    "shopping_error_plan_expired": { "other": "Denne planen er ikke lenger tilgjengelig." },
-    "shopping_payment_method_header": { "other": "Betalingsmetoder" },
-    "shopping_payment_method_credit_card": { "other": "Kredittkort" },
-    "shopping_payment_method_giropay": { "other": "Giropay" },
-    "shopping_error_stripe_unknown_error": { "other": "Noe gikk galt med denne betalingen. Prøv igjen senere." },
-    "shopping_error_payment_complete_failed": { "other": "Betalingen ble avvist. Lukk dette vinduet og prøv igjen." },
-    "header_banner": { "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021" },
-
-    "account_form_pin_code": { "other": "PIN" },
-    "account_form_pin_code_not_set": { "other": "Du har ikke en PIN-kode, som kreves for å kjøpe, leie og se noen titler."},
-    "account_form_set_pin": { "other": "Set PIN" },
-    "account_form_pin_changed": { "other": "Oppdatert" },
-    "account_form_change_pin": { "other": "Endring PIN" },
-
-    "user_set_pin_header": { "other": "Still inn din PIN" },
-    "user_set_pin_button": { "other": "Still PIN" },
-    "user_submit_pin_heading": { "other": "Skriv inn PIN-koden til {{.Action}}dette begrensede innholdet" },
-    "user_error_wrong_pin_retry": { "other": "Beklager, du har skrevet inn feil PIN" },
-    "user_submit_pin_button": { "other": "Tast inn" },
-    "user_reset_pin_button": { "other": "Nullstille PIN" },
-
-    "validation_pincode1_required": { "other": "Vennligst skriv inn en gyldig PIN-kode." },
-    "validation_pincode2_required": { "other": "Vennligst skriv inn en gyldig PIN-kode." },
-    "validation_pincode1_pattern": { "other": "Vennligst skriv inn en gyldig PIN-kode." },
-    "validation_pincode2_pattern": { "other": "Vennligst skriv inn en gyldig PIN-kode." },
-    "validation_pincode2_match": { "other": "PIN-kode passer ikke." },
-  
-    "userdevices_delete_limits": { "other": "Du kan fjerne {{.Limit}} device(s) fra denne listen hver {{.Period}} dag(s)."},
-    "userdevices_delete_limit_reached": { "other": "Du har nådd denne grensen og kan ikke fjerne noen enheter akkurat nå. Du kan slette en enhet om {{.Days}} dag(s)." },
-    "shopping_card_new_subscription": { "other": "Dette kortet vil bli lagret og belastet regelmessig" },
-
-  "changepincode_modal_header": { "other": "Forandre din PIN" },
-  "changepincode_modal_currentpassword": { "other": "Ditt nåværende passord" },
-  "changepincode_modal_pincode1": { "other": "Din nye 4-sifrede PIN-kode" },
-  "changepincode_modal_pincode2": { "other": "Bekreft din nye 4-sifrede PIN-kode" },
-  "changepincode_modal_submit": { "other": "Sett PIN" },
-  "changepincode_modal_error_wrong_password": { "other": "Det passordet er feil." },
-
-  "user_set_pin_intro": { "other": "Du trenger en PIN-kode for å{{.Action}} begrenset innhold"},
-  "user_error_wrong_pin_reset": { "other": "Klikk her for å tilbakestille PIN-koden din" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Dette innholdet er aldersbegrenset." },
-  "shopping_error_close_button": { "other": "OK" },
-
-  "availability_expires": { "other": "Utløper {{.Expiry}}" },
-  "availability_expired": { "other": "Utløpt"}
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Innstillinger"
+  },
+  "powered_by": {
+    "other": "Drevet av"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "i samarbeid med"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
+  "episode_name": {
+    "other": "Episode"
+  },
+  "season_name": {
+    "other": "Sesong"
+  },
+  "seasons": {
+    "one": "one årstid",
+    "other": "{{.Count}} årstid"
+  },
+  "tvseason": {
+    "other": "{{.ShowInfo.Title}} Serie {{.Season.SeasonNumber}}"
+  },
+  "tvseason_html": {
+    "other": "{{.ShowInfo.Title}} <span>Serie {{.Season.SeasonNumber}}</span>"
+  },
+  "tvepisode": {
+    "other": "{{.Episode.Title}}"
+  },
+  "tvseason_number": {
+    "other": "Serie {{.Season.SeasonNumber}}"
+  },
+  "episode_count": {
+    "one": "1 Episode",
+    "other": "{{.Count}} Episodes"
+  },
+  "date_day": {
+    "other": "Dag"
+  },
+  "date_month": {
+    "other": "Måned"
+  },
+  "date_year": {
+    "other": "År"
+  },
+  "404_page_header": {
+    "other": "Siden finnes ikke..."
+  },
+  "404_page_content": {
+    "other": "<p>Beklager, det ser ut til at siden du forsøker å finne ikke eksisterer.</p><p>Den kan ha blitt flyttet eller slettet, eller kanskje adressen har blitt feilstavet.</p><p>Forsøk å gå tilbake til startsiden for å finne hva du leter etter.</p><p><a href=\"{{.URL}}\">Tilbake til startsiden</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Logg inn"
+  },
+  "nav_signup": {
+    "other": "Opprett konto"
+  },
+  "nav_signed_in_as": {
+    "other": "Logget inn som"
+  },
+  "nav_library": {
+    "other": "Mine filmer"
+  },
+  "nav_devices": {
+    "other": "Mine enheter"
+  },
+  "nav_wishlist": {
+    "other": "Min liste"
+  },
+  "nav_account": {
+    "other": "Min konto"
+  },
+  "nav_signout": {
+    "other": "Logg ut"
+  },
+  "play_trailer": {
+    "other": "Trailer"
+  },
+  "runtime_hours": {
+    "other": "t"
+  },
+  "runtime_minutes": {
+    "other": "min"
+  },
+  "datetime_today": {
+    "other": "i dag {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "i morgen {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "i går {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "forrige {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Søk"
+  },
+  "search_control_submit": {
+    "other": "Søk"
+  },
+  "play_button_watch": {
+    "other": "Spill av"
+  },
+  "play_button_resume": {
+    "other": "Fortsett"
+  },
+  "social_media_buttons_title": {
+    "other": "Del"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Del på Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Del på Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Del på Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Del via e-post"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Linkdeling"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Linken er kopiert til utklippstavlen!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Kopiere til utklippstavle"
+  },
+  "accept_invite_page_header": {
+    "other": "Velkommen "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Det ser ut til at du allerede har godtatt denne invitasjonen, forsøk i stedet å <a href=\"{{.SigninURL}}\">logge inn</a>. Hvis du har glemt passordet kan du også <a href=\"{{.ForgotPasswordURL}}\">tilbakestille passordet</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Takk! Din konto er opprettet."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Godta invitasjon"
+  },
+  "acceptinvite_agreement": {
+    "other": "Ved å klikke på Godta invitasjon bekrefter du at du har lest og forstått våre <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">vilkår og betingelser</a>, og våre <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">retningslinjer for personvern</a>."
+  },
+  "signup_page_header": {
+    "other": "Opprett ny konto"
+  },
+  "signup_form_name": {
+    "other": "Navn"
+  },
+  "signup_form_email": {
+    "other": "E-post"
+  },
+  "signup_form_password": {
+    "other": "Passord"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Bekreft passordet ditt"
+  },
+  "signup_form_gender": {
+    "other": "Kjønn"
+  },
+  "signup_form_dob": {
+    "other": "Fødselsdato"
+  },
+  "signup_form_submit": {
+    "other": "Send"
+  },
+  "signin_page_header": {
+    "other": "Logg inn"
+  },
+  "signin_form_email": {
+    "other": "E-post"
+  },
+  "signin_form_password": {
+    "other": "Passord"
+  },
+  "signin_form_remember": {
+    "other": "Husk meg"
+  },
+  "signin_form_submit": {
+    "other": "Send"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Glemt passordet ditt?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Har du ikke en konto? Opprett en ny konto."
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Har du allerede en konto? Logg inn."
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "E-postadressen er allerede i bruk."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Brukernavn eller passord er feil."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Du har mislyktes i å logge på for mange ganger. Prøv igjen senere."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Kontoen din er midlertidig stengt. Ta kontakt med en administrator hvis du mener dette er feil."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Det har oppstått en feil."
+  },
+  "combined_auth_continue": {
+    "other": "Fortsett"
+  },
+  "combined_auth_change": {
+    "other": "Endre"
+  },
+  "combined_auth_signin": {
+    "other": "Logg inn"
+  },
+  "combined_auth_signup": {
+    "other": "Opprett konto"
+  },
+  "combined_auth_signin_password": {
+    "other": "Vennligst skriv inn passordet ditt for å logge på kontoen din."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Passordet stemmer ikke."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Det har oppstått en feil."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "For mange forespørsler. Vær snill å prøv senere."
+  },
+  "forgotpassword_page_header": {
+    "other": "Tilbakestill passord"
+  },
+  "forgotpassword_form_email": {
+    "other": "E-postadresse"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Tilbakestill"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Vi finner ingen kontoer tilknyttet den e-postadressen."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Denne kontoen er suspendert."
+  },
+  "forgotpassword_complete": {
+    "other": "Takk skal du ha! Du mottar straks en e-post for å tilbakestille passordet."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Det har oppstått en feil."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "For mange forespørsler. Vær snill å prøv senere."
+  },
+  "resetpassword_page_header": {
+    "other": "Endre passord"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Det ser ut til at denne forespørselen er ugyldig, vennligst fyll ut skjemaet om <a href=\"{{.URL}}\">tilbakestilling av passord </a> på nytt."
+  },
+  "resetpassword_form_password": {
+    "other": "Nytt passord"
+  },
+  "resetpassword_form_password2": {
+    "other": "Bekreft ditt nye passord"
+  },
+  "resetpassword_form_submit": {
+    "other": "Change"
+  },
+  "resetpassword_complete": {
+    "other": "Takk skal du ha! Ditt passord har blitt endret, og du er nå logget inn."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Forespørselen om tilbakestilling av passord er ikke gyldig. Vennligst prøv igjen senere."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Forespørselen om tilbakestilling av passord har gått ut på tid. Vennligst prøv på nytt."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "For mange forespørsler. Vær snill å prøv senere."
+  },
+  "account_page_header": {
+    "other": "Min konto"
+  },
+  "account_form_name": {
+    "other": "Navn"
+  },
+  "account_form_email": {
+    "other": "E-post"
+  },
+  "account_form_password": {
+    "other": "Passord"
+  },
+  "account_form_change_password": {
+    "other": "Endre"
+  },
+  "account_form_gender": {
+    "other": "Kjønn"
+  },
+  "account_form_dob": {
+    "other": "Fødselsdato"
+  },
+  "account_form_submit": {
+    "other": "Oppdater"
+  },
+  "account_form_submitted": {
+    "other": "Oppdatert"
+  },
+  "account_form_password_changed": {
+    "other": "Oppdatert"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Passordet stemmer ikke."
+  },
+  "signup_form_optin": {
+    "other": "Meld deg på vårt gratis nyhetsbrev"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Bekreft passordet ditt"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Vennligst skriv inn passordet ditt for å gjennomføre endringene"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Bekreft"
+  },
+  "changepassword_modal_header": {
+    "other": "Endre passord"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Nåværende passord"
+  },
+  "changepassword_modal_password": {
+    "other": "Nytt passord"
+  },
+  "changepassword_modal_password2": {
+    "other": "Bekreft ditt nye passord"
+  },
+  "changepassword_modal_submit": {
+    "other": "Oppdater"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Passordet stemmer ikke."
+  },
+  "userlibrary_page_header": {
+    "other": "Mine filmer"
+  },
+  "userlibrary_empty_header": {
+    "other": "Ditt bibliotek er tomt."
+  },
+  "userlibrary_empty_content": {
+    "other": "Finn nye filmer ved å <a href=\"{{.HomeURL}}\">bla gjennom </a>vårt store utvalg."
+  },
+  "searchresults_page_header": {
+    "other": "Søkeresultater"
+  },
+  "searchresults_load_more": {
+    "other": "Last inn {{.Count}} til"
+  },
+  "searchresults_total": {
+    "one": "Fant {{.Count}} treff for \"{{.Query}}\".",
+    "other": "Fant ett treff for \"{{.Query}}\"."
+  },
+  "searchresults_empty_header": {
+    "other": "Fant ingen treff for \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Prøv et nytt søk, eller <a href=\"{{.HomeURL}}\">bla gjennom filmene våre</a> for å finne det du leter etter."
+  },
+  "validation_name_required": {
+    "other": "Vennligst skriv inn navnet ditt."
+  },
+  "validation_email_required": {
+    "other": "Vennligst skriv inn e-postadressen din."
+  },
+  "validation_email_email": {
+    "other": "Vennligst bruk en gyldig e-postadresse."
+  },
+  "validation_currentpassword_required": {
+    "other": "Vennligst skriv inn ditt nåværende passord."
+  },
+  "validation_password_required": {
+    "other": "Vennligst oppgi et passord."
+  },
+  "validation_password2_required": {
+    "other": "Vennligst bekreft passordet ditt."
+  },
+  "validation_password2_match": {
+    "other": "Passordene dine samsvarer ikke."
+  },
+  "validation_password_minlength": {
+    "other": "Passordet må være på minst {{.Count}} tegn."
+  },
+  "validation_promocode_required": {
+    "other": "Vennligst skriv inn en promo-kode."
+  },
+  "validation_pincode_required": {
+    "other": "Please enter a PIN code."
+  },
+  "validation_gender_required": {
+    "other": "Vennligst velg kjønnet du identifiserer deg mest med."
+  },
+  "validation_dob_required": {
+    "other": "Vennligst skriv inn fødselsdatoen din."
+  },
+  "validation_dob_date": {
+    "other": "Vennligst skriv inn en gyldig fødselsdato."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Video on Demand"
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Video on Demand."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Funds in your Wallet may be used for the purchase or rental of any content on ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Se her for systemkrav."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "Kjøp"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "Lei"
+  },
+  "shopping_info_sd_only": {
+    "other": "Bare begrenset til SD-avspilling."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Tilgjengelig fra {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Du kan leie den nå, men du får ikke sett den før da."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Du kan kjøpe den nå, men du får ikke sett den før da."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Tilgjengelig til {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Du vil ikke kunne se innholdet etter dette."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Du vil ikke kunne se innholdet etter dette."
+  },
+  "duration_hour": {
+    "one": "1 time",
+    "other": "{{.Count}} timer"
+  },
+  "duration_day": {
+    "one": "1 dag",
+    "other": "{{.Count}} dager"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} leie "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} timers avspillingsvindu. "
+  },
+  "shopping_info_watch_window_explanation_film": {
+    "one": "Ved leie av film, vil den være tilgjengelig i kontoen din i {{.ValueUnit}}. ",
+    "other": "Ved leie av film, vil den være tilgjengelig i kontoen din i {{.ValueUnit}}. "
+  },
+  "shopping_info_watch_window_explanation2_film": {
+    "one": "Avspillingsvinduet starter i det du starter filmen, og du har da {{.Count}} timer til å se den så mange ganger du ønsker.",
+    "other": "Avspillingsvinduet starter i det du starter filmen, og du har da én time til å se den så mange ganger du ønsker."
+  },
+  "shopping_info_watch_window_explanation_bundle": {
+    "one": "Ved leie av en samling filmer, vil de være tilgjengelig i kontoen din i {{.Count}} dager. ",
+    "other": "Ved leie av en samling filmer, vil de være tilgjengelig i kontoen din i én dag. "
+  },
+  "shopping_info_watch_window_explanation2_bundle": {
+    "one": "Avspillingsvinduet starter i det du starter en film, og du har da {{.Count}} timer til å se den så mange ganger du ønsker.",
+    "other": "Avspillingsvinduet starter i det du starter en film, og du har da én time til å se den så mange ganger du ønsker."
+  },
+  "shopping_info_watch_window_explanation_season": {
+    "one": "Når den er leid, vil sesongen din være tilgjengelig på kontoen din i en dag. ",
+    "other": "Når den er leid, vil sesongen din være tilgjengelig på kontoen din i en {{.Count}} dag. "
+  },
+  "shopping_info_watch_window_explanation2_season": {
+    "one": "Avspillingsvinduet for en episode starter i det du starter den, og du har da {{.Count}} timer til å se den så mange ganger du ønsker.",
+    "other": "Avspillingsvinduet for en episode starter i det du starter den, og du har da én time til å se den så mange ganger du ønsker."
+  },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% bonus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Skriv inn kredittkortopplysningene dine nedenfor for å fullføre ditt {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Ved å fullføre denne transaksjonen godtar jeg<a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">vilkår og betingelser</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} rabatt brukt."
+  },
+  "shopping_discount_apply": {
+    "other": "Søke om"
+  },
+  "shopping_discount_code": {
+    "other": "Tast inn en promo-kode. "
+  },
+  "shopping_discount_have_code": {
+    "other": "Jeg har en promo-kode. "
+  },
+  "shopping_price_you_pay": {
+    "other": "Du betaler"
+  },
+  "shopping_price_nothing": {
+    "other": "Ingenting"
+  },
+  "shopping_price_free": {
+    "other": "Gratis"
+  },
+  "shopping_auth_directions": {
+    "other": "En konto er nødvendig først. Vennligst skriv inn e-postadressen din."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} er allerede tilgjengelig i biblioteket ditt."
+  },
+  "shopping_error_missing_card": {
+    "other": "Fyll inn dine kredittkortdetaljer."
+  },
+  "shopping_error_title": {
+    "other": "En feil har oppstått."
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Skriv inn en gyldig CVV-kode."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Skriv inn en gyldig CVV-kode."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Skriv inn et gyldig kredittkortnummer."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Skriv inn et gyldig kredittkortnummer."
+  },
+  "shopping_error_card_declined": {
+    "other": "Kredittkortet ble avvist."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Skriv inn en gyldig utløpsdato."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Skriv inn en gyldig utløpsdato."
+  },
+  "shopping_error_expired_card": {
+    "other": "Kredittkortet er utløpt."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Ditt {{.Ownership}} er ikke fullført. Du må befinne deg i landet kredittkortet ditt ble utstedt. Vennligst bruk et annet kort for å gjennomføre betalingen."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Ditt {{.Ownership}} er ikke fullført. Det ble oppdaget bruk av en unblocker eller en proxytjeneste. Vennligst slå av noen av disse tjenestene og prøv på nytt."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Den kampanjekoden kan ikke lenger brukes."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Vennligst skriv inn en promo-kode."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Vennligst skriv inn en gyldig promo-kode."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Vennligst skriv inn en gyldig promo-kode."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Vennligst skriv inn en gyldig promo-kode."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "En promo-kode har allerede blitt benyttet for denne økten."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Promo-koden har allerede blitt brukt."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Promo-koden har allerede blitt brukt."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Promo-koden kan ikke lenger benyttes."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Denne promo-koden er utløpt."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Denne promo-koden kan ikke bli brukt til kjøp."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Denne promo-koden kan ikke bli brukt til leie."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Promo-koden kan ikke benyttes for denne filmen."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Promo-koden kan ikke benyttes i ditt land."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Denne promo-koden kan ikke benyttes."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Denne promo-koden kan ikke benyttes til samlinger."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Kredittkortet har blitt avvist. Vennligst prøv igjen."
+  },
+  "shopping_complete_rental": {
+    "other": "Vellykket!"
+  },
+  "shopping_complete_rental_period": {
+    "one": "Du kan nå se filmen så mange ganger du ønsker de neste {{.Count}} dagene.",
+    "other": "Du kan se filmen så mange ganger du ønsker den neste dagen."
+  },
+  "shopping_complete_purchase": {
+    "other": "Takk for at du kjøpte {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Takk for at du kjøpte {{.Title}}, {{.CreditTotal}} har blitt lagt til kontoen din."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Du kan se filmen fra {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "En kvittering har blitt sendt til deg per e-post."
+  },
+  "shopping_complete_library_link": {
+    "other": "Start med å se noe fra {{.BundleItems}} i biblioteket ditt nå."
+  },
+  "shopping_complete_plan": {
+    "other": "Kjøpet av {{ .Title }} var vellykket."
+  },
+  "shopping_complete_rental_watch_window_start": {
+    "one": "Du kan nå se den om {{.Count}} dager.",
+    "other": "You are now able to start watching it within the next {{.Count}} days."
+  },
+  "shopping_complete_rental_watch_window_end": {
+    "one": "Når du starter avspillingen, vil du ha {{.Count}} timer til å se filmen så mange ganger du vil.",
+    "other": "Når du starter avspillingen, vil du ha én time til å se filmen så mange ganger du vil."
+  },
+  "shopping_complete_rental_coming_soon": {
+    "one": "Du vil kunne se filmen fra {{.Date}}, og din leieperiode er aktiv i {{.Count}} dager.",
+    "other": "Du vil kunne se filmen fra {{.Date}}, og din leieperiode er aktiv i én dag."
+  },
+  "shopping_complete_rental_coming_soon_watch_window_start": {
+    "one": "Du vil kunne se filmen fra {{.Date}}, og din leieperiode er aktiv i {{.Count}} dager.",
+    "other": "Du vil kunne se filmen fra {{.Date}}, og din leieperiode er aktiv i én dag."
+  },
+  "shopping_action_rent": {
+    "other": "Leie"
+  },
+  "shopping_action_buy": {
+    "other": "Kjøpe"
+  },
+  "meta_detail_cast_title": {
+    "other": "Medvirkende"
+  },
+  "meta_detail_crew_title": {
+    "other": "Filmteam"
+  },
+  "meta_detail_languages": {
+    "one": "Språk",
+    "other": "Språk"
+  },
+  "meta_detail_studios": {
+    "one": "Distributører",
+    "other": "Distributør"
+  },
+  "meta_detail_countries": {
+    "one": "Land",
+    "other": "Land"
+  },
+  "meta_detail_subtitles": {
+    "other": "Undertekster"
+  },
+  "meta_detail_captions": {
+    "other": "Undertekster [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Episoder"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Bonusinnhold"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Relaterte filmer"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Innholdet i denne samlingen"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} filmer"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} sesonger"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} filmer og sesonger"
+  },
+  "userwishlist_page_header": {
+    "other": "Min liste"
+  },
+  "userwishlist_slider_header": {
+    "other": "Min liste"
+  },
+  "userwishlist_empty_header": {
+    "other": "Listen er tom."
+  },
+  "userwishlist_empty_content": {
+    "other": "Fyll den ved å <a href=\"{{.HomeURL}}\">bla gjennom</a> vårt store utvalg!"
+  },
+  "userwishlist_button_add": {
+    "other": "Legg til i listen min"
+  },
+  "userwishlist_button_remove": {
+    "other": "Min liste"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Min liste"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Min liste"
+  },
+  "activatedevice_page_header": {
+    "other": "Aktiver enheten"
+  },
+  "activatedevice_page_content": {
+    "other": "Følg instruksjonene på enheten for å få en PIN-kode. Datamaskinen og enheten må begge være koblet til internett for å aktiveres."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN Code"
+  },
+  "activatedevice_form_submit": {
+    "other": "aktivere"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "Finner ikke PIN-koden, prøv igjen."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "Finner ikke PIN-koden, prøv igjen."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Logg på før du aktiverer enheten."
+  },
+  "activatedevice_page_activated": {
+    "other": "Takk for at du aktiverer {{.DeviceName}}. Du skal nå kunne bla gjennom biblioteket ditt på TV-en eller enheten."
+  },
+  "userdevices_page_header": {
+    "other": "Enheter"
+  },
+  "userdevices_page_content": {
+    "one": "Enheter vil automatisk bli lagt til her når du bruker dem. Du er begrenset til {{.Count}} enheter.",
+    "other": "Enheter vil automatisk bli lagt til her når du bruker dem. Du er begrenset til én enhet."
+  },
+  "userdevices_empty_content": {
+    "other": "Du har for øyeblikket 0 registrerte enheter."
+  },
+  "userdevices_header_type": {
+    "other": "Enhetstype"
+  },
+  "userdevices_header_description": {
+    "other": "Beskrivelse"
+  },
+  "userdevices_device_added": {
+    "other": "Lagt til {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Fjern"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Avbryt"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Ja, fjern enhet"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Fjernet)"
+  },
+  "playlist_page_header": {
+    "other": "Spilleliste"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Logg på for å se direktesendt TV."
+  },
+  "playlist_share_title": {
+    "other": "Spilleliste"
+  },
+  "playlist_up_next_title": {
+    "other": "Neste"
+  },
+  "pricing_ownership_buy": {
+    "other": "Kjøp"
+  },
+  "pricing_ownership_rent": {
+    "other": "Lei"
+  },
+  "classification_intro": {
+    "other": "Aldersgrense: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Dette nettstedet bruker informasjonskapsler for å forbedre din opplevelse. Ved å bruke dette nettstedet aksepterer du <a href=\"{{.CookiePolicyURL}}\">bruk av informasjonskapsler</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Aksepterer"
+  },
+  "all_rights_reserved": {
+    "other": "Alle rettigheter forbeholdes. Ingen deler av dette nettstedet kan reproduseres uten skriftlig tillatelse."
+  },
+  "users_gender_none": {
+    "other": "Ikke valgt"
+  },
+  "users_gender_female": {
+    "other": "Kvinne"
+  },
+  "users_gender_male": {
+    "other": "Mann"
+  },
+  "users_gender_diverse": {
+    "other": "Ikke-binær"
+  },
+  "users_gender_other": {
+    "other": "Uspesifisert"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD kun"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD kun"
+  },
+  "shopping_card_save_card": {
+    "other": "Lagre dette kortet for fremtidig bruk"
+  },
+  "shopping_card_button_change": {
+    "other": "Vis alle lagrede kort"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} slutter om {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(utløper {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(utløpt)"
+  },
+  "shopping_card_use_other": {
+    "other": "Bruk et nytt kort"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Bytt kort"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Intekening"
+  },
+  "shopping_action_credit": {
+    "other": "fylle opp"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "fra datoen og tidspunktet for utgivelsen."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Bytt kredittkort"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Oppdater kredittkortdetaljer"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Oppdater"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Utløper"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Prøveperiode"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Si opp abonnementet mitt"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Avbryt"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Ja, kanseller abonnementet mitt"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Avbestille abonnementet?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Dette vil kansellere abonnementet på {{.Name}} Du vil fortsatt kunne se innholdet i planen til den utløper {{.Expiry}}."
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Oppdater kredittkortet ditt. Støttede kort er Visa, Mastercard og American Expresse"
+  },
+  "availability_coming_soon": {
+    "other": "Kommer snart"
+  },
+  "availability_renting": {
+    "other": "Kan leies"
+  },
+  "availability_not_available": {
+    "other": "Ikke tilgjengelig"
+  },
+  "availability_in_watch_window": {
+    "other": "Tilgjengelig"
+  },
+  "availability_sold_out": {
+    "other": "Utsolgt"
+  },
+  "availability_available_till": {
+    "other": "Tilgjengelig til {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Ikke tilgjengelig"
+  },
+  "availability_available": {
+    "other": "Tilgjengelig fra {{.ReleaseDate}}"
+  },
+  "modal_cancel": {
+    "other": "Avbryt"
+  },
+  "play": {
+    "other": "Spill av"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Logg inn"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Opprett konto"
+  },
+  "combined_auth_terms": {
+    "other": "Jeg godtar alle <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">vilkår og betingelser</a>."
+  },
+  "signup_terms": {
+    "other": "Jeg godtar alle <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">vilkår og betingelser</a>."
+  },
+  "validation_terms_required": {
+    "other": "Du må godta vilkårene og betingelsene."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Dessverre er det utsolgt for visninger av {{.Title}}."
+  },
+  "shopping_card_change": {
+    "other": "Kredittkortet er feil? <a href=\"{{.SubscriptionsURL}}\">Klikk her for å oppdatere kortet ditt.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Ser ut som du har problemer.</p><p>Tilbakestill PIN-koden eller kontakt oss for <a href=\"{{.HelpURL}}\" target=\"_blank\">hjelp</a>"
+  },
+  "app_badge_title": {
+    "other": "Last ned appen for å se innholdet du har kjøpt!"
+  },
+  "app_badge_ios": {
+    "other": "Last ned på App Store"
+  },
+  "app_badge_android": {
+    "other": "Få den på Google Play"
+  },
+  "shopping_price_title_plan": {
+    "other": "Pris"
+  },
+  "shopping_price_plan_note": {
+    "zero": "Lades hvert {{ .Interval }} .",
+    "one": "Belastet hvert {{ .Interval }} etter at den 24-timers gratis prøveperioden er over.",
+    "other": "Belastet hvert {{ .Interval }} etter at {{ .Count }} dager avsluttes."
+  },
+  "shopping_price_plan_note_interval": {
+    "one": "{{ .Interval }}",
+    "other": "{{ .Count }} {{ .Interval }}"
+  },
+  "shopping_enter_card_prompt_plan": {
+    "other": "Skriv inn kredittkortopplysningene dine nedenfor for å starte abonnementet."
+  },
+  "shopping_action_plan": {
+    "other": "Fullstendig"
+  },
+  "shopping_complete_subscription": {
+    "other": "Abonnementskjøpet var vellykket. Du abonnerer nå på {{ .Title }} ."
+  },
+  "shopping_complete_subscription_browse": {
+    "other": "<a href=\"/\">Bla deg gjerne rundt</a> på siden, eller <a href=\"/search.html\">søk</a> etter noe spesifikt."
+  },
+  "shopping_info_plan_offer": {
+    "one": "{{ .Interval }} automatisk hver .Interval",
+    "other": "{{ .Count }} automatisk hver {{ .Interval }}"
+  },
+  "shopping_info_trial_period_offer": {
+    "one": "Prøv din gratis 24-timers prøveversjon nå!",
+    "other": "Prøv din gratis {{ .Count }} day prøveversjon!"
+  },
+  "plans_page_header": {
+    "other": "Tilgjengelige planer"
+  },
+  "plan_label_owned": {
+    "other": "Du eier denne planen"
+  },
+  "plan_expiry_date": {
+    "other": "Salg stenger:"
+  },
+  "plan_read_more": {
+    "other": "Finne ut mer"
+  },
+  "plan_page_read_more": {
+    "other": "Les mer"
+  },
+  "plan_page_header_text": {
+    "other": "Nyt {{ .Name }}"
+  },
+  "page_plan_explore_intro": {
+    "other": "ELLER"
+  },
+  "page_plan_explore_link": {
+    "other": "Utforsk andre pass"
+  },
+  "plan_showcase_page_ownership_button_buy": {
+    "other": "Kjøp nå"
+  },
+  "plan_free_link_text": {
+    "other": "Registrer deg gratis"
+  },
+  "awards_in_competition": {
+    "other": "I konkurranse"
+  },
+  "awards_winner": {
+    "other": "Vinner"
+  },
+  "donate_button_text": {
+    "other": "Doneren"
+  },
+  "wcag_skip_links_header": {
+    "other": "Tilgjengelighetslenker"
+  },
+  "wcag_skip_links_content": {
+    "other": "Hopp til innholdet"
+  },
+  "wcag_homepage_h1": {
+    "other": "Hjemmeside"
+  },
+  "wcag_carousel_h2": {
+    "other": "Karusell"
+  },
+  "wcag_collections_h2": {
+    "other": "Samlinger"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Bunntekst"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Hoved"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Slå på navigering"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Bunt varers"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Karusell"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Page Karusell"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Karusell List"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Karusell Slider"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Ønskeliste"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Dele påFacebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Dele på Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Dele på LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Dele på Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Du har allerede denne planen."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Denne planen er ikke lenger tilgjengelig."
+  },
+  "shopping_payment_method_header": {
+    "other": "Betalingsmetoder"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Kredittkort"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Noe gikk galt med denne betalingen. Prøv igjen senere."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Betalingen ble avvist. Lukk dette vinduet og prøv igjen."
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Du har ikke en PIN-kode, som kreves for å kjøpe, leie og se noen titler."
+  },
+  "account_form_set_pin": {
+    "other": "Set PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Oppdatert"
+  },
+  "account_form_change_pin": {
+    "other": "Endring PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Still inn din PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Still PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Skriv inn PIN-koden til {{.Action}}dette begrensede innholdet"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Beklager, du har skrevet inn feil PIN"
+  },
+  "user_submit_pin_button": {
+    "other": "Tast inn"
+  },
+  "user_reset_pin_button": {
+    "other": "Nullstille PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "Vennligst skriv inn en gyldig PIN-kode."
+  },
+  "validation_pincode2_required": {
+    "other": "Vennligst skriv inn en gyldig PIN-kode."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Vennligst skriv inn en gyldig PIN-kode."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Vennligst skriv inn en gyldig PIN-kode."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN-kode passer ikke."
+  },
+  "userdevices_delete_limits": {
+    "other": "Du kan fjerne {{.Limit}} device(s) fra denne listen hver {{.Period}} dag(s)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Du har nådd denne grensen og kan ikke fjerne noen enheter akkurat nå. Du kan slette en enhet om {{.Days}} dag(s)."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Dette kortet vil bli lagret og belastet regelmessig"
+  },
+  "changepincode_modal_header": {
+    "other": "Forandre din PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Ditt nåværende passord"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Din nye 4-sifrede PIN-kode"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Bekreft din nye 4-sifrede PIN-kode"
+  },
+  "changepincode_modal_submit": {
+    "other": "Sett PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Det passordet er feil."
+  },
+  "user_set_pin_intro": {
+    "other": "Du trenger en PIN-kode for å{{.Action}} begrenset innhold"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Klikk her for å tilbakestille PIN-koden din"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Dette innholdet er aldersbegrenset."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "availability_expires": {
+    "other": "Utløper {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Utløpt"
   }
-  
+}

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1,149 +1,361 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Configuración" },
-  "powered_by": { "other": "Obsługiwane przez" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.shift72.com" },
-  "in_partnership_with": { "other": "we współpracy z" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "English" },
-  "fr": { "other": "French" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Configuración"
+  },
+  "powered_by": {
+    "other": "Obsługiwane przez"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "we współpracy z"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
   "episode_name": {
     "other": "Odcinek"
   },
-
   "season_name": {
     "other": "Sezon"
   },
-
-  "date_day": { "other": "Dzień" },
-  "date_month": { "other": "Miesiąc" },
-  "date_year": { "other": "Rok" },
-
-  "404_page_header": { "other": "Podana strona nie istnieje..." },
-  "404_page_content": { "other": "<p> Niestety, wygląda na to, że strona, której szukasz, nie istnieje. </p> <p> Mogła zostać przeniesiona, usunięta lub wpisany adres jest błędny. </p> <p> Spróbuj powrócić do strony głównej w celu znalezienia tego, czego szukasz. </p> <p> <a href=\"{{.URL}}\"> Powrót do strony głównej </a> </p>"},
-
-  "nav_signin": { "other": "Zaloguj się" },
-  "nav_signup": { "other": "Utwórz konto" },
-  "nav_signed_in_as": { "other": "Zalogowano jako" },
-  "nav_library": { "other": "Moja biblioteka" },
-  "nav_devices": { "other": "Moje urządzenia" },
-  "nav_wishlist": { "other": "Moja lista" },
-  "nav_account": { "other": "Moje konto" },
-  "nav_signout": { "other": "Wyloguj się" },
-  "play_trailer": { "other": "Trailer" },
-  "runtime_hours": { "other": "godz." },
-  "runtime_minutes": { "other": "min." },
-
-  "datetime_today": { "other": "dzisiaj {{.Date}}" },
-  "datetime_tomorrow": { "other": "jutro {{.Date}}" },
-  "datetime_yesterday": { "other": "wczoraj {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "ostatni {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Szukaj" },
-  "search_control_submit": { "other": "Wyszukaj" },
-
-  "play_button_watch": { "other" : "Odtwórz"},
-  "play_button_resume": { "other" : "Kontynuuj"},
-
-  "social_media_buttons_title": { "other": "Udostępnij" },
-  "social_media_buttons_facebook": { "other": "Udostępnij na Facebooku" },
-  "social_media_buttons_twitter": { "other": "Podziel się na Twitterze" },
-  "social_media_buttons_linkedin": { "other": "Udostępnij na Linkedin" },
-  "social_media_buttons_email": { "other": "Udostępnij przez e-mail" },
-  "social_media_buttons_email_subject": { "other": "Udostępnianie linków" },
-  "social_media_buttons_copied_link": { "other": "Link skopiowany do schowka!" },
-  "social_media_buttons_copy_link": { "other": "Skopiuj do schowka" },
-
-  "accept_invite_page_header": { "other": "Witamy " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Wygląda na to, że już odebrałeś to zaproszenie. Kliknij zatem <a href=\"{{.SigninURL}}\"> zaloguj się </a>. Jeśli zapomniałeś hasła, możesz je odzyskać <a href=\"{{.ForgotPasswordURL}}\"> resetując hasło </a>." },
-  "acceptinvite_complete": { "other": "Dziękujemy. Twoje konto zostało utworzone." },
-  "acceptinvite_form_submit": { "other": "Zaakceptuj zaproszenie." },
-  "acceptinvite_agreement": { "other": "Klikając „Przyjmij zaproszenie”, potwierdzasz zapoznanie się z naszymi <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">warunkami korzystania z serwisu</a> oraz <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">polityką prywatności</a>." },
-
-  "signup_page_header": { "other": "Utwórz nowe konto" },
-  "signup_form_name": { "other": "Nazwa użytkownika" },
-  "signup_form_email": { "other": "Adres e-mail" },
-  "signup_form_password": { "other": "Hasło" },
-  "signup_form_password_confirmation": { "other": "Powtórz hasło" },
-  "signup_form_gender": { "other": "Płeć" },
-  "signup_form_dob": { "other": "Data urodzenia" },
-  "signup_form_submit": { "other": "Zatwierdź" },
-
-  "signin_page_header": { "other": "Zaloguj się" },
-  "signin_form_email": { "other": "Adres e-mail" },
-  "signin_form_password": { "other": "Hasło" },
-  "signin_form_remember": { "other": "Zapamiętaj" },
-  "signin_form_submit": { "other": "Zatwierdź" },
-  "signin_page_forgotpassword": { "other": "Zapomniałeś hasła?" },
-  "signin_page_createnewaccount": { "other": "Nie masz jeszcze konta? Utwórz nowe." },
-  "signup_page_alreadyhaveanaccount": { "other": "Masz już konto? Zaloguj się." },
-  "signup_form_error_email_already_in_use": { "other": "Podany adres e-mail jest już zarejestrowany." },
-  "signin_form_error_incorrect_credentials": { "other": "Nazwa użytkownika lub hasło są nieprawidłowe." },
-
-  "signup_form_error_forbidden": { "other": "Wystąpił błąd." },
-
-  "combined_auth_continue": { "other": "Kontynuuj" },
-  "combined_auth_change": { "other": "zmień" },
-  "combined_auth_signin": { "other": "Zaloguj się" },
-  "combined_auth_signup": { "other": "Utwórz konto" },
-  "combined_auth_signin_password": { "other": "Podaj swoje hasło, aby zalogować się do konta." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Podane hasło jest nieprawidłowe." },
-  "combined_auth_error_forbidden": { "other": "Wystąpił błąd." },
-  "combined_auth_error_too_many_requests": { "other": "Zbyt wiele zapytań. Spróbuj ponownie później." },
-
-  "forgotpassword_page_header": { "other": "Zresetuj swoje hasło" },
-  "forgotpassword_form_email": { "other": "Adres e-mail" },
-  "forgotpassword_form_submit": { "other": "Zresetuj" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Konto powiązane z podanym adresem e-mail nie istnieje." },
-  "forgotpassword_form_error_account_suspended": { "other": "Konto jest zawieszone." },
-  "forgotpassword_complete": { "other": "Dziękujemy. E-mail dotyczący resetowania hasła powinien wkrótce pojawić się w Twojej skrzynce odbiorczej." },
-  "forgotpassword_form_error_forbidden": { "other": "Wystąpił błąd." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Zbyt wiele zapytań. Spróbuj ponownie później." },
-
-  "resetpassword_page_header": { "other": "Zmień swoje hasło." },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Wygląda na to, że ta prośba o zresetowanie hasła jest nieprawidłowa, należy ponownie wypełnić formularz <a href=\"{{.URL}}\">Zapomniałem hasła</a>." },
-  "resetpassword_form_password": { "other": "Nowe hasło" },
-  "resetpassword_form_password2": { "other": "Potwierdź swoje hasło" },
-  "resetpassword_form_submit": { "other": "Zmień" },
-  "resetpassword_complete": { "other": "Dziękujemy. Twoje hasło zostało zmienione i jesteś już zalogowany." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Żądanie resetowania hasła jest nieprawidłowe. Spróbuj ponownie później." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Link do zresetowania hasła wygasł. Poproś o nowy." },
-  "resetpassword_form_error_too_many_requests": { "other": "Zbyt wiele zapytań. Spróbuj ponownie później." },
-
-  "account_page_header": { "other": "Moje konto" },
-  "account_form_name": { "other": "Nazwa użytkownika" },
-  "account_form_email": { "other": "Adres e-mail" },
-  "account_form_password": { "other": "Hasło" },
-  "account_form_change_password": { "other": "Zmień" },
-  "account_form_gender": { "other": "Płeć" },
-  "account_form_dob": { "other": "Data urodzenia" },
-  "account_form_submit": { "other": "Aktualizuj" },
-  "account_form_submitted": { "other": "Zaktualizowano" },
-  "account_form_password_changed": { "other": "Zaktualizowano" },
-  "account_form_error_incorrect_password": { "other": "Podane hasło jest nieprawidłowe." },
-
-  "signup_form_optin": {"other": "Zapisz się do naszego bezpłatnego newslettera."},
-
-  "passwordconfirmation_modal_header": { "other": "Potwierdź swoje hasło" },
-  "passwordconfirmation_modal_label": { "other": "Wprowadź swoje hasło, aby zaakcpetować zmiany." },
-  "passwordconfirmation_modal_confirm": { "other": "Potwierdź" },
-
-  "changepassword_modal_header": { "other": "Zmień swoje hasło" },
-  "changepassword_modal_currentpassword": { "other": "Twoje aktualne hasło" },
-  "changepassword_modal_password": { "other": "Twoje nowe hasło" },
-  "changepassword_modal_password2": { "other": "Potwierdź nowe hasło" },
-  "changepassword_modal_submit": { "other": "Zaktualizuj" },
-  "changepassword_modal_error_incorrect_password": { "other": "Podane hasło jest nieprawidłowe." },
-
-  "userlibrary_page_header": { "other": "Moja biblioteka" },
-  "userlibrary_empty_header":  { "other": "Twoja biblioteka jest pusta." },
-  "userlibrary_empty_content": { "other": "Wypełnij je <a href=\"{{.HomeURL}}\">przeglądając</a> naszą listę filmów." },
-
-  "searchresults_page_header": { "other": "Wyniki wyszukiwania" },
+  "date_day": {
+    "other": "Dzień"
+  },
+  "date_month": {
+    "other": "Miesiąc"
+  },
+  "date_year": {
+    "other": "Rok"
+  },
+  "404_page_header": {
+    "other": "Podana strona nie istnieje..."
+  },
+  "404_page_content": {
+    "other": "<p> Niestety, wygląda na to, że strona, której szukasz, nie istnieje. </p> <p> Mogła zostać przeniesiona, usunięta lub wpisany adres jest błędny. </p> <p> Spróbuj powrócić do strony głównej w celu znalezienia tego, czego szukasz. </p> <p> <a href=\"{{.URL}}\"> Powrót do strony głównej </a> </p>"
+  },
+  "nav_signin": {
+    "other": "Zaloguj się"
+  },
+  "nav_signup": {
+    "other": "Utwórz konto"
+  },
+  "nav_signed_in_as": {
+    "other": "Zalogowano jako"
+  },
+  "nav_library": {
+    "other": "Moja biblioteka"
+  },
+  "nav_devices": {
+    "other": "Moje urządzenia"
+  },
+  "nav_wishlist": {
+    "other": "Moja lista"
+  },
+  "nav_account": {
+    "other": "Moje konto"
+  },
+  "nav_signout": {
+    "other": "Wyloguj się"
+  },
+  "play_trailer": {
+    "other": "Trailer"
+  },
+  "runtime_hours": {
+    "other": "godz."
+  },
+  "runtime_minutes": {
+    "other": "min."
+  },
+  "datetime_today": {
+    "other": "dzisiaj {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "jutro {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "wczoraj {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "ostatni {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Szukaj"
+  },
+  "search_control_submit": {
+    "other": "Wyszukaj"
+  },
+  "play_button_watch": {
+    "other": "Odtwórz"
+  },
+  "play_button_resume": {
+    "other": "Kontynuuj"
+  },
+  "social_media_buttons_title": {
+    "other": "Udostępnij"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Udostępnij na Facebooku"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Podziel się na Twitterze"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Udostępnij na Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Udostępnij przez e-mail"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Udostępnianie linków"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link skopiowany do schowka!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Skopiuj do schowka"
+  },
+  "accept_invite_page_header": {
+    "other": "Witamy "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Wygląda na to, że już odebrałeś to zaproszenie. Kliknij zatem <a href=\"{{.SigninURL}}\"> zaloguj się </a>. Jeśli zapomniałeś hasła, możesz je odzyskać <a href=\"{{.ForgotPasswordURL}}\"> resetując hasło </a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Dziękujemy. Twoje konto zostało utworzone."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Zaakceptuj zaproszenie."
+  },
+  "acceptinvite_agreement": {
+    "other": "Klikając „Przyjmij zaproszenie”, potwierdzasz zapoznanie się z naszymi <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">warunkami korzystania z serwisu</a> oraz <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">polityką prywatności</a>."
+  },
+  "signup_page_header": {
+    "other": "Utwórz nowe konto"
+  },
+  "signup_form_name": {
+    "other": "Nazwa użytkownika"
+  },
+  "signup_form_email": {
+    "other": "Adres e-mail"
+  },
+  "signup_form_password": {
+    "other": "Hasło"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Powtórz hasło"
+  },
+  "signup_form_gender": {
+    "other": "Płeć"
+  },
+  "signup_form_dob": {
+    "other": "Data urodzenia"
+  },
+  "signup_form_submit": {
+    "other": "Zatwierdź"
+  },
+  "signin_page_header": {
+    "other": "Zaloguj się"
+  },
+  "signin_form_email": {
+    "other": "Adres e-mail"
+  },
+  "signin_form_password": {
+    "other": "Hasło"
+  },
+  "signin_form_remember": {
+    "other": "Zapamiętaj"
+  },
+  "signin_form_submit": {
+    "other": "Zatwierdź"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Zapomniałeś hasła?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Nie masz jeszcze konta? Utwórz nowe."
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Masz już konto? Zaloguj się."
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Podany adres e-mail jest już zarejestrowany."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Nazwa użytkownika lub hasło są nieprawidłowe."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Wystąpił błąd."
+  },
+  "combined_auth_continue": {
+    "other": "Kontynuuj"
+  },
+  "combined_auth_change": {
+    "other": "zmień"
+  },
+  "combined_auth_signin": {
+    "other": "Zaloguj się"
+  },
+  "combined_auth_signup": {
+    "other": "Utwórz konto"
+  },
+  "combined_auth_signin_password": {
+    "other": "Podaj swoje hasło, aby zalogować się do konta."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Podane hasło jest nieprawidłowe."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Wystąpił błąd."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Zbyt wiele zapytań. Spróbuj ponownie później."
+  },
+  "forgotpassword_page_header": {
+    "other": "Zresetuj swoje hasło"
+  },
+  "forgotpassword_form_email": {
+    "other": "Adres e-mail"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Zresetuj"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Konto powiązane z podanym adresem e-mail nie istnieje."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Konto jest zawieszone."
+  },
+  "forgotpassword_complete": {
+    "other": "Dziękujemy. E-mail dotyczący resetowania hasła powinien wkrótce pojawić się w Twojej skrzynce odbiorczej."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Wystąpił błąd."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Zbyt wiele zapytań. Spróbuj ponownie później."
+  },
+  "resetpassword_page_header": {
+    "other": "Zmień swoje hasło."
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Wygląda na to, że ta prośba o zresetowanie hasła jest nieprawidłowa, należy ponownie wypełnić formularz <a href=\"{{.URL}}\">Zapomniałem hasła</a>."
+  },
+  "resetpassword_form_password": {
+    "other": "Nowe hasło"
+  },
+  "resetpassword_form_password2": {
+    "other": "Potwierdź swoje hasło"
+  },
+  "resetpassword_form_submit": {
+    "other": "Zmień"
+  },
+  "resetpassword_complete": {
+    "other": "Dziękujemy. Twoje hasło zostało zmienione i jesteś już zalogowany."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Żądanie resetowania hasła jest nieprawidłowe. Spróbuj ponownie później."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Link do zresetowania hasła wygasł. Poproś o nowy."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Zbyt wiele zapytań. Spróbuj ponownie później."
+  },
+  "account_page_header": {
+    "other": "Moje konto"
+  },
+  "account_form_name": {
+    "other": "Nazwa użytkownika"
+  },
+  "account_form_email": {
+    "other": "Adres e-mail"
+  },
+  "account_form_password": {
+    "other": "Hasło"
+  },
+  "account_form_change_password": {
+    "other": "Zmień"
+  },
+  "account_form_gender": {
+    "other": "Płeć"
+  },
+  "account_form_dob": {
+    "other": "Data urodzenia"
+  },
+  "account_form_submit": {
+    "other": "Aktualizuj"
+  },
+  "account_form_submitted": {
+    "other": "Zaktualizowano"
+  },
+  "account_form_password_changed": {
+    "other": "Zaktualizowano"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Podane hasło jest nieprawidłowe."
+  },
+  "signup_form_optin": {
+    "other": "Zapisz się do naszego bezpłatnego newslettera."
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Potwierdź swoje hasło"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Wprowadź swoje hasło, aby zaakcpetować zmiany."
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Potwierdź"
+  },
+  "changepassword_modal_header": {
+    "other": "Zmień swoje hasło"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Twoje aktualne hasło"
+  },
+  "changepassword_modal_password": {
+    "other": "Twoje nowe hasło"
+  },
+  "changepassword_modal_password2": {
+    "other": "Potwierdź nowe hasło"
+  },
+  "changepassword_modal_submit": {
+    "other": "Zaktualizuj"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Podane hasło jest nieprawidłowe."
+  },
+  "userlibrary_page_header": {
+    "other": "Moja biblioteka"
+  },
+  "userlibrary_empty_header": {
+    "other": "Twoja biblioteka jest pusta."
+  },
+  "userlibrary_empty_content": {
+    "other": "Wypełnij je <a href=\"{{.HomeURL}}\">przeglądając</a> naszą listę filmów."
+  },
+  "searchresults_page_header": {
+    "other": "Wyniki wyszukiwania"
+  },
   "searchresults_load_more": {
     "one": "Załaduj {{.Count}} więcej",
     "few": "Załaduj {{.Count}} więcej",
@@ -156,42 +368,89 @@
     "many": "Znaleziono {{.Count}} wyniki dla „{{.Query}}”.",
     "other": "Znaleziono {{.Count}} wyniki dla „{{.Query}}”."
   },
-  "searchresults_empty_header":  { "other": "Brak wyników wyszukiwania dla „{{.Query}}”" },
-  "searchresults_empty_content": { "other": "Spróbuj innego zapytania lub <a href=\"{{.HomeURL}}\"> przejrzyj naszą bibiotekę filmów </a>, aby znaleźć to, czego szukasz" },
-
-  "validation_name_required": { "other": "Podaj nazwę użytkownika." },
-  "validation_email_required": { "other": "Podaj adres e-mail." },
-  "validation_email_email": { "other": "Podaj prawidłowy adres e-mail." },
-  "validation_currentpassword_required": { "other": "Podaj swoje obecne hasło." },
-  "validation_password_required": { "other": "Podaj hasło." },
-  "validation_password2_required": { "other": "Potwierdź hasło." },
-  "validation_password2_match": { "other": "Hasła nie zgadzają się." },
+  "searchresults_empty_header": {
+    "other": "Brak wyników wyszukiwania dla „{{.Query}}”"
+  },
+  "searchresults_empty_content": {
+    "other": "Spróbuj innego zapytania lub <a href=\"{{.HomeURL}}\"> przejrzyj naszą bibiotekę filmów </a>, aby znaleźć to, czego szukasz"
+  },
+  "validation_name_required": {
+    "other": "Podaj nazwę użytkownika."
+  },
+  "validation_email_required": {
+    "other": "Podaj adres e-mail."
+  },
+  "validation_email_email": {
+    "other": "Podaj prawidłowy adres e-mail."
+  },
+  "validation_currentpassword_required": {
+    "other": "Podaj swoje obecne hasło."
+  },
+  "validation_password_required": {
+    "other": "Podaj hasło."
+  },
+  "validation_password2_required": {
+    "other": "Potwierdź hasło."
+  },
+  "validation_password2_match": {
+    "other": "Hasła nie zgadzają się."
+  },
   "validation_password_minlength": {
     "one": "Hasło musi mieć co najmniej {{.Count}} znaków.",
     "few": "Hasło musi mieć co najmniej {{.Count}} znaków.",
     "many": "Hasło musi mieć co najmniej {{.Count}} znaków.",
     "other": "Hasło musi mieć co najmniej {{.Count}} znaków."
   },
-  "validation_promocode_required": { "other": "Podaj kod promocyjny." },
-  "validation_gender_required": { "other": "Wybierz płeć, z którą się identyfikujesz" },
-  "validation_dob_required": { "other": "Podaj datę urodzenia." },
-  "validation_dob_date": { "other": "Podaj prawidłową datę urodzenia." },
-
-  "shopping_info_subtitle_hd": { "other": "Wideo HD na żądanie." },
-  "shopping_info_subtitle_sd": { "other": "Sprawdź wymagania systemowe." },
-  "shopping_info_ownership_buy": { "other": "zakup" },
-  "shopping_info_ownership_rent": { "other": "wypożyczenie" },
-
-  "shopping_info_release_date_title": { "other": "Wydania {{.Date}} " },
-  "shopping_info_release_date_explanation_rent": { "other": "Możesz teraz wypożyczyć film, ale póki co nie będziesz w stanie go obejrzeć." },
-  "shopping_info_release_date_explanation_buy": { "other": "Możesz teraz zakupić dostęp do filmu, ale póki co nie będziesz w stanie go obejrzeć." },
-
-  "shopping_info_available_until_date_title": { "other": "Dostępny do {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Po upływie tego czasu nie będziesz mógł przeglądać treści." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Po upływie tego czasu nie będziesz mógł przeglądać treści." },
-
-  "duration_hour": { "one": "1 godzina", "other": "{{.Count}} godziny" },
-  "duration_day": { "one": "1 dzień", "other": "{{.Count}} dni" },
+  "validation_promocode_required": {
+    "other": "Podaj kod promocyjny."
+  },
+  "validation_gender_required": {
+    "other": "Wybierz płeć, z którą się identyfikujesz"
+  },
+  "validation_dob_required": {
+    "other": "Podaj datę urodzenia."
+  },
+  "validation_dob_date": {
+    "other": "Podaj prawidłową datę urodzenia."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "Wideo HD na żądanie."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "Sprawdź wymagania systemowe."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "zakup"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "wypożyczenie"
+  },
+  "shopping_info_release_date_title": {
+    "other": "Wydania {{.Date}} "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Możesz teraz wypożyczyć film, ale póki co nie będziesz w stanie go obejrzeć."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Możesz teraz zakupić dostęp do filmu, ale póki co nie będziesz w stanie go obejrzeć."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Dostępny do {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Po upływie tego czasu nie będziesz mógł przeglądać treści."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Po upływie tego czasu nie będziesz mógł przeglądać treści."
+  },
+  "duration_hour": {
+    "one": "1 godzina",
+    "other": "{{.Count}} godziny"
+  },
+  "duration_day": {
+    "one": "1 dzień",
+    "other": "{{.Count}} dni"
+  },
   "shopping_info_rental_period_duration": {
     "one": "Wypożyczono na {{.ValueUnit}} ",
     "few": "Wypożyczono na {{.ValueUnit}} ",
@@ -240,67 +499,150 @@
     "many": "Po naciśnięciu przycisku odtwarzania otworzy się player i pozostanie Ci {{.Count}} godzin na obejrzenie wybranego odcinka dowolną liczbę razy.",
     "other": "Po naciśnięciu przycisku odtwarzania otworzy się player i pozostanie Ci {{.Count}} godzin na obejrzenie wybranego odcinka dowolną liczbę razy."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% rabatu" },
-
-  "shopping_enter_card_prompt": { "other": "Wprowadź poniżej dane karty kredytowej, aby dokończyć {{.Verb}}." },
-
-  "shopping_terms": { "other": "Realizując tę transakcję, zgadzam się na <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\"> warunki korzystania z serwisu </a>."},
-  "shopping_discount_applied": { "other": "Uwzględniono rabat w wysokości {{.DiscountAmount}}." },
-  "shopping_discount_apply": { "other": "Zastosuj" },
-  "shopping_discount_code": { "other": "Wprowadź kod promocyjny" },
-  "shopping_discount_have_code": { "other": "Mam kod promocyjny" },
-
-  "shopping_price_you_pay": { "other": "Ty płacisz" },
-  "shopping_price_nothing": { "other": "Nic" },
-  "shopping_price_free": { "other": "Bezpłatne" },
-
-  "shopping_auth_directions": { "other": "Najpierw potrzebne jest konto. Podaj swój adres e-mail." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} jest już w Twojej bibliotece" },
-
-  "shopping_error_missing_card": { "other": "Wprowadź dane swojej karty kredytowej." },
-  "shopping_error_title": { "other": "Wystąpił błąd" },
-  "shopping_error_incorrect_cvc": { "other": "Wprowadź prawidłowy kod CVV." },
-  "shopping_error_invalid_cvc": { "other": "Wprowadź prawidłowy kod CVV." },
-  "shopping_error_incorrect_number": { "other": "Wprowadź prawidłowy numer karty kredytowej" },
-  "shopping_error_invalid_number": { "other": "Wprowadź prawidłowy numer karty kredytowej" },
-  "shopping_error_card_declined": { "other": "Karta kredytowa została odrzucona." },
-  "shopping_error_invalid_expiry_month": { "other": "Wprowadź prawidłowy okres ważności." },
-  "shopping_error_invalid_expiry_year": { "other": "Wprowadź prawidłowy okres ważności." },
-  "shopping_error_expired_card": { "other": "Ważność karty kredytowej wygasła." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Twoje {{.Ownership}} nie zostało ukończone. Musisz przebywać w kraju, w którym została wydana Twoja karta kredytowa. Do dokonania płatności użyj innej karty." },
-  "shopping_error_proxy_detected": { "other": "Twoje {{.Ownership}} nie zostało ukończone. Wykryliśmy, że korzystasz z usług odblokowujących lub proxy. Wyłącz dowolną z tych usług i spróbuj ponownie." },
-
-
-  "shopping_error_discount_blank": { "other": "Wpisz kod promocyjny." },
-  "shopping_error_discount_not_applied": { "other": "Wpisz prawidłowy kod promocyjny." },
-  "shopping_error_discount_invalid": { "other": "Wpisz prawidłowy kod promocyjny." },
-  "shopping_error_discount_disabled": { "other": "Wpisz prawidłowy kod promocyjny." },
-  "shopping_error_discount_already_applied": { "other": "W tej sesji został już wykorzystany podany kod promocyjny." },
-  "shopping_error_discount_already_redeemed": { "other": "Podany kod promocyjny został już wykorzystany." },
-  "shopping_error_discount_used_previously": { "other": "Podany kod promocyjny został już wykorzystany." },
-  "shopping_error_discount_max_limit": { "other": "Podany kod promocyjny został już wykorzystany." },
-  "shopping_error_discount_expired": { "other": "Podany kod promocyjny wygasł." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Podanego kodu promocyjnego nie można użyć przy zakupie." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Podanego kodu promocyjnego nie można wykorzystać przy wypożyczaniu." },
-  "shopping_error_discount_invalid_item": { "other": "Podanego kodu promocyjnego nie można wykorzystać z obecnym zamówieniem." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Podanego kodu promocyjnego nie można użyć w Twoim kraju." },
-  "shopping_error_discounts_not_allowed": { "other": "Podanego kodu promocyjnego nie można użyć." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Podanego kodu promocyjnego nie można używać w pakietach." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Karta kredytowa została odrzucona. Proszę spróbuj ponownie." },
-
-  "shopping_complete_rental": { "other": "Udało się!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% rabatu"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Wprowadź poniżej dane karty kredytowej, aby dokończyć {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Realizując tę transakcję, zgadzam się na <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\"> warunki korzystania z serwisu </a>."
+  },
+  "shopping_discount_applied": {
+    "other": "Uwzględniono rabat w wysokości {{.DiscountAmount}}."
+  },
+  "shopping_discount_apply": {
+    "other": "Zastosuj"
+  },
+  "shopping_discount_code": {
+    "other": "Wprowadź kod promocyjny"
+  },
+  "shopping_discount_have_code": {
+    "other": "Mam kod promocyjny"
+  },
+  "shopping_price_you_pay": {
+    "other": "Ty płacisz"
+  },
+  "shopping_price_nothing": {
+    "other": "Nic"
+  },
+  "shopping_price_free": {
+    "other": "Bezpłatne"
+  },
+  "shopping_auth_directions": {
+    "other": "Najpierw potrzebne jest konto. Podaj swój adres e-mail."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} jest już w Twojej bibliotece"
+  },
+  "shopping_error_missing_card": {
+    "other": "Wprowadź dane swojej karty kredytowej."
+  },
+  "shopping_error_title": {
+    "other": "Wystąpił błąd"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Wprowadź prawidłowy kod CVV."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Wprowadź prawidłowy kod CVV."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Wprowadź prawidłowy numer karty kredytowej"
+  },
+  "shopping_error_invalid_number": {
+    "other": "Wprowadź prawidłowy numer karty kredytowej"
+  },
+  "shopping_error_card_declined": {
+    "other": "Karta kredytowa została odrzucona."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Wprowadź prawidłowy okres ważności."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Wprowadź prawidłowy okres ważności."
+  },
+  "shopping_error_expired_card": {
+    "other": "Ważność karty kredytowej wygasła."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Twoje {{.Ownership}} nie zostało ukończone. Musisz przebywać w kraju, w którym została wydana Twoja karta kredytowa. Do dokonania płatności użyj innej karty."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Twoje {{.Ownership}} nie zostało ukończone. Wykryliśmy, że korzystasz z usług odblokowujących lub proxy. Wyłącz dowolną z tych usług i spróbuj ponownie."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Wpisz kod promocyjny."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Wpisz prawidłowy kod promocyjny."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Wpisz prawidłowy kod promocyjny."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Wpisz prawidłowy kod promocyjny."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "W tej sesji został już wykorzystany podany kod promocyjny."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Podany kod promocyjny został już wykorzystany."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Podany kod promocyjny został już wykorzystany."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Podany kod promocyjny został już wykorzystany."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Podany kod promocyjny wygasł."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Podanego kodu promocyjnego nie można użyć przy zakupie."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Podanego kodu promocyjnego nie można wykorzystać przy wypożyczaniu."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Podanego kodu promocyjnego nie można wykorzystać z obecnym zamówieniem."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Podanego kodu promocyjnego nie można użyć w Twoim kraju."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Podanego kodu promocyjnego nie można użyć."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Podanego kodu promocyjnego nie można używać w pakietach."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Karta kredytowa została odrzucona. Proszę spróbuj ponownie."
+  },
+  "shopping_complete_rental": {
+    "other": "Udało się!"
+  },
   "shopping_complete_rental_period": {
     "one": "Możesz teraz oglądać go tak często, jak chcesz przez następny dzień.",
     "few": "Możesz teraz oglądać go tak często, jak chcesz przez następne {{.Count}} dni.",
     "many": "Możesz teraz oglądać go tak często, jak chcesz przez następne {{.Count}} dni.",
     "other": "Możesz teraz oglądać go tak często, jak chcesz przez następne {{.Count}} dni."
   },
-  "shopping_complete_purchase": { "other": "Dziękujemy za zakup {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Dziękujemy za zakup {{.Title}}, {{.CreditTotal}} zostało dodane do Twojego konta." },
-  "shopping_complete_purchase_coming_soon": { "other": "Będzie można go oglądać od {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Potwierdzenie zostało wysłane do Ciebie e-mailem." },
-  "shopping_complete_library_link": { "other": "Zacznij teraz oglądać dowolne z {{.BundleItems}} w swojej bibliotece." },
+  "shopping_complete_purchase": {
+    "other": "Dziękujemy za zakup {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Dziękujemy za zakup {{.Title}}, {{.CreditTotal}} zostało dodane do Twojego konta."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Będzie można go oglądać od {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Potwierdzenie zostało wysłane do Ciebie e-mailem."
+  },
+  "shopping_complete_library_link": {
+    "other": "Zacznij teraz oglądać dowolne z {{.BundleItems}} w swojej bibliotece."
+  },
   "shopping_complete_plan": {
     "other": "Twój zakup {{ .Title }} powiódł się."
   },
@@ -326,22 +668,48 @@
     "many": "Będziesz mógł go oglądać od {{.Date}}, a wypożyczenie pozostanie aktywne przez {{.Count}} dni.",
     "other": "Będziesz mógł go oglądać od {{.Date}}, a wypożyczenie pozostanie aktywne przez {{.Count}} dni."
   },
-
-  "shopping_action_rent": { "other": "Wypożycz" },
-  "shopping_action_buy": { "other": "Kup" },
-
-  "meta_detail_cast_title": { "other": "Obsada" },
-  "meta_detail_crew_title": { "other": "Produkcja" },
-  "meta_detail_languages": { "one": "Język", "other": "Języki" },
-  "meta_detail_studios": { "one": "Studio", "other": "Studio" },
-  "meta_detail_countries": { "one": "Kraj", "other": "Kraje" },
-  "meta_detail_subtitles": { "other": "Napisy" },
-  "meta_detail_captions": { "other": "Napisy [CC]" },
-  "meta_detail_episodes_title": { "other": "Odcinki" },
-  "meta_detail_bonus_title": { "other": "Materiał dodatkowy" },
-  "meta_detail_recommendations_title": { "other": "Propozycje dla Ciebie" },
-  "meta_detail_bundle_items_title": { "other": "Zawartość waybranego pakietu:" },
-
+  "shopping_action_rent": {
+    "other": "Wypożycz"
+  },
+  "shopping_action_buy": {
+    "other": "Kup"
+  },
+  "meta_detail_cast_title": {
+    "other": "Obsada"
+  },
+  "meta_detail_crew_title": {
+    "other": "Produkcja"
+  },
+  "meta_detail_languages": {
+    "one": "Język",
+    "other": "Języki"
+  },
+  "meta_detail_studios": {
+    "one": "Studio",
+    "other": "Studio"
+  },
+  "meta_detail_countries": {
+    "one": "Kraj",
+    "other": "Kraje"
+  },
+  "meta_detail_subtitles": {
+    "other": "Napisy"
+  },
+  "meta_detail_captions": {
+    "other": "Napisy [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Odcinki"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Materiał dodatkowy"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Propozycje dla Ciebie"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Zawartość waybranego pakietu:"
+  },
   "bundle_items_all_films": {
     "one": "{{.Count}} filmów",
     "few": "{{.Count}} filmów",
@@ -360,75 +728,162 @@
     "many": "{{.Count}} filmów i odcinków",
     "other": "{{.Count}} filmów i odcinków"
   },
-  "userwishlist_page_header": { "other": "Moja lista" },
-  "userwishlist_slider_header": { "other": "Moja lista" },
-  "userwishlist_empty_header":  { "other": "Twoja lista jest pusta." },
-  "userwishlist_empty_content": { "other": "Wypełnij je, <a href=\"{{.HomeURL}}\"> przeglądając </a> naszą obszerną bibliotekę." },
-  "userwishlist_button_add": { "other": "Dodaj do mojej listy" },
-  "userwishlist_button_remove": { "other": "Moja lista" },
-  "userwishlist_button_add_compact": { "other": "Moja lista" },
-  "userwishlist_button_remove_compact": { "other": "Moja lista" },
-
-  "userdevices_page_header": { "other": "Urządzenia" },
+  "userwishlist_page_header": {
+    "other": "Moja lista"
+  },
+  "userwishlist_slider_header": {
+    "other": "Moja lista"
+  },
+  "userwishlist_empty_header": {
+    "other": "Twoja lista jest pusta."
+  },
+  "userwishlist_empty_content": {
+    "other": "Wypełnij je, <a href=\"{{.HomeURL}}\"> przeglądając </a> naszą obszerną bibliotekę."
+  },
+  "userwishlist_button_add": {
+    "other": "Dodaj do mojej listy"
+  },
+  "userwishlist_button_remove": {
+    "other": "Moja lista"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Moja lista"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Moja lista"
+  },
+  "userdevices_page_header": {
+    "other": "Urządzenia"
+  },
   "userdevices_page_content": {
     "one": "Urządzenia zostaną automatycznie dodane, gdy ich użyjesz. Masz ograniczenie do 1 urządzenia.",
     "few": "Urządzenia zostaną automatycznie dodane, gdy ich użyjesz. Masz ograniczenie do {{.Count}} urządzeń.",
     "many": "Urządzenia zostaną automatycznie dodane, gdy ich użyjesz. Masz ograniczenie do {{.Count}} urządzeń.",
     "other": "Urządzenia zostaną automatycznie dodane, gdy ich użyjesz. Masz ograniczenie do {{.Count}} urządzeń."
   },
-  "userdevices_empty_content": { "other": "Obecnie masz 0 zarejestrowanych urządzeń" },
-  "userdevices_header_type": { "other": "Rodzaj urządzenia" },
-  "userdevices_header_description": { "other": "Opis" },
-  "userdevices_device_added": { "other": "Dodano {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Usuń" },
-  "userdevices_device_actions_cancel": { "other": "Anuluj" },
-  "userdevices_device_actions_confirm": { "other": "Tak, usuń urządzenie" },
-  "userdevices_device_deleted": { "other": "(Usunięto)" },
-
-  "pricing_ownership_buy": { "other": "Kup" },
-  "pricing_ownership_rent": { "other": "Wypożycz" },
-
-  "classification_intro": { "other": "Klasyfikacja: " },
-
-  "cookie_banner_message": { "other": "Korzystanie z naszej witryny oznacza zgodę na wykorzystywanie plików cookie. Więcej informacji można znaleźć na <a href=\"{{.CookiePolicyURL}}\">polityka prywatności</a>." },
-  "cookie_banner_accept": { "other": "Zaakceptować" },
-
-  "all_rights_reserved": { "other": "Wszelkie prawa zastrzeżone. Treści witryny nie mogą być powielane bez pisemnej zgody jej administratora." },
-
-  "users_gender_none": { "other": "Nieokreślona" },
-  "users_gender_female": { "other": "Kobieta" },
-  "users_gender_male": { "other": "Mężczyzna" },
-  "users_gender_diverse": { "other": "Zróżnicowana" },
-  "users_gender_other": { "other": "Inna" },
-
-  "shopping_info_rental_period_coming_soon": { "other": "od daty i godziny wypożyczenia." },
-
-  "availability_coming_soon": { "other": "Wkrótce" },
-  "availability_renting": { "other": "Do wypożyczenia" },
-  "availability_not_available": { "other": "Niedostępny" },
-  "availability_in_watch_window": { "other": "Dostępny" },
-  "availability_sold_out": { "other": "Wyprzedano" },
-  "availability_available_till": { "other": "Dostępny do {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Niedostępny" },
-  "availability_available": { "other": "Dostępny {{.ReleaseDate}}" },
-  "availability_expires": { "other": "Wygasa {{.Expiry}}" },
-  "availability_expired": { "other": "Wygasł"},
-
-  "modal_cancel": { "other": "Anuluj" },
-
-  "play": { "other": "Odtwórz" },
-
-  "combined_auth_signin_prompt": { "other": "Zaloguj się" },
-  "combined_auth_signup_prompt": { "other": "Zapisz się" },
-  "combined_auth_terms": { "other": "Akceptuję wszystkie <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">warunki korzystania z serwisu</a>." },
-  "signup_terms": { "other": "Akceptuję wszystkie <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">warunki korzystania z serwisu</a>." },
-  "validation_terms_required": { "other": "Musisz zaakceptować warunki korzystania z serwisu." },
-  "shopping_error_item_limit_exceeded": { "other": "Niestety, {{.Title}} został wyprzedany." },
-
-  "app_badge_title": { "other": "Pobierz aplikację, aby wyświetlić zakupione treści!" },
-  "app_badge_ios": { "other": "Pobierz w App Store" },
-  "app_badge_android": { "other": "Kup w Google Play" },
-
+  "userdevices_empty_content": {
+    "other": "Obecnie masz 0 zarejestrowanych urządzeń"
+  },
+  "userdevices_header_type": {
+    "other": "Rodzaj urządzenia"
+  },
+  "userdevices_header_description": {
+    "other": "Opis"
+  },
+  "userdevices_device_added": {
+    "other": "Dodano {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Usuń"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Anuluj"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Tak, usuń urządzenie"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Usunięto)"
+  },
+  "pricing_ownership_buy": {
+    "other": "Kup"
+  },
+  "pricing_ownership_rent": {
+    "other": "Wypożycz"
+  },
+  "classification_intro": {
+    "other": "Klasyfikacja: "
+  },
+  "cookie_banner_message": {
+    "other": "Korzystanie z naszej witryny oznacza zgodę na wykorzystywanie plików cookie. Więcej informacji można znaleźć na <a href=\"{{.CookiePolicyURL}}\">polityka prywatności</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Zaakceptować"
+  },
+  "all_rights_reserved": {
+    "other": "Wszelkie prawa zastrzeżone. Treści witryny nie mogą być powielane bez pisemnej zgody jej administratora."
+  },
+  "users_gender_none": {
+    "other": "Nieokreślona"
+  },
+  "users_gender_female": {
+    "other": "Kobieta"
+  },
+  "users_gender_male": {
+    "other": "Mężczyzna"
+  },
+  "users_gender_diverse": {
+    "other": "Zróżnicowana"
+  },
+  "users_gender_other": {
+    "other": "Inna"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "od daty i godziny wypożyczenia."
+  },
+  "availability_coming_soon": {
+    "other": "Wkrótce"
+  },
+  "availability_renting": {
+    "other": "Do wypożyczenia"
+  },
+  "availability_not_available": {
+    "other": "Niedostępny"
+  },
+  "availability_in_watch_window": {
+    "other": "Dostępny"
+  },
+  "availability_sold_out": {
+    "other": "Wyprzedano"
+  },
+  "availability_available_till": {
+    "other": "Dostępny do {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Niedostępny"
+  },
+  "availability_available": {
+    "other": "Dostępny {{.ReleaseDate}}"
+  },
+  "availability_expires": {
+    "other": "Wygasa {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Wygasł"
+  },
+  "modal_cancel": {
+    "other": "Anuluj"
+  },
+  "play": {
+    "other": "Odtwórz"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Zaloguj się"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Zapisz się"
+  },
+  "combined_auth_terms": {
+    "other": "Akceptuję wszystkie <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">warunki korzystania z serwisu</a>."
+  },
+  "signup_terms": {
+    "other": "Akceptuję wszystkie <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">warunki korzystania z serwisu</a>."
+  },
+  "validation_terms_required": {
+    "other": "Musisz zaakceptować warunki korzystania z serwisu."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Niestety, {{.Title}} został wyprzedany."
+  },
+  "app_badge_title": {
+    "other": "Pobierz aplikację, aby wyświetlić zakupione treści!"
+  },
+  "app_badge_ios": {
+    "other": "Pobierz w App Store"
+  },
+  "app_badge_android": {
+    "other": "Kup w Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Cena"
   },
@@ -500,107 +955,256 @@
   "donate_button_text": {
     "other": "Podarować"
   },
-  "wcag_skip_links_header": { "other": "Linki ułatwień dostępu" },
-  "wcag_skip_links_content": { "other": "Przejdź do treści" },
-
-  "wcag_homepage_h1": { "other": "Strona główna" },
-  "wcag_carousel_h2": { "other": "Karuzela" },
-  "wcag_collections_h2": { "other": "Kolekcje" },
-
-  "wcag_aria_label_footer": { "other": "Stopka" },
-  "wcag_aria_label_nav_main": { "other": "Główny" },
-  "wcag_aria_label_nav_sub": { "other": "Pod" },
-  "wcag_aria_label_toggle_nav": { "other": "Przełącz nawigację" },
-  "wcag_aria_label_bundle_items": { "other": "Zestaw przedmiotów" },
-  "wcag_aria_label_carousel": { "other": "Karuzela" },
-  "wcag_aria_label_page_collection": { "other": "Kolekcja stron" },
-  "wcag_aria_label_collection_list": { "other": "Lista kolekcji" },
-  "wcag_aria_label_collection_slider": { "other": "Suwak kolekcji" },
-  "wcag_aria_label_wishlist": { "other": "Lista życzeń" },
-  "wcag_aria_label_facebook": { "other": "Podziel się Facebook" },
-  "wcag_aria_label_twitter": { "other": "Podziel się Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Podziel się LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Podziel się Letterboxd" },
-
-  "shopping_error_plan_already_owned": { "other": "Masz już ten plan." },
-  "shopping_error_plan_expired": { "other": "Ten plan nie jest już dostępny." },
-  "shopping_payment_method_header": { "other": "Metody Płatności" },
-  "shopping_payment_method_credit_card": { "other": "Karta kredytowa" },
-
-  "shopping_payment_method_giropay": { "other": "Giropay" },
-  "shopping_error_stripe_unknown_error": { "other": "Coś poszło nie tak z tą płatnością. Spróbuj ponownie później." },
-  "shopping_error_payment_complete_failed": { "other": "Płatność została odrzucona. Zamknij to okno i spróbuj ponownie." },
-
-  "header_banner": { "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021" },
-
-  "account_form_pin_code": { "other": "SZPILKA" },
-  "account_form_pin_code_not_set": { "other": "Nie masz zestawu PIN, który jest wymagany do zakupu, wypożyczenia i oglądania niektórych tytułów."},
-  "account_form_set_pin": { "other": "Ustaw PIN" },
-  "account_form_pin_changed": { "other": "Zaktualizowano" },
-  "account_form_change_pin": { "other": "Zmień PIN" },
-
-  "user_set_pin_header": { "other": "Ustaw kod PIN" },
-  "user_set_pin_button": { "other": "Ustaw PIN" },
-  "user_submit_pin_heading": { "other": "Wprowadź kod PIN, aby {{.Action}} tę zastrzeżoną treść" },
-  "user_error_wrong_pin_retry": { "other": "Ups, wpisałeś nieprawidłowy kod PIN" },
-  "user_submit_pin_button": { "other": "Wchodzić" },
-  "user_reset_pin_button": { "other": "Zresetuj PIN" },
-
-  "validation_pincode1_required": { "other": "Wprowadź prawidłowy kod PIN." },
-  "validation_pincode2_required": { "other": "Wprowadź prawidłowy kod PIN." },
-  "validation_pincode1_pattern": { "other": "Wprowadź prawidłowy kod PIN." },
-  "validation_pincode2_pattern": { "other": "Wprowadź prawidłowy kod PIN." },
-  "validation_pincode2_match": { "other": "Kod PIN nie pasuje." },
-
-  "userdevices_delete_limits": { "other": "Możesz usunąć {{.Limit}} urządzenia z tej listy co {{.Period}} dzień(s)."},
-  "userdevices_delete_limit_reached": { "other": "Osiągnąłeś ten limit i nie możesz teraz usunąć żadnych urządzeń. Możesz usunąć urządzenie za {{.Days}} dzień(s)." },
-  "shopping_card_new_subscription": { "other": "Ta karta będzie regularnie zapisywana i ładowana" },
-
-"changepincode_modal_header": { "other": "Zmień kod PIN" },
-"changepincode_modal_currentpassword": { "other": "Twoje obecne hasło" },
-"changepincode_modal_pincode1": { "other": "Twój nowy 4-cyfrowy kod PIN" },
-"changepincode_modal_pincode2": { "other": "Potwierdź nowy 4-cyfrowy kod PIN" },
-"changepincode_modal_submit": { "other": "Ustaw PIN" },
-"changepincode_modal_error_wrong_password": { "other": "To hasło jest nieprawidłowe." },
-
-"user_set_pin_intro": { "other": "Potrzebujesz kodu PIN do {{.Action}} treści objętych ograniczeniami"},
-"user_error_wrong_pin_reset": { "other": "Kliknij tutaj, aby zresetować kod PIN" },
-"user_error_too_many_pin_errors_help_page_link": { "other": "" },
-"shopping_error_age_restricted": { "other": "Ta treść jest ograniczona wiekowo." },
-"shopping_error_close_button": { "other": "OK" },
-
-"usersubscriptions_change_payment_method_change": { "other": "Zmień kartę kredytową" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Zaktualizuj dane karty kredytowej" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Aktualizacja" },
-
-  "usersubscriptions_subscription_expiry": { "other": "Wygasa {{.Expiry}}" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Okres próbny" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Anuluj moją subskrypcję" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Anulować" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Tak, anuluj moją subskrypcję" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Anuluj subskrypcje?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "To anuluje subskrypcję planu {{.Name}}. Nadal będziesz mógł oglądać zawartość planu do czasu jego wygaśnięcia {{.Expiry}}." },
-
-"signin_form_error_ip_throttled": { "other": "nie logowałeś się zbyt wiele razy. Spróbuj ponownie później." },
-"signin_form_error_account_suspended": { "other": "Ynasze konto zostało tymczasowo zawieszone. Skontaktuj się z administratorem, jeśli uważasz, że to pomyłka. " },
-
-"pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HD tylko" },
-  "pricing_quality_sd_only": { "other": "SD tylko"  },
-
-  "shopping_card_save_card": { "other": "Zapisz tę kartę do wykorzystania w przyszłości" },
-  "shopping_card_button_change": { "other": "Pokaż wszystkie zapisane karty" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} kończący się na{{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(wygasa {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(wygasły)" },
-  "shopping_card_use_other": { "other": "Użyj nowej karty" },
-  "shopping_card_use_new_card": { "other": "Zmień kartę" },
-  "shopping_card_update_reason_none": { "other": "Zaktualizuj swoją kartę kredytową. Obsługiwane karty to Visa, Mastercard i American Express." },
-  "shopping_info_ownership_plan": { "other": "Subskrypcja" },
-  "shopping_action_credit": { "other": "Uzupełniać" },
-
-  "seasons":{
+  "wcag_skip_links_header": {
+    "other": "Linki ułatwień dostępu"
+  },
+  "wcag_skip_links_content": {
+    "other": "Przejdź do treści"
+  },
+  "wcag_homepage_h1": {
+    "other": "Strona główna"
+  },
+  "wcag_carousel_h2": {
+    "other": "Karuzela"
+  },
+  "wcag_collections_h2": {
+    "other": "Kolekcje"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Stopka"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Główny"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Pod"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Przełącz nawigację"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Zestaw przedmiotów"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Karuzela"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Kolekcja stron"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Lista kolekcji"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Suwak kolekcji"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Lista życzeń"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Podziel się Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Podziel się Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Podziel się LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Podziel się Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Masz już ten plan."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Ten plan nie jest już dostępny."
+  },
+  "shopping_payment_method_header": {
+    "other": "Metody Płatności"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Karta kredytowa"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Coś poszło nie tak z tą płatnością. Spróbuj ponownie później."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Płatność została odrzucona. Zamknij to okno i spróbuj ponownie."
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021"
+  },
+  "account_form_pin_code": {
+    "other": "SZPILKA"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Nie masz zestawu PIN, który jest wymagany do zakupu, wypożyczenia i oglądania niektórych tytułów."
+  },
+  "account_form_set_pin": {
+    "other": "Ustaw PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Zaktualizowano"
+  },
+  "account_form_change_pin": {
+    "other": "Zmień PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Ustaw kod PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Ustaw PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Wprowadź kod PIN, aby {{.Action}} tę zastrzeżoną treść"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Ups, wpisałeś nieprawidłowy kod PIN"
+  },
+  "user_submit_pin_button": {
+    "other": "Wchodzić"
+  },
+  "user_reset_pin_button": {
+    "other": "Zresetuj PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "Wprowadź prawidłowy kod PIN."
+  },
+  "validation_pincode2_required": {
+    "other": "Wprowadź prawidłowy kod PIN."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Wprowadź prawidłowy kod PIN."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Wprowadź prawidłowy kod PIN."
+  },
+  "validation_pincode2_match": {
+    "other": "Kod PIN nie pasuje."
+  },
+  "userdevices_delete_limits": {
+    "other": "Możesz usunąć {{.Limit}} urządzenia z tej listy co {{.Period}} dzień(s)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Osiągnąłeś ten limit i nie możesz teraz usunąć żadnych urządzeń. Możesz usunąć urządzenie za {{.Days}} dzień(s)."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Ta karta będzie regularnie zapisywana i ładowana"
+  },
+  "changepincode_modal_header": {
+    "other": "Zmień kod PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Twoje obecne hasło"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Twój nowy 4-cyfrowy kod PIN"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Potwierdź nowy 4-cyfrowy kod PIN"
+  },
+  "changepincode_modal_submit": {
+    "other": "Ustaw PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "To hasło jest nieprawidłowe."
+  },
+  "user_set_pin_intro": {
+    "other": "Potrzebujesz kodu PIN do {{.Action}} treści objętych ograniczeniami"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Kliknij tutaj, aby zresetować kod PIN"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Ta treść jest ograniczona wiekowo."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Zmień kartę kredytową"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Zaktualizuj dane karty kredytowej"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Aktualizacja"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Wygasa {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Okres próbny"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Anuluj moją subskrypcję"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Anulować"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Tak, anuluj moją subskrypcję"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Anuluj subskrypcje?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "To anuluje subskrypcję planu {{.Name}}. Nadal będziesz mógł oglądać zawartość planu do czasu jego wygaśnięcia {{.Expiry}}."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "nie logowałeś się zbyt wiele razy. Spróbuj ponownie później."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Ynasze konto zostało tymczasowo zawieszone. Skontaktuj się z administratorem, jeśli uważasz, że to pomyłka. "
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD tylko"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD tylko"
+  },
+  "shopping_card_save_card": {
+    "other": "Zapisz tę kartę do wykorzystania w przyszłości"
+  },
+  "shopping_card_button_change": {
+    "other": "Pokaż wszystkie zapisane karty"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} kończący się na{{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(wygasa {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(wygasły)"
+  },
+  "shopping_card_use_other": {
+    "other": "Użyj nowej karty"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Zmień kartę"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Zaktualizuj swoją kartę kredytową. Obsługiwane karty to Visa, Mastercard i American Express."
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Subskrypcja"
+  },
+  "shopping_action_credit": {
+    "other": "Uzupełniać"
+  },
+  "seasons": {
     "one": "jeden sezon",
     "other": "{{.Count}} pory roku"
   },
@@ -620,31 +1224,70 @@
     "one": "1 Epizod",
     "other": "{{.Count}} Epizod"
   },
-
-  "nav_homepage": { "other": "ABC Cinemas" },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Wygląda na to, że masz problemy.</p><p>Zresetuj kod PIN lub skontaktuj się z nami w sprawie <a href=\"{{.HelpURL}}\" target=\"_blank\">Wsparcie</a>" },
-  "validation_pincode_required": { "other": "Proszę wpisać kod PIN." },
-  "shopping_info_subtitle_wallet": { "other": "Środki z Twojego Portfela mogą zostać wykorzystane na zakup lub wypożyczenie dowolnej zawartości w ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "Zobacz tutaj wymagania systemowe." },
-  "shopping_info_sd_only": { "other": "Ograniczone tylko do odtwarzania SD." },
-  "shopping_error_discount_worn_out": { "other": "Tego kodu promocyjnego nie można już użyć." },
-
-  "activatedevice_page_header": { "other": "Aktywuj urządzenie" },
-  "activatedevice_page_content": { "other": "Postępuj zgodnie z instrukcjami na urządzeniu, aby uzyskać kod PIN. Aby przeprowadzić aktywację, komputer i urządzenie muszą być połączone z Internetem." },
-  "activatedevice_form_pin": { "other": "Kod PIN" },
-  "activatedevice_form_submit": { "other": "Aktywuj" },
-  "activatedevice_form_error_invalid_code": { "other": "Nie znaleziono kodu PIN, spróbuj ponownie." },
-  "activatedevice_form_error_pin_not_found": { "other": "Nie znaleziono kodu PIN, spróbuj ponownie." },
-  "activatedevice_signin_prompt": { "other": "Zaloguj się przed aktywacją urządzenia." },
-  "activatedevice_page_activated": { "other": "Dziękujemy za aktywację {{.DeviceName}}. Powinieneś teraz móc przeglądać swoją bibliotekę na telewizorze lub urządzeniu." },
-
-  "playlist_page_header": { "other": "Lista odtwarzania" },
-  "playlist_sign_in_warning": { "other": "Zaloguj się, aby oglądać telewizję na żywo."},
-  "playlist_share_title": { "other": "Lista odtwarzania" },
-  "playlist_up_next_title": { "other": "W przyszłym" },
-
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-  "shopping_card_change": { "other": "Karta kredytowa jest nieprawidłowa? <a href=\"{{.SubscriptionsURL}}\">Kliknij tutaj, aby zaktualizować swoją kartę.</a>" }
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Wygląda na to, że masz problemy.</p><p>Zresetuj kod PIN lub skontaktuj się z nami w sprawie <a href=\"{{.HelpURL}}\" target=\"_blank\">Wsparcie</a>"
+  },
+  "validation_pincode_required": {
+    "other": "Proszę wpisać kod PIN."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Środki z Twojego Portfela mogą zostać wykorzystane na zakup lub wypożyczenie dowolnej zawartości w ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Zobacz tutaj wymagania systemowe."
+  },
+  "shopping_info_sd_only": {
+    "other": "Ograniczone tylko do odtwarzania SD."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Tego kodu promocyjnego nie można już użyć."
+  },
+  "activatedevice_page_header": {
+    "other": "Aktywuj urządzenie"
+  },
+  "activatedevice_page_content": {
+    "other": "Postępuj zgodnie z instrukcjami na urządzeniu, aby uzyskać kod PIN. Aby przeprowadzić aktywację, komputer i urządzenie muszą być połączone z Internetem."
+  },
+  "activatedevice_form_pin": {
+    "other": "Kod PIN"
+  },
+  "activatedevice_form_submit": {
+    "other": "Aktywuj"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "Nie znaleziono kodu PIN, spróbuj ponownie."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "Nie znaleziono kodu PIN, spróbuj ponownie."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Zaloguj się przed aktywacją urządzenia."
+  },
+  "activatedevice_page_activated": {
+    "other": "Dziękujemy za aktywację {{.DeviceName}}. Powinieneś teraz móc przeglądać swoją bibliotekę na telewizorze lub urządzeniu."
+  },
+  "playlist_page_header": {
+    "other": "Lista odtwarzania"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Zaloguj się, aby oglądać telewizję na żywo."
+  },
+  "playlist_share_title": {
+    "other": "Lista odtwarzania"
+  },
+  "playlist_up_next_title": {
+    "other": "W przyszłym"
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "shopping_card_change": {
+    "other": "Karta kredytowa jest nieprawidłowa? <a href=\"{{.SubscriptionsURL}}\">Kliknij tutaj, aby zaktualizować swoją kartę.</a>"
+  }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -139,13 +139,27 @@
   "social_media_buttons_title": {
     "other": "Compartilhar"
   },
-  "social_media_buttons_facebook": { "other": "Compartilhar no Facebook" },
-  "social_media_buttons_twitter": { "other": "Compartilhar no Twitter" },
-  "social_media_buttons_linkedin": { "other": "Compartilhar no Linkedin" },
-  "social_media_buttons_email": { "other": "Compartilhe via e-mail" },
-  "social_media_buttons_email_subject": { "other": "Compartilhamento de link" },
-  "social_media_buttons_copied_link": { "other": "Link copiado para a área de transferência!" },
-  "social_media_buttons_copy_link": { "other": "Copiar para área de transferência" },
+  "social_media_buttons_facebook": {
+    "other": "Compartilhar no Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Compartilhar no Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Compartilhar no Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Compartilhe via e-mail"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Compartilhamento de link"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link copiado para a área de transferência!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Copiar para área de transferência"
+  },
   "accept_invite_page_header": {
     "other": "Acolher "
   },
@@ -477,8 +491,12 @@
   "validation_dob_date": {
     "other": "Por favor, insira uma data de nascimento válida."
   },
-  "shopping_info_subtitle_hd": { "other": "HD Vídeo sob demanda." },
-  "shopping_info_subtitle_sd": { "other": "SD Vídeo sob demanda." },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Vídeo sob demanda."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Vídeo sob demanda."
+  },
   "shopping_info_subtitle_wallet": {
     "other": "Os créditos em sua Carteira podem ser usados para a compra ou aluguel de qualquer conteúdo no ScreenPlus."
   },
@@ -967,23 +985,36 @@
   "shopping_info_rental_period_coming_soon": {
     "other": "a partir da data e horário do lançamento.."
   },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Alterar cartão de crédito" },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Alterar cartão de crédito"
+  },
   "usersubscriptions_change_payment_method_modal_title": {
     "other": "Atualizar detalhes do cartão de crédito"
   },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Atualizar" },
-
-  "usersubscriptions_subscription_expiry": { "other": "Expira {{.Expiry}}" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Período de teste" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Cancelar minha assinaturan" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Cancelar" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Sim, cancelar minha assinatura" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Cancelar assinatura?" },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Atualizar"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Expira {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Período de teste"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Cancelar minha assinaturan"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Cancelar"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Sim, cancelar minha assinatura"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Cancelar assinatura?"
+  },
   "usersubscriptions_unsubscribe_modal_body": {
     "other": "Isso cancelará a assinatura do plano {{.Name}}. Você ainda poderá assistir ao conteúdo do plano até que expire {{.Expiry}}."
   },
-
   "availability_coming_soon": {
     "other": "Em breve"
   },
@@ -1038,43 +1069,105 @@
   "shopping_error_item_limit_exceeded": {
     "other": "Infelizmente, {{.Title}} já está esgotado."
   },
-  "changepincode_modal_header": { "other": "Alterar seu PIN" },
-  "changepincode_modal_currentpassword": { "other": "Sua senha atual" },
-  "changepincode_modal_pincode1": { "other": "Seus novos 4 dígitos" },
-  "changepincode_modal_pincode2": { "other": "Confirme seus novos 4 dígitos PIN" },
-  "changepincode_modal_submit": { "other": "Definir PIN" },
-  "changepincode_modal_error_wrong_password": { "other": "Essa senha está incorreta." },
-  "user_set_pin_intro": { "other": "Você precisa de um PIN para {{.Action}} conteúdo restrito" },
-  "user_error_wrong_pin_reset": { "other": "Clique aqui para redefinir seu PIN" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Este conteúdo tem restrição de idade." },
-  "shopping_error_close_button": { "other": "OK" },
-  "wcag_skip_links_header": { "other": "Links de acessibilidade" },
-  "wcag_skip_links_content": { "other": "Ir para o conteúdo" },
-
-  "wcag_homepage_h1": { "other": "Pagina inicial" },
-  "wcag_carousel_h2": { "other": "Carrossel" },
-  "wcag_collections_h2": { "other": "Coleções" },
-
-  "wcag_aria_label_footer": { "other": "Rodapé" },
-  "wcag_aria_label_nav_main": { "other": "Principal" },
-  "wcag_aria_label_nav_sub": { "other": "Sub" },
-  "wcag_aria_label_toggle_nav": { "other": "Alternar de navegação" },
-  "wcag_aria_label_bundle_items": { "other": "Itens do pacote" },
-  "wcag_aria_label_carousel": { "other": "Carrossel" },
-  "wcag_aria_label_page_collection": { "other": "Página Coleções" },
-  "wcag_aria_label_collection_list": { "other": "Coleções Lista" },
-  "wcag_aria_label_collection_slider": { "other": "Coleções Controle deslizante" },
-  "wcag_aria_label_wishlist": { "other": "Lista de Desejos" },
-  "wcag_aria_label_facebook": { "other": "Compartilhar no Facebook" },
-  "wcag_aria_label_twitter": { "other": "Compartilhar no Twitter" },
-  "wcag_aria_label_linkedin": { "other": "Compartilhar no LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Visualizar no Letterboxd" },
-
-  "app_badge_title": { "other": "Baixe o aplicativo para visualizar o conteúdo adquirido!" },
-  "app_badge_ios": { "other": "Baixar na loja de aplicativos" },
-  "app_badge_android": { "other": "Obtê-lo no Google Play" },
-
+  "changepincode_modal_header": {
+    "other": "Alterar seu PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Sua senha atual"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Seus novos 4 dígitos"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Confirme seus novos 4 dígitos PIN"
+  },
+  "changepincode_modal_submit": {
+    "other": "Definir PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Essa senha está incorreta."
+  },
+  "user_set_pin_intro": {
+    "other": "Você precisa de um PIN para {{.Action}} conteúdo restrito"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Clique aqui para redefinir seu PIN"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Este conteúdo tem restrição de idade."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "wcag_skip_links_header": {
+    "other": "Links de acessibilidade"
+  },
+  "wcag_skip_links_content": {
+    "other": "Ir para o conteúdo"
+  },
+  "wcag_homepage_h1": {
+    "other": "Pagina inicial"
+  },
+  "wcag_carousel_h2": {
+    "other": "Carrossel"
+  },
+  "wcag_collections_h2": {
+    "other": "Coleções"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Rodapé"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Principal"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Alternar de navegação"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Itens do pacote"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Carrossel"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Página Coleções"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Coleções Lista"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Coleções Controle deslizante"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Lista de Desejos"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Compartilhar no Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Compartilhar no Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Compartilhar no LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Visualizar no Letterboxd"
+  },
+  "app_badge_title": {
+    "other": "Baixe o aplicativo para visualizar o conteúdo adquirido!"
+  },
+  "app_badge_ios": {
+    "other": "Baixar na loja de aplicativos"
+  },
+  "app_badge_android": {
+    "other": "Obtê-lo no Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Preço"
   },
@@ -1146,8 +1239,10 @@
   "donate_button_text": {
     "other": "Doar"
   },
-
-  "shopping_error_plan_already_owned": { "other": "Você já tem este plano." },
-  "shopping_error_plan_expired": { "other": "Este plano não está mais disponível." }
-
+  "shopping_error_plan_already_owned": {
+    "other": "Você já tem este plano."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Este plano não está mais disponível."
+  }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1,598 +1,1248 @@
 {
-    "site_owner": { "other": "ABC Cinemas" },
-    "settings_title": { "other": "Configurações" },
-    "powered_by": { "other": "Distribuído por" },
-    "powered_by_name": { "other": "ScreenPlus" },
-    "powered_by_url": { "other": "https://www.shift72.com" },
-    "in_partnership_with": { "other": "em parceria com" },
-    "festival_scope": { "other": "Festival Scope" },
-    "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-    "en": { "other": "English" },
-    "fr": { "other": "French" },
-  
-    "episode_name": {
-      "other": "Episódio"
-    },
-
-    "season_name": {
-      "other": "Temporada"
-    },
-
-    "seasons":{
-      "one": "uma temporada",
-      "other": "{{.Count}} temporadas"
-    },
-    "tvseason": {
-      "other": "{{.ShowInfo.Title}} Séries {{.Season.SeasonNumber}}"
-    },
-    "tvseason_html": {
-      "other": "{{.ShowInfo.Title}} <span> Séries {{.Season.SeasonNumber}}</span>"
-    },
-    "tvepisode": {
-      "other": "{{.Episode.Title}}"
-    },
-    "tvseason_number": {
-      "other": "Séries {{.Season.SeasonNumber}}"
-    },
-    "episode_count": {
-      "one": "1 Episódio",
-      "other": "{{.Count}} Episódios"
-    },
-
-    "date_day": { "other": "Dia" },
-    "date_month": { "other": "Mês" },
-    "date_year": { "other": "Ano" },
-
-    "404_page_header": { "other": "Esta página não existe..." },
-    "404_page_content": { "other": "<p>Desculpe-nos, parece que a página que você está procurando não existe.</p><p>Ela pode ter sido removida, ou talvez você tenha digitado algo errado.</p><p>Tente voltar para a Página Inicial para buscar o que você estava procurando.</p><p><a href=\"{{.URL}}\">Voltar a Página Inicial</a></p>" },
-
-
-    "nav_homepage": { "other": "ABC Cinemas" },
-    "nav_signin": { "other": "Entrar" },
-    "nav_signup": { "other": "Criar Conta" },
-    "nav_signed_in_as": { "other": "Conectado como" },
-    "nav_library": { "other": "Minha Biblioteca" },
-    "nav_devices": { "other": "Meus Dispositivos" },
-    "nav_wishlist": { "other": "Minha Lista" },
-    "nav_account": { "other": "Minha Conta" },
-    "nav_signout": { "other": "Sair" },
-    "play_trailer": { "other": "Trailer" },
-    "runtime_hours": { "other": "h" },
-    "runtime_minutes": { "other": "m" },
-
-    "datetime_today": { "other": "hoje {{.Date}}" },
-    "datetime_tomorrow": { "other": "amanhã {{.Date}}" },
-    "datetime_yesterday": { "other": "ontem {{.Date}}" },
-    "datetime_next": { "other": "{{.Date}}" },
-    "datetime_last": { "other": "último(a) {{.Date}}" },
-
-    "search_control_placeholder": { "other": "Buscar" },
-    "search_control_submit": { "other": "Buscar" },
-
-    "play_button_watch": { "other" : "Assistir Agora"},
-    "play_button_resume": { "other" : "Continuar"},
-
-    "social_media_buttons_title": { "other": "Compartilhar" },
-    "social_media_buttons_facebook": { "other": "Compartilhar no Facebook" },
-    "social_media_buttons_twitter": { "other": "Compartilhar no Twitter" },
-    "social_media_buttons_linkedin": { "other": "Compartilhar no Linkedin" },
-    "social_media_buttons_email": { "other": "Compartilhe via e-mail" },
-    "social_media_buttons_email_subject": { "other": "Compartilhamento de link" },
-    "social_media_buttons_copied_link": { "other": "Link copiado para a área de transferência!" },
-    "social_media_buttons_copy_link": { "other": "Copiar para área de transferência" },
-
-    "accept_invite_page_header": { "other": "Acolher " },
-    "acceptinvite_form_invalid_reset_password_token": { "other": "Parece que você já aceitou esse convite, você deve <a href=\"{{.SigninURL}}\">entrar em sua conta</a>. Se você esqueceu sua senha, você também pode <a href=\"{{.ForgotPasswordURL}}\">alterar sua senha</a>." },
-    "acceptinvite_complete": { "other": "Obrigado! Sua conta foi criada." },
-    "acceptinvite_form_submit": { "other": "Aceitar Convite" },
-    "acceptinvite_agreement": { "other": "Ao clicar em \"Aceitar Convite\" você concorda que leu e concorda com os nossos <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termos de uso</a> e <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">política de privacidade</a>." },
-
-    "signup_page_header": { "other": "Criar nova conta" },
-    "signup_form_name": { "other": "Nome" },
-    "signup_form_email": { "other": "E-mail" },
-    "signup_form_password": { "other": "Senha" },
-    "signup_form_password_confirmation": { "other": "Confirme sua senha" },
-    "signup_form_gender": { "other": "Gênero" },
-    "signup_form_dob": { "other": "Data de nascimento" },
-    "signup_form_submit": { "other": "Enviar" },
-
-    "signin_page_header": { "other": "Entrar" },
-    "signin_form_email": { "other": "E-mail" },
-    "signin_form_password": { "other": "Senha" },
-    "signin_form_remember": { "other": "Lembrar-me" },
-    "signin_form_submit": { "other": "Enviar" },
-    "signin_page_forgotpassword": { "other": "Esqueceu sua senha?" },
-    "signin_page_createnewaccount": { "other": "Não tem uma conta? Criar uma conta" },
-    "signup_page_alreadyhaveanaccount": { "other": "Já possui uma conta? Acessar sua conta" },
-    "signup_form_error_email_already_in_use": { "other": "Esse endereço de e-mail já está em uso." },
-    "signin_form_error_incorrect_credentials": { "other": "O nome de usuário ou senha estão incorretos." },
-    "signup_form_error_forbidden": { "other": "Ocorreu um erro." },
-
-    "combined_auth_continue": { "other": "Continuar" },
-    "combined_auth_change": { "other": "mudar" },
-    "combined_auth_signin": { "other": "Entrar" },
-    "combined_auth_signup": { "other": "Criar conta" },
-    "combined_auth_signin_password": { "other": "Por favor, insira sua senha para entrar em sua conta." },
-    "combined_auth_signin_error_incorrect_credentials": { "other": "A senha fornecida está incorreta." },
-    "combined_auth_error_forbidden": { "other": "Ocorreu um erro." },
-    "combined_auth_error_too_many_requests": { "other": "Muitos pedidos. Por favor tente mais tarde." },
-
-    "forgotpassword_page_header": { "other": "Alterar senha" },
-    "forgotpassword_form_email": { "other": "E-mail" },
-    "forgotpassword_form_submit": { "other": "Alterar" },
-    "forgotpassword_form_error_email_doesnt_exist": { "other": "Não existe uma conta com esse endereço de e-mail." },
-    "forgotpassword_form_error_account_suspended": { "other": "Essa conta foi suspensa." },
-    "forgotpassword_complete": { "other": "Obrigado. Você deve receber um e-mail para alteração de senha na sua caixa de entrada." },
-    "forgotpassword_form_error_forbidden": { "other": "Ocorreu um erro." },
-    "forgotpassword_form_error_too_many_requests": { "other": "Muitos pedidos. Por favor tente mais tarde." },
-
-    "resetpassword_page_header": { "other": "Alterar sua senha" },
-    "resetpassword_form_invalid_reset_password_token": { "other": "Parece que esse pedido para alteração de senha é inválido. Por favor, faça uma nova solicitação em <a href=\"{{.URL}}\">Esqueci minha senha</a>." },
-    "resetpassword_form_password": { "other": "Nova senha" },
-    "resetpassword_form_password2": { "other": "Confirmar nova senha" },
-    "resetpassword_form_submit": { "other": "Alterar" },
-    "resetpassword_complete": { "other": "Obrigado. Sua senha foi alterada e você está conectado." },
-    "resetpassword_form_error_invalid_reset_password_token": { "other": "O pedido para alteração de senha é inválido, por favor tente novamente mais tarde." },
-    "resetpassword_form_error_reset_password_token_expired": { "other": "O token para alteração de senha expirou. Por favor, solicite novamente." },
-    "resetpassword_form_error_too_many_requests": { "other": "Muitos pedidos. Por favor tente mais tarde." },
-
-    "account_page_header": { "other": "Minha conta" },
-    "account_form_name": { "other": "Nome" },
-    "account_form_email": { "other": "E-mail" },
-    "account_form_password": { "other": "Senha" },
-    "account_form_change_password": { "other": "Alterar" },
-    "account_form_gender": { "other": "Gênero" },
-    "account_form_dob": { "other": "Data de Nascimento" },
-    "account_form_submit": { "other": "Atualizar" },
-    "account_form_submitted": { "other": "Atualizado" },
-    "account_form_password_changed": { "other": "Atualizado" },
-    "account_form_error_incorrect_password": { "other": "Senha incorreta." },
-
-    "signup_form_optin": {"other": "Inscreva-se na nossa newsletter"},
-
-    "passwordconfirmation_modal_header": { "other": "Confirme sua senha" },
-    "passwordconfirmation_modal_label": { "other": "Por favor, insira sua senha para atualizar seu cadastro." },
-    "passwordconfirmation_modal_confirm": { "other": "Confirmar" },
-
-    "changepassword_modal_header": { "other": "Alterar senha" },
-    "changepassword_modal_currentpassword": { "other": "Sua senha atual" },
-    "changepassword_modal_password": { "other": "Sua nova senha" },
-    "changepassword_modal_password2": { "other": "Confirmar nova senha" },
-    "changepassword_modal_submit": { "other": "Alterar" },
-    "changepassword_modal_error_incorrect_password": { "other": "Senha incorreta." },
-
-    "userlibrary_page_header": { "other": "Minha Biblioteca" },
-    "userlibrary_empty_header":  { "other": "Sua biblioteca está vazia." },
-    "userlibrary_empty_content": { "other": "Preencha-a <a href=\"{{.HomeURL}}\">navegando</a> em nossa programação." },
-
-    "searchresults_page_header": { "other": "Resultados da busca" },
-    "searchresults_load_more": { "other": "Carregar {{.Count}} mais" },
-    "searchresults_total": {
-      "one": "Encontrado 1 resultado para  \"{{.Query}}\".",
-      "other": "Encontrado {{.Count}} resultado para \"{{.Query}}\"."
-    },
-    "searchresults_empty_header":  { "other": "Não foram encontrados resultados para \"{{.Query}}\"" },
-    "searchresults_empty_content": { "other": "Tente fazer outra busca ou <a href=\"{{.HomeURL}}\">navegue pelo nosso conteúdo</a> para encontrar o que está procurando." },
-
-    "validation_name_required": { "other": "Por favor, insira seu nome." },
-    "validation_email_required": { "other": "Por favor, insira seu e-mail" },
-    "validation_email_email": { "other": "Por favor, insira um e-mail válido." },
-    "validation_currentpassword_required": { "other": "Por favor, insira sua senha atual." },
-    "validation_password_required": { "other": "Por favor, insira uma senha" },
-    "validation_password2_required": { "other": "Por favor, confirme sua senha." },
-    "validation_password2_match": { "other": "Suas senhas não conferem." },
-    "validation_password_minlength": { "other": "Por favor, sua senha deve ter pelo menos {{.Count}} caracteres." },
-    "validation_promocode_required": { "other": "Por favor, insira um código promocional" },
-    "validation_pincode_required": { "other": "Por favor, insira um código PIN." },
-    "validation_gender_required": { "other": "Por favor, selecione o gênero com o qual você se identifica mais." },
-    "validation_dob_required": { "other": "Por favor, insira sua data de nascimento" },
-    "validation_dob_date": { "other": "Por favor, insira uma data de nascimento válida." },
-
-    "shopping_info_subtitle_hd": { "other": "HD Vídeo sob demanda." },
-    "shopping_info_subtitle_sd": { "other": "SD Vídeo sob demanda." },
-    "shopping_info_subtitle_wallet": { "other": "Os fundos em sua Carteira podem ser usados ​​para a compra ou aluguel de qualquer conteúdo no ScreenPlus." },
-    "shopping_info_subtitle_help": { "other": "Veja aqui os requisitos de sistema." },
-    "shopping_info_ownership_buy": { "other": "compra" },
-    "shopping_info_ownership_rent": { "other": "aluguel" },
-
-    "shopping_info_sd_only": { "other": "Limitado apenas à reprodução SD." },
-    "shopping_info_release_date_title": { "other": "Lançamentos {{.Date}}. " },
-    "shopping_info_release_date_explanation_rent": { "other": "Você pode alugar agora, mas não poderá assistir até a data." },
-    "shopping_info_release_date_explanation_buy": { "other": "Você pode comprar agora, mas não poderá assistir até a data." },
-
-    "shopping_info_available_until_date_title": { "other": "Disponível até {{.Date}}. " },
-    "shopping_info_available_until_date_explanation_rent": { "other": "Você não poderá assistir ao conteúdo após esta data." },
-    "shopping_info_available_until_date_explanation_buy": { "other": "Você não poderá assistir ao conteúdo após esta data." },
-
-    "duration_hour": { "one": "1 hora", "other": "{{.Count}} horas" },
-    "duration_day": { "one": "1 dia", "other": "{{.Count}} dias" },
-    "shopping_info_rental_period_duration": { "other": "Aluguel de {{.ValueUnit}} " },
-    "shopping_info_watch_window_duration": { "other": "Período de reprodução de {{.Count}} horas. " },
-    "shopping_info_watch_window_explanation_film": {
-      "one": "Uma vez alugado, o filme estará disponível na sua conta por {{.ValueUnit}}. ",
-      "other": "Uma vez alugado, o filme estará disponível na sua conta por {{.ValueUnit}}. "
-    },
-    "shopping_info_watch_window_explanation2_film": {
-      "one": "Uma vez pressionado play, o período de reprodução se inicia e você tem uma hora para assistir o filme quantas vezes quiser.",
-      "other": "Uma vez pressionado play, o período de reprodução se inicia e você tem {{.Count}} horas para assistir o filme quantas vezes quiser."
-    },
-    "shopping_info_watch_window_explanation_bundle": {
-      "one": "Uma vez alugado, os filmes do pacote estarão disponíveis na sua conta por um dia.",
-      "other": "Uma vez alugado, os filmes do pacote estarão disponíveis na sua conta por {{.Count}} dias."
-    },
-    "shopping_info_watch_window_explanation2_bundle": {
-      "one": "Uma vez pressionado play, o período de reprodução se inicia e você tem uma hora para assistir o filme quantas vezes quiser.",
-      "other": "Uma vez pressionado play, o período de reprodução se inicia e você tem {{.Count}} horas para assistir o filme quantas vezes quiser."
-    },
-    "shopping_info_watch_window_explanation_season": {
-      "one": "Uma vez alugada, sua temporada estará disponível na sua conta por um dia. ",
-      "other": "Uma vez alugada, sua temporada estará disponível na sua conta por {{.Count}} dias."
-    },
-    "shopping_info_watch_window_explanation2_season": {
-      "one": "Uma vez pressionado play, o período de reprodução se inicia e você tem uma hora para assistir o episódio quantas vezes quiser.",
-      "other": "Uma vez pressionado play, o período de reprodução se inicia e você tem {{.Count}} horas para assistir o episódio quantas vezes quiser."
-    },
-    "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Bônus" },
-
-    "shopping_enter_card_prompt": { "other": "Preencha abaixo os dados do seu cartão para completar sua {{.Verb}}." },
-
-    "shopping_terms": { "other": "Ao realizar essa transação, eu aceito os <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">termos e condições</a>."},
-    "shopping_discount_applied": { "other": "{{.DiscountAmount}} de desconto aplicado." },
-    "shopping_discount_apply": { "other": "Aplicar" },
-    "shopping_discount_code": { "other": "Insira um código promocional." },
-    "shopping_discount_have_code": { "other": "Eu tenho um código promocional." },
-
-    "shopping_price_you_pay": { "other": "Você paga" },
-    "shopping_price_nothing": { "other": "Nada" },
-    "shopping_price_free": { "other": "Gratuito" },
-
-    "shopping_auth_directions": { "other": "Uma conta é necessária primeiro. Por favor, insira seu endereço de e-mail." },
-
-    "shopping_error_in_library": { "other": "{{.Title}} já está na sua biblioteca." },
-
-    "shopping_error_missing_card": { "other": "Por favor, insira os dados do seu cartão de crédito." },
-    "shopping_error_title": { "other": "Ocorreu um erro." },
-    "shopping_error_incorrect_cvc": { "other": "Por favor, insira um CVV válido." },
-    "shopping_error_invalid_cvc": { "other": "Por favor, insira um CVV válido." },
-    "shopping_error_incorrect_number": { "other": "Por favor, insira um número de cartão de crédito válido." },
-    "shopping_error_invalid_number": { "other": "Por favor, insira um número de cartão de crédito válido." },
-    "shopping_error_card_declined": { "other": "O cartão de crédito foi recusado." },
-    "shopping_error_invalid_expiry_month": { "other": "Por favor, insira uma data de validade válida." },
-    "shopping_error_invalid_expiry_year": { "other": "Por favor, insira uma data de validade válida." },
-    "shopping_error_expired_card": { "other": "O cartão de crédito está vencido." },
-    "shopping_error_creditcard_country_mismatch": { "other": "Sua {{.Ownership}} não foi bem-sucedida. Você deve estar no mesmo país onde seu cartão de crédito foi emitido. Por favor, use outro cartão de crédito para este pagamento." },
-    "shopping_error_proxy_detected": { "other": "Sua {{.Ownership}} não foi bem-sucedida. Nós detectamos que você está utilizando um desbloqueador ou proxy. Por favor, desligue esses dispositivos e tente novamente." },
-
-    "shopping_error_discount_worn_out": { "other": "Esse código promocional não pode mais ser usado." },
-    "shopping_error_discount_blank": { "other": "Por favor, insira um código promocional válido" },
-    "shopping_error_discount_not_applied": { "other": "Por favor, insira um código promocional válido" },
-    "shopping_error_discount_invalid": { "other": "Por favor, insira um código promocional válido" },
-    "shopping_error_discount_disabled": { "other": "Por favor, insira um código promocional válido." },
-    "shopping_error_discount_already_applied": { "other": "Um código promocional já foi usado para essa sessão." },
-    "shopping_error_discount_already_redeemed": { "other": "Este código promocional já foi utilizado." },
-    "shopping_error_discount_used_previously": { "other": "Este código promocional já foi utilizado." },
-    "shopping_error_discount_max_limit": { "other": "Este código promocional já não pode ser utilizado." },
-    "shopping_error_discount_expired": { "other": "Este código promocional já expirou." },
-    "shopping_error_discount_invalid_ownership_buy": { "other": "Este código promocional não pode ser usado para compra." },
-    "shopping_error_discount_invalid_ownership_rent": { "other": "Este código promocional não pode ser usado para locação." },
-    "shopping_error_discount_invalid_item": { "other": "Este código promocional não pode ser usado para este item." },
-    "shopping_error_discount_invalid_pricing_region": { "other": "Este código promocional não pode ser usado no seu país." },
-    "shopping_error_discounts_not_allowed": { "other": "Este código promocional não pode ser usado." },
-    "shopping_error_discount_disallowed_on_bundles": { "other": "Este código promocional não pode ser usado em pacotes." },
-    "shopping_error_payment_intent_authentication_failure": { "other": "Seu cartão de crédito foi recusado. Por favor, tente novamente." },
-
-    "shopping_complete_rental": { "other": "Successo!" },
-    "shopping_complete_rental_period": {
-      "one": "Agora você pode assistir quantas vezes quiser durante o próximo dia.",
-      "other": "Agora você pode assistir quantas vezes quiser durante os próximos {{.Count}} dias."
-    },
-    "shopping_complete_purchase": { "other": "Obrigado por comprar {{.Title}}." },
-    "shopping_complete_credit_purchase": { "other": "Obrigado por comprar {{.Title}}, {{.CreditTotal}} foram adicionados à sua conta." },
-    "shopping_complete_purchase_coming_soon": { "other": "Você poderá assistir a partir de {{.Date}}." },
-    "shopping_complete_receipt": { "other": "Um comprovante foi enviado por e-mail." },
-    "shopping_complete_library_link": { "other": "Ver sua biblioteca" },
-    "shopping_complete_plan": {
-      "other": "Sua compra de {{ .Title }} foi bem-sucedida."
-    },
-    "shopping_complete_rental_watch_window_start": {
-      "one": "Você pode começar a assistir durante o próximo dia.",
-      "other": "Você pode começar a assistir durante os próximos{{.Count}} dias."
-    },
-    "shopping_complete_rental_watch_window_end": {
-      "one": "Quando a reprodução iniciar, você terá uma hora para assistir quantas vezes quiser.",
-      "other": "Quando a reprodução iniciar, você terá {{.Count}} horas para assistir quantas vezes quiser."
-    },
-    "shopping_complete_rental_coming_soon": {
-      "one": "Você poderá assistir a partir de {{.Date}} e sua locação continuará ativa por um dia.",
-      "other": "Você poderá assistir a partir de {{.Date}} e sua locação continuará ativa por {{.Count}} dias."
-    },
-    "shopping_complete_rental_coming_soon_watch_window_start": {
-      "one": "Você poderá assistir a partir de {{.Date}} e sua locação continuará ativa por um dia.",
-      "other": "Você poderá assistir a partir de {{.Date}} e sua locação continuará ativa por {{.Count}} dias."
-    },
-
-    "shopping_action_rent": { "other": "Alugar" },
-    "shopping_action_buy": { "other": "Comprar" },
-
-    "meta_detail_cast_title": { "other": "Elenco" },
-    "meta_detail_crew_title": { "other": "Equipe" },
-    "meta_detail_languages": { "one": "Idioma", "other": "Idiomas" },
-    "meta_detail_studios": { "one": "Estúdio", "other": "Estúdios" },
-    "meta_detail_countries": { "one": "País", "other": "Países" },
-    "meta_detail_subtitles": { "other": "Legendas" },
-    "meta_detail_captions": { "other": "Legendas [CC]" },
-    "meta_detail_episodes_title": { "other": "Episódios" },
-    "meta_detail_bonus_title": { "other": "Conteúdo Adicional" },
-    "meta_detail_recommendations_title": { "other": "Você também pode gostar de..." },
-    "meta_detail_bundle_items_title": { "other": "Conteúdo incluso nesse pacote" },
-
-    "bundle_items_all_films": { "other": "{{.Count}} filmes" },
-    "bundle_items_all_seasons": { "other": "{{.Count}} temporada" },
-    "bundle_items_mixed": { "other": "{{.Count}} filmes e temporadas" },
-    "userwishlist_page_header": { "other": "Minha Lista" },
-    "userwishlist_slider_header": { "other": "Minha Lista" },
-    "userwishlist_empty_header":  { "other": "Sua lista está vazia." },
-    "userwishlist_empty_content": { "other": "Preencha-a <a href=\"{{.HomeURL}}\">navegando</a> na nossa programação." },
-    "userwishlist_button_add": { "other": "Adicionar à minha lista" },
-    "userwishlist_button_remove": { "other": "Minha Lista" },
-    "userwishlist_button_add_compact": { "other": "Minha Lista" },
-    "userwishlist_button_remove_compact": { "other": "Minha Lista" },
-
-    "activatedevice_page_header": { "other": "Dispositivo Ativado" },
-    "activatedevice_page_content": { "other": "Siga as instruções no seu dispositivo para obter um código PIN. O computador e o dispositivo devem estar conectados à Internet para ativar." },
-    "activatedevice_form_pin": { "other": "PIN Código" },
-    "activatedevice_form_submit": { "other": "Ativar" },
-    "activatedevice_form_error_invalid_code": { "other": "Código PIN não encontrado, tente novamente." },
-    "activatedevice_form_error_pin_not_found": { "other": "Código PIN não encontrado, tente novamente." },
-    "activatedevice_signin_prompt": { "other": "Faça login antes de ativar seu dispositivo." },
-    "activatedevice_page_activated": { "other": "Obrigado por ativar {{.DeviceName}}. Agora você pode navegar na sua biblioteca na televisão ou dispositivo." },
-
-    "userdevices_page_header": { "other": "Dispositivos" },
-    "userdevices_page_content": {
-      "one": "Dispositivos serão automaticamente adicionados aqui quando você usá-los. Você pode adicionar apenas um dispositivo.",
-      "other": "Dispositivos serão automaticamente adicionados aqui quando você usá-los. Você pode adicionar até {{.Count}} dispositivos."
-    },
-    "userdevices_empty_content": { "other": "Você possui 0 dispositivos registrados." },
-    "userdevices_header_type": { "other": "Tipo de Dispositivo" },
-    "userdevices_header_description": { "other": "Descrição" },
-    "userdevices_device_added": { "other": "Adicionado em {{.Date}}" },
-    "userdevices_device_actions_delete": { "other": "Remover" },
-    "userdevices_device_actions_cancel": { "other": "Cancelar" },
-    "userdevices_device_actions_confirm": { "other": "Sim, remover dispositivo" },
-    "userdevices_device_deleted": { "other": "(Removido)" },
-
-    "playlist_page_header": { "other": "Lista de reprodução" },
-    "playlist_sign_in_warning": { "other": "Faça login para assistir TV ao vivo."},
-    "playlist_share_title": { "other": "Lista de reprodução" },
-    "playlist_up_next_title": { "other": "Próximo" },
-
-    "pricing_ownership_buy": { "other": "Comprar" },
-    "pricing_ownership_rent": { "other": "Alugar" },
-
-    "classification_intro": { "other": "Classificação: " },
-    "classification_divider": { "other": " - " },
-    "classification_outro": { "other": "" },
-
-    "cookie_banner_message": { "other": "Esse site utiliza cookies para melhorar sua experiência. Ao usar esse site, você aceita nossa <a href=\"{{.CookiePolicyURL}}\">cookie usage</a>." },
-    "cookie_banner_accept": { "other": "Aceitar" },
-
-    "all_rights_reserved": { "other": "Todos os direitos reservados. Nenhuma parte desse site pode ser reproduzida sem permissão por escrito." },
-
-    "users_gender_none": { "other": "Não especificado" },
-    "users_gender_female": { "other": "Feminino" },
-    "users_gender_male": { "other": "Masculino" },
-    "users_gender_diverse": { "other": "Diverso" },
-    "users_gender_other": { "other": "Outro" },
-
-    "pricing_quality_hd": { "other": "HD" },
-    "pricing_quality_sd": { "other": "SD" },
-    "pricing_quality_hd_only": { "other": "HD só" },
-    "pricing_quality_sd_only": { "other": "SD só" },
-
-    "shopping_card_save_card": { "other": "Salve este cartão para nós no futuroe" },
-    "shopping_card_button_change": { "other": "Mostrar todos os cartões salvos" },
-    "shopping_card_existing_description": { "other": "{{.Card.Brand}} acabando{{.Card.Number}}" },
-    "shopping_card_existing_expiry": { "other": "(expira {{.Card.Expiry}})" },
-    "shopping_card_existing_expired": { "other": "(expirada)" },
-    "shopping_card_use_other": { "other": "Usar um novo cartão" },
-    "shopping_card_use_new_card": { "other": "Alterar cartão" },
-
-    "shopping_info_ownership_plan": { "other": "Inscrição" },
-
-
-
-    "shopping_action_credit": { "other": "Completar" },
-
-
-
-    "shopping_info_rental_period_coming_soon": { "other": "a partir da data e horário do lançamento.." },
-
-    "usersubscriptions_change_payment_method_change": { "other": "Alterar cartão de crédito" },
-    "usersubscriptions_change_payment_method_modal_title": { "other": "Atualizar detalhes do cartão de crédito" },
-    "usersubscriptions_change_payment_method_modal_submit": { "other": "Atualizar" },
-  
-    "usersubscriptions_subscription_expiry": { "other": "Expira {{.Expiry}}" },
-    "usersubscriptions_subscription_status_trialing": { "other": "Período de teste" },
-    "usersubscriptions_subscription_unsubscribe": { "other": "Cancelar minha assinaturan" },
-    "usersubscriptions_unsubscribe_modal_cancel": { "other": "Cancelar" },
-    "usersubscriptions_unsubscribe_modal_confirm": { "other": "Sim, cancelar minha assinatura" },
-    "usersubscriptions_unsubscribe_modal_title": { "other": "Cancelar assinatura?" },
-    "usersubscriptions_unsubscribe_modal_body": { "other": "Isso cancelará a assinatura do plano {{.Name}}. Você ainda poderá assistir ao conteúdo do plano até que expire {{.Expiry}}." },
-  
-
-    "shopping_card_update_reason_none": { "other": "Atualize seu cartão de crédito. Os cartões suportados são Visa, Mastercard e American Express" },
-
-    "availability_coming_soon": { "other": "Em breve" },
-    "availability_renting": { "other": "Alugando" },
-    "availability_not_available": { "other": "Não disponível" },
-    "availability_in_watch_window": { "other": "availability_in_watch_window" },
-    "availability_sold_out": { "other": "Esgotado" },
-    "availability_available_till": { "other": "Disponível até {{.ExpiryDate}}" },
-    "availability_not_available_in_country": { "other": "Não disponível" },
-    "availability_available": { "other": "Disponível em {{.ReleaseDate}}" },
-
-    "modal_cancel": { "other": "Cancelar" },
-
-    "play": { "other": "Assistir" },
-
-    "combined_auth_signin_prompt": { "other": "Entrar" },
-    "combined_auth_signup_prompt": { "other": "Inscrever-se" },
-    "combined_auth_terms": { "other": "Eu aceito todos os <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termos &amp; condições</a>." },
-    "signup_terms": { "other": "Eu aceito todos os <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termos &amp; condições</a>." },
-    "validation_terms_required": { "other": "Você deve aceitar os termos e condições." },
-    "shopping_error_item_limit_exceeded": { "other": "Infelizmente, {{.Title}} já está esgotado." },
-
-    "shopping_card_change": { "other": "Cartão de crédito incorreto? <a href=\"{{.SubscriptionsURL}}\">Clique aqui para atualizar seu cartão.</a>" },
-
-    "user_error_too_many_pin_errors": { "other": "<p>Parece que você está com problemas.</p><p>Redefina seu PIN ou entre em contato conosco para <a href=\"{{.HelpURL}}\" target=\"_blank\">ajuda</a>" },
-
-    "app_badge_title": { "other": "Baixe o aplicativo para visualizar o conteúdo adquirido!" },
-    "app_badge_ios": { "other": "Baixar na loja de aplicativos" },
-    "app_badge_android": { "other": "Obtê-lo no Google Play" },
-
-    "shopping_price_title_plan": {
-      "other": "Preço"
-    },
-    "shopping_price_plan_note": {
-      "zero": "Cobrado a cada {{ .Interval }} .",
-      "one": "Cobrado a cada {{ .Interval }} após o término da avaliação gratuita de 24 horas.",
-      "other": "Cobrado a cada {{ .Interval }} após o {{ .Count }} avaliação gratuita de .Count dias."
-    },
-    "shopping_price_plan_note_interval": {
-      "one": "{{ .Interval }}",
-      "other": "{{ .Count }} {{ .Interval }}"
-    },
-    "shopping_enter_card_prompt_plan": {
-      "other": "Insira os dados do seu cartão de crédito abaixo para iniciar a sua assinatura."
-    },
-    "shopping_action_plan": {
-      "other": "Completo"
-    },
-    "shopping_complete_subscription": {
-      "other": "Sua compra de assinatura foi bem-sucedida. Agora você está inscrito em {{ .Title }} ."
-    },
-    "shopping_complete_subscription_browse": {
-      "other": "Fique à vontade para <a href=\"/\">navegar pelo</a> site ou <a href=\"/search.html\">pesquisar</a> algo específico."
-    },
-    "shopping_info_plan_offer": {
-      "one": "Renova automaticamente a cada {{ .Interval }}",
-      "other": "Renova automaticamente cada {{ .Count }} {{ .Interval }}"
-    },
-    "shopping_info_trial_period_offer": {
-      "one": "Experimente agora o seu teste gratuito de 24 horas!",
-      "other": "Experimente o seu teste gratuito de {{ .Count }} dia!"
-    },
-    "plans_page_header": {
-      "other": "Planos Disponíveis"
-    },
-    "plan_label_owned": {
-      "other": "Você possui este plano"
-    },
-    "plan_expiry_date": {
-      "other": "Fechamento de vendas:"
-    },
-    "plan_read_more": {
-      "other": "Descubra mais"
-    },
-    "plan_page_read_more": {
-      "other": "Consulte Mais informação"
-    },
-    "plan_page_header_text": {
-      "other": "Aproveite {{ .Name }}"
-    },
-    "page_plan_explore_intro": {
-      "other": "OU"
-    },
-    "page_plan_explore_link": {
-      "other": "Explore outros passes"
-    },
-    "plan_showcase_page_ownership_button_buy": {
-      "other": "Compre Agora"
-    },
-    "plan_free_link_text": {
-      "other": "Cadastre-se gratuitamente"
-    },
-    "awards_in_competition": {
-      "other": "Em competição"
-    },
-    "awards_winner": {
-      "other": "Vencedora"
-    },
-    "donate_button_text": {
-      "other": "Doar"
-    },
-    "wcag_skip_links_header": { "other": "Links de acessibilidade" },
-    "wcag_skip_links_content": { "other": "Ir para o conteúdo" },
-  
-    "wcag_homepage_h1": { "other": "Pagina inicial" },
-    "wcag_carousel_h2": { "other": "Carrossel" },
-    "wcag_collections_h2": { "other": "Coleções" },
-  
-    "wcag_aria_label_footer": { "other": "Rodapé" },
-    "wcag_aria_label_nav_main": { "other": "Principal" },
-    "wcag_aria_label_nav_sub": { "other": "Sub" },
-    "wcag_aria_label_toggle_nav": { "other": "Alternar de navegação" },
-    "wcag_aria_label_bundle_items": { "other": "Itens do pacote" },
-    "wcag_aria_label_carousel": { "other": "Carrossel" },
-    "wcag_aria_label_page_collection": { "other": "Página Coleções" },
-    "wcag_aria_label_collection_list": { "other": "Coleções Lista" },
-    "wcag_aria_label_collection_slider": { "other": "Coleções Controle deslizante" },
-    "wcag_aria_label_wishlist": { "other": "Lista de Desejos" },
-    "wcag_aria_label_facebook": { "other": "Compartilhar no Facebook" },
-    "wcag_aria_label_twitter": { "other": "Compartilhar no Twitter" },
-    "wcag_aria_label_linkedin": { "other": "Compartilhar no LinkedIn" },
-    "wcag_aria_label_letterboxd": { "other": "Visualizar no Letterboxd" },
-
-    "shopping_error_plan_already_owned": { "other": "Você já tem este plano." },
-    "shopping_error_plan_expired": { "other": "Este plano não está mais disponível." },
-    "shopping_payment_method_header": { "other": "Métodos de Pagamento" },
-    "shopping_payment_method_credit_card": { "other": "Cartão de crédito" },
-    "shopping_payment_method_giropay": { "other": "Giropay" },
-    "shopping_error_stripe_unknown_error": { "other": "Salgo deu errado com este pagamento. Por favor, tente novamente mais tarde." },
-    "shopping_error_payment_complete_failed": { "other": "O pagamento foi recusado. Feche esta janela e tente novamente." },
-
-    "header_banner": { "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021" },
-
-    "account_form_pin_code": { "other": "PIN" },
-    "account_form_pin_code_not_set": { "other": "Você não tem um PIN definido, que é necessário para comprar, alugar e assistir a alguns títulos."},
-    "account_form_set_pin": { "other": "Definir PIN" },
-    "account_form_pin_changed": { "other": "Atualizada" },
-    "account_form_change_pin": { "other": "Mudar PIN" },
-
-    "user_set_pin_header": { "other": "Defina seu PIN" },
-    "user_set_pin_button": { "other": "Defina PIN" },
-    "user_submit_pin_heading": { "other": "Digite seu PIN para {{.Action}} este conteúdo restrito" },
-    "user_error_wrong_pin_retry": { "other": "Ops, você digitou um PIN incorreto" },
-    "user_submit_pin_button": { "other": "Entrar" },
-    "user_reset_pin_button": { "other": "Redefinir PIN" },
-
-    "validation_pincode1_required": { "other": "Insira um código PIN válido." },
-    "validation_pincode2_required": { "other": "Insira um código PIN válido." },
-    "validation_pincode1_pattern": { "other": "Insira um código PIN válido." },
-    "validation_pincode2_pattern": { "other": "Insira um código PIN válido." },
-    "validation_pincode2_match": { "other": "O código PIN não corresponde." },
-  
-    "userdevices_delete_limits": { "other": "Você pode remover {{.Limit}} dispositivo(s) desta lista a cada {{.Period}} dia(s)."},
-    "userdevices_delete_limit_reached": { "other": "Você atingiu esse limite e não pode remover nenhum dispositivo agora. Você pode excluir um dispositivo em {{.Days}} dia(s)." },
-    "shopping_card_new_subscription": { "other": "Este cartão será salvo e cobrado regularmente" },
-
-  "changepincode_modal_header": { "other": "Alterar seu PIN" },
-  "changepincode_modal_currentpassword": { "other": "Sua senha atual" },
-  "changepincode_modal_pincode1": { "other": "Seus novos 4 dígitos"},
-  "changepincode_modal_pincode2": { "other": "Confirme seus novos 4 dígitos PIN" },
-  "changepincode_modal_submit": { "other": "Definir PIN" },
-  "changepincode_modal_error_wrong_password": { "other": "Essa senha está incorreta." },
-
-  "user_set_pin_intro": { "other": "Você precisa de um PIN para {{.Action}} conteúdo restrito"},
-  "user_error_wrong_pin_reset": { "other": "Clique aqui para redefinir seu PIN" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Este conteúdo tem restrição de idade." },
-  "shopping_error_close_button": { "other": "OK" },
-
-  "availability_expires": { "other": "Expira {{.Expiry}}" },
-  "availability_expired": { "other": "Expirada"},
-
-  "signin_form_error_ip_throttled": { "other": "Você falhou ao fazer login muitas vezes. Por favor, tente novamente mais tarde." },
-  "signin_form_error_account_suspended": { "other": "Sua conta foi temporariamente suspensa. Entre em contato com um administrador se você acredita que isso é um erro." }
-    
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Configurações"
+  },
+  "powered_by": {
+    "other": "Distribuído por"
+  },
+  "powered_by_name": {
+    "other": "ScreenPlus"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "em parceria com"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "English"
+  },
+  "fr": {
+    "other": "French"
+  },
+  "episode_name": {
+    "other": "Episódio"
+  },
+  "season_name": {
+    "other": "Temporada"
+  },
+  "seasons": {
+    "one": "uma temporada",
+    "other": "{{.Count}} temporadas"
+  },
+  "tvseason": {
+    "other": "{{.ShowInfo.Title}} Séries {{.Season.SeasonNumber}}"
+  },
+  "tvseason_html": {
+    "other": "{{.ShowInfo.Title}} <span> Séries {{.Season.SeasonNumber}}</span>"
+  },
+  "tvepisode": {
+    "other": "{{.Episode.Title}}"
+  },
+  "tvseason_number": {
+    "other": "Séries {{.Season.SeasonNumber}}"
+  },
+  "episode_count": {
+    "one": "1 Episódio",
+    "other": "{{.Count}} Episódios"
+  },
+  "date_day": {
+    "other": "Dia"
+  },
+  "date_month": {
+    "other": "Mês"
+  },
+  "date_year": {
+    "other": "Ano"
+  },
+  "404_page_header": {
+    "other": "Esta página não existe..."
+  },
+  "404_page_content": {
+    "other": "<p>Desculpe-nos, parece que a página que você está procurando não existe.</p><p>Ela pode ter sido removida, ou talvez você tenha digitado algo errado.</p><p>Tente voltar para a Página Inicial para buscar o que você estava procurando.</p><p><a href=\"{{.URL}}\">Voltar a Página Inicial</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Entrar"
+  },
+  "nav_signup": {
+    "other": "Criar Conta"
+  },
+  "nav_signed_in_as": {
+    "other": "Conectado como"
+  },
+  "nav_library": {
+    "other": "Minha Biblioteca"
+  },
+  "nav_devices": {
+    "other": "Meus Dispositivos"
+  },
+  "nav_wishlist": {
+    "other": "Minha Lista"
+  },
+  "nav_account": {
+    "other": "Minha Conta"
+  },
+  "nav_signout": {
+    "other": "Sair"
+  },
+  "play_trailer": {
+    "other": "Trailer"
+  },
+  "runtime_hours": {
+    "other": "h"
+  },
+  "runtime_minutes": {
+    "other": "m"
+  },
+  "datetime_today": {
+    "other": "hoje {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "amanhã {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "ontem {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "último(a) {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Buscar"
+  },
+  "search_control_submit": {
+    "other": "Buscar"
+  },
+  "play_button_watch": {
+    "other": "Assistir Agora"
+  },
+  "play_button_resume": {
+    "other": "Continuar"
+  },
+  "social_media_buttons_title": {
+    "other": "Compartilhar"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Compartilhar no Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Compartilhar no Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Compartilhar no Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Compartilhe via e-mail"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Compartilhamento de link"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link copiado para a área de transferência!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Copiar para área de transferência"
+  },
+  "accept_invite_page_header": {
+    "other": "Acolher "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Parece que você já aceitou esse convite, você deve <a href=\"{{.SigninURL}}\">entrar em sua conta</a>. Se você esqueceu sua senha, você também pode <a href=\"{{.ForgotPasswordURL}}\">alterar sua senha</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Obrigado! Sua conta foi criada."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Aceitar Convite"
+  },
+  "acceptinvite_agreement": {
+    "other": "Ao clicar em \"Aceitar Convite\" você concorda que leu e concorda com os nossos <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termos de uso</a> e <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">política de privacidade</a>."
+  },
+  "signup_page_header": {
+    "other": "Criar nova conta"
+  },
+  "signup_form_name": {
+    "other": "Nome"
+  },
+  "signup_form_email": {
+    "other": "E-mail"
+  },
+  "signup_form_password": {
+    "other": "Senha"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Confirme sua senha"
+  },
+  "signup_form_gender": {
+    "other": "Gênero"
+  },
+  "signup_form_dob": {
+    "other": "Data de nascimento"
+  },
+  "signup_form_submit": {
+    "other": "Enviar"
+  },
+  "signin_page_header": {
+    "other": "Entrar"
+  },
+  "signin_form_email": {
+    "other": "E-mail"
+  },
+  "signin_form_password": {
+    "other": "Senha"
+  },
+  "signin_form_remember": {
+    "other": "Lembrar-me"
+  },
+  "signin_form_submit": {
+    "other": "Enviar"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Esqueceu sua senha?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Não tem uma conta? Criar uma conta"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Já possui uma conta? Acessar sua conta"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Esse endereço de e-mail já está em uso."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "O nome de usuário ou senha estão incorretos."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Ocorreu um erro."
+  },
+  "combined_auth_continue": {
+    "other": "Continuar"
+  },
+  "combined_auth_change": {
+    "other": "mudar"
+  },
+  "combined_auth_signin": {
+    "other": "Entrar"
+  },
+  "combined_auth_signup": {
+    "other": "Criar conta"
+  },
+  "combined_auth_signin_password": {
+    "other": "Por favor, insira sua senha para entrar em sua conta."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "A senha fornecida está incorreta."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Ocorreu um erro."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Muitos pedidos. Por favor tente mais tarde."
+  },
+  "forgotpassword_page_header": {
+    "other": "Alterar senha"
+  },
+  "forgotpassword_form_email": {
+    "other": "E-mail"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Alterar"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Não existe uma conta com esse endereço de e-mail."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Essa conta foi suspensa."
+  },
+  "forgotpassword_complete": {
+    "other": "Obrigado. Você deve receber um e-mail para alteração de senha na sua caixa de entrada."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Ocorreu um erro."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Muitos pedidos. Por favor tente mais tarde."
+  },
+  "resetpassword_page_header": {
+    "other": "Alterar sua senha"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Parece que esse pedido para alteração de senha é inválido. Por favor, faça uma nova solicitação em <a href=\"{{.URL}}\">Esqueci minha senha</a>."
+  },
+  "resetpassword_form_password": {
+    "other": "Nova senha"
+  },
+  "resetpassword_form_password2": {
+    "other": "Confirmar nova senha"
+  },
+  "resetpassword_form_submit": {
+    "other": "Alterar"
+  },
+  "resetpassword_complete": {
+    "other": "Obrigado. Sua senha foi alterada e você está conectado."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "O pedido para alteração de senha é inválido, por favor tente novamente mais tarde."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "O token para alteração de senha expirou. Por favor, solicite novamente."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Muitos pedidos. Por favor tente mais tarde."
+  },
+  "account_page_header": {
+    "other": "Minha conta"
+  },
+  "account_form_name": {
+    "other": "Nome"
+  },
+  "account_form_email": {
+    "other": "E-mail"
+  },
+  "account_form_password": {
+    "other": "Senha"
+  },
+  "account_form_change_password": {
+    "other": "Alterar"
+  },
+  "account_form_gender": {
+    "other": "Gênero"
+  },
+  "account_form_dob": {
+    "other": "Data de Nascimento"
+  },
+  "account_form_submit": {
+    "other": "Atualizar"
+  },
+  "account_form_submitted": {
+    "other": "Atualizado"
+  },
+  "account_form_password_changed": {
+    "other": "Atualizado"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Senha incorreta."
+  },
+  "signup_form_optin": {
+    "other": "Inscreva-se na nossa newsletter"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Confirme sua senha"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Por favor, insira sua senha para atualizar seu cadastro."
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Confirmar"
+  },
+  "changepassword_modal_header": {
+    "other": "Alterar senha"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Sua senha atual"
+  },
+  "changepassword_modal_password": {
+    "other": "Sua nova senha"
+  },
+  "changepassword_modal_password2": {
+    "other": "Confirmar nova senha"
+  },
+  "changepassword_modal_submit": {
+    "other": "Alterar"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Senha incorreta."
+  },
+  "userlibrary_page_header": {
+    "other": "Minha Biblioteca"
+  },
+  "userlibrary_empty_header": {
+    "other": "Sua biblioteca está vazia."
+  },
+  "userlibrary_empty_content": {
+    "other": "Preencha-a <a href=\"{{.HomeURL}}\">navegando</a> em nossa programação."
+  },
+  "searchresults_page_header": {
+    "other": "Resultados da busca"
+  },
+  "searchresults_load_more": {
+    "other": "Carregar {{.Count}} mais"
+  },
+  "searchresults_total": {
+    "one": "Encontrado 1 resultado para  \"{{.Query}}\".",
+    "other": "Encontrado {{.Count}} resultado para \"{{.Query}}\"."
+  },
+  "searchresults_empty_header": {
+    "other": "Não foram encontrados resultados para \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Tente fazer outra busca ou <a href=\"{{.HomeURL}}\">navegue pelo nosso conteúdo</a> para encontrar o que está procurando."
+  },
+  "validation_name_required": {
+    "other": "Por favor, insira seu nome."
+  },
+  "validation_email_required": {
+    "other": "Por favor, insira seu e-mail"
+  },
+  "validation_email_email": {
+    "other": "Por favor, insira um e-mail válido."
+  },
+  "validation_currentpassword_required": {
+    "other": "Por favor, insira sua senha atual."
+  },
+  "validation_password_required": {
+    "other": "Por favor, insira uma senha"
+  },
+  "validation_password2_required": {
+    "other": "Por favor, confirme sua senha."
+  },
+  "validation_password2_match": {
+    "other": "Suas senhas não conferem."
+  },
+  "validation_password_minlength": {
+    "other": "Por favor, sua senha deve ter pelo menos {{.Count}} caracteres."
+  },
+  "validation_promocode_required": {
+    "other": "Por favor, insira um código promocional"
+  },
+  "validation_pincode_required": {
+    "other": "Por favor, insira um código PIN."
+  },
+  "validation_gender_required": {
+    "other": "Por favor, selecione o gênero com o qual você se identifica mais."
+  },
+  "validation_dob_required": {
+    "other": "Por favor, insira sua data de nascimento"
+  },
+  "validation_dob_date": {
+    "other": "Por favor, insira uma data de nascimento válida."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD Vídeo sob demanda."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD Vídeo sob demanda."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Os fundos em sua Carteira podem ser usados ​​para a compra ou aluguel de qualquer conteúdo no ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Veja aqui os requisitos de sistema."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "compra"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "aluguel"
+  },
+  "shopping_info_sd_only": {
+    "other": "Limitado apenas à reprodução SD."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Lançamentos {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Você pode alugar agora, mas não poderá assistir até a data."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Você pode comprar agora, mas não poderá assistir até a data."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Disponível até {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Você não poderá assistir ao conteúdo após esta data."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Você não poderá assistir ao conteúdo após esta data."
+  },
+  "duration_hour": {
+    "one": "1 hora",
+    "other": "{{.Count}} horas"
+  },
+  "duration_day": {
+    "one": "1 dia",
+    "other": "{{.Count}} dias"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "Aluguel de {{.ValueUnit}} "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "Período de reprodução de {{.Count}} horas. "
+  },
+  "shopping_info_watch_window_explanation_film": {
+    "one": "Uma vez alugado, o filme estará disponível na sua conta por {{.ValueUnit}}. ",
+    "other": "Uma vez alugado, o filme estará disponível na sua conta por {{.ValueUnit}}. "
+  },
+  "shopping_info_watch_window_explanation2_film": {
+    "one": "Uma vez pressionado play, o período de reprodução se inicia e você tem uma hora para assistir o filme quantas vezes quiser.",
+    "other": "Uma vez pressionado play, o período de reprodução se inicia e você tem {{.Count}} horas para assistir o filme quantas vezes quiser."
+  },
+  "shopping_info_watch_window_explanation_bundle": {
+    "one": "Uma vez alugado, os filmes do pacote estarão disponíveis na sua conta por um dia.",
+    "other": "Uma vez alugado, os filmes do pacote estarão disponíveis na sua conta por {{.Count}} dias."
+  },
+  "shopping_info_watch_window_explanation2_bundle": {
+    "one": "Uma vez pressionado play, o período de reprodução se inicia e você tem uma hora para assistir o filme quantas vezes quiser.",
+    "other": "Uma vez pressionado play, o período de reprodução se inicia e você tem {{.Count}} horas para assistir o filme quantas vezes quiser."
+  },
+  "shopping_info_watch_window_explanation_season": {
+    "one": "Uma vez alugada, sua temporada estará disponível na sua conta por um dia. ",
+    "other": "Uma vez alugada, sua temporada estará disponível na sua conta por {{.Count}} dias."
+  },
+  "shopping_info_watch_window_explanation2_season": {
+    "one": "Uma vez pressionado play, o período de reprodução se inicia e você tem uma hora para assistir o episódio quantas vezes quiser.",
+    "other": "Uma vez pressionado play, o período de reprodução se inicia e você tem {{.Count}} horas para assistir o episódio quantas vezes quiser."
+  },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Bônus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Preencha abaixo os dados do seu cartão para completar sua {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Ao realizar essa transação, eu aceito os <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">termos e condições</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} de desconto aplicado."
+  },
+  "shopping_discount_apply": {
+    "other": "Aplicar"
+  },
+  "shopping_discount_code": {
+    "other": "Insira um código promocional."
+  },
+  "shopping_discount_have_code": {
+    "other": "Eu tenho um código promocional."
+  },
+  "shopping_price_you_pay": {
+    "other": "Você paga"
+  },
+  "shopping_price_nothing": {
+    "other": "Nada"
+  },
+  "shopping_price_free": {
+    "other": "Gratuito"
+  },
+  "shopping_auth_directions": {
+    "other": "Uma conta é necessária primeiro. Por favor, insira seu endereço de e-mail."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} já está na sua biblioteca."
+  },
+  "shopping_error_missing_card": {
+    "other": "Por favor, insira os dados do seu cartão de crédito."
+  },
+  "shopping_error_title": {
+    "other": "Ocorreu um erro."
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Por favor, insira um CVV válido."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Por favor, insira um CVV válido."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Por favor, insira um número de cartão de crédito válido."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Por favor, insira um número de cartão de crédito válido."
+  },
+  "shopping_error_card_declined": {
+    "other": "O cartão de crédito foi recusado."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Por favor, insira uma data de validade válida."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Por favor, insira uma data de validade válida."
+  },
+  "shopping_error_expired_card": {
+    "other": "O cartão de crédito está vencido."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Sua {{.Ownership}} não foi bem-sucedida. Você deve estar no mesmo país onde seu cartão de crédito foi emitido. Por favor, use outro cartão de crédito para este pagamento."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Sua {{.Ownership}} não foi bem-sucedida. Nós detectamos que você está utilizando um desbloqueador ou proxy. Por favor, desligue esses dispositivos e tente novamente."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Esse código promocional não pode mais ser usado."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Por favor, insira um código promocional válido"
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Por favor, insira um código promocional válido"
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Por favor, insira um código promocional válido"
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Por favor, insira um código promocional válido."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Um código promocional já foi usado para essa sessão."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Este código promocional já foi utilizado."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Este código promocional já foi utilizado."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Este código promocional já não pode ser utilizado."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Este código promocional já expirou."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Este código promocional não pode ser usado para compra."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Este código promocional não pode ser usado para locação."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Este código promocional não pode ser usado para este item."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Este código promocional não pode ser usado no seu país."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Este código promocional não pode ser usado."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Este código promocional não pode ser usado em pacotes."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Seu cartão de crédito foi recusado. Por favor, tente novamente."
+  },
+  "shopping_complete_rental": {
+    "other": "Successo!"
+  },
+  "shopping_complete_rental_period": {
+    "one": "Agora você pode assistir quantas vezes quiser durante o próximo dia.",
+    "other": "Agora você pode assistir quantas vezes quiser durante os próximos {{.Count}} dias."
+  },
+  "shopping_complete_purchase": {
+    "other": "Obrigado por comprar {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Obrigado por comprar {{.Title}}, {{.CreditTotal}} foram adicionados à sua conta."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Você poderá assistir a partir de {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Um comprovante foi enviado por e-mail."
+  },
+  "shopping_complete_library_link": {
+    "other": "Ver sua biblioteca"
+  },
+  "shopping_complete_plan": {
+    "other": "Sua compra de {{ .Title }} foi bem-sucedida."
+  },
+  "shopping_complete_rental_watch_window_start": {
+    "one": "Você pode começar a assistir durante o próximo dia.",
+    "other": "Você pode começar a assistir durante os próximos{{.Count}} dias."
+  },
+  "shopping_complete_rental_watch_window_end": {
+    "one": "Quando a reprodução iniciar, você terá uma hora para assistir quantas vezes quiser.",
+    "other": "Quando a reprodução iniciar, você terá {{.Count}} horas para assistir quantas vezes quiser."
+  },
+  "shopping_complete_rental_coming_soon": {
+    "one": "Você poderá assistir a partir de {{.Date}} e sua locação continuará ativa por um dia.",
+    "other": "Você poderá assistir a partir de {{.Date}} e sua locação continuará ativa por {{.Count}} dias."
+  },
+  "shopping_complete_rental_coming_soon_watch_window_start": {
+    "one": "Você poderá assistir a partir de {{.Date}} e sua locação continuará ativa por um dia.",
+    "other": "Você poderá assistir a partir de {{.Date}} e sua locação continuará ativa por {{.Count}} dias."
+  },
+  "shopping_action_rent": {
+    "other": "Alugar"
+  },
+  "shopping_action_buy": {
+    "other": "Comprar"
+  },
+  "meta_detail_cast_title": {
+    "other": "Elenco"
+  },
+  "meta_detail_crew_title": {
+    "other": "Equipe"
+  },
+  "meta_detail_languages": {
+    "one": "Idioma",
+    "other": "Idiomas"
+  },
+  "meta_detail_studios": {
+    "one": "Estúdio",
+    "other": "Estúdios"
+  },
+  "meta_detail_countries": {
+    "one": "País",
+    "other": "Países"
+  },
+  "meta_detail_subtitles": {
+    "other": "Legendas"
+  },
+  "meta_detail_captions": {
+    "other": "Legendas [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Episódios"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Conteúdo Adicional"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Você também pode gostar de..."
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Conteúdo incluso nesse pacote"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} filmes"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} temporada"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} filmes e temporadas"
+  },
+  "userwishlist_page_header": {
+    "other": "Minha Lista"
+  },
+  "userwishlist_slider_header": {
+    "other": "Minha Lista"
+  },
+  "userwishlist_empty_header": {
+    "other": "Sua lista está vazia."
+  },
+  "userwishlist_empty_content": {
+    "other": "Preencha-a <a href=\"{{.HomeURL}}\">navegando</a> na nossa programação."
+  },
+  "userwishlist_button_add": {
+    "other": "Adicionar à minha lista"
+  },
+  "userwishlist_button_remove": {
+    "other": "Minha Lista"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Minha Lista"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Minha Lista"
+  },
+  "activatedevice_page_header": {
+    "other": "Dispositivo Ativado"
+  },
+  "activatedevice_page_content": {
+    "other": "Siga as instruções no seu dispositivo para obter um código PIN. O computador e o dispositivo devem estar conectados à Internet para ativar."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN Código"
+  },
+  "activatedevice_form_submit": {
+    "other": "Ativar"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "Código PIN não encontrado, tente novamente."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "Código PIN não encontrado, tente novamente."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Faça login antes de ativar seu dispositivo."
+  },
+  "activatedevice_page_activated": {
+    "other": "Obrigado por ativar {{.DeviceName}}. Agora você pode navegar na sua biblioteca na televisão ou dispositivo."
+  },
+  "userdevices_page_header": {
+    "other": "Dispositivos"
+  },
+  "userdevices_page_content": {
+    "one": "Dispositivos serão automaticamente adicionados aqui quando você usá-los. Você pode adicionar apenas um dispositivo.",
+    "other": "Dispositivos serão automaticamente adicionados aqui quando você usá-los. Você pode adicionar até {{.Count}} dispositivos."
+  },
+  "userdevices_empty_content": {
+    "other": "Você possui 0 dispositivos registrados."
+  },
+  "userdevices_header_type": {
+    "other": "Tipo de Dispositivo"
+  },
+  "userdevices_header_description": {
+    "other": "Descrição"
+  },
+  "userdevices_device_added": {
+    "other": "Adicionado em {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Remover"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Cancelar"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Sim, remover dispositivo"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Removido)"
+  },
+  "playlist_page_header": {
+    "other": "Lista de reprodução"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Faça login para assistir TV ao vivo."
+  },
+  "playlist_share_title": {
+    "other": "Lista de reprodução"
+  },
+  "playlist_up_next_title": {
+    "other": "Próximo"
+  },
+  "pricing_ownership_buy": {
+    "other": "Comprar"
+  },
+  "pricing_ownership_rent": {
+    "other": "Alugar"
+  },
+  "classification_intro": {
+    "other": "Classificação: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Esse site utiliza cookies para melhorar sua experiência. Ao usar esse site, você aceita nossa <a href=\"{{.CookiePolicyURL}}\">cookie usage</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Aceitar"
+  },
+  "all_rights_reserved": {
+    "other": "Todos os direitos reservados. Nenhuma parte desse site pode ser reproduzida sem permissão por escrito."
+  },
+  "users_gender_none": {
+    "other": "Não especificado"
+  },
+  "users_gender_female": {
+    "other": "Feminino"
+  },
+  "users_gender_male": {
+    "other": "Masculino"
+  },
+  "users_gender_diverse": {
+    "other": "Diverso"
+  },
+  "users_gender_other": {
+    "other": "Outro"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD só"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD só"
+  },
+  "shopping_card_save_card": {
+    "other": "Salve este cartão para nós no futuroe"
+  },
+  "shopping_card_button_change": {
+    "other": "Mostrar todos os cartões salvos"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} acabando{{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(expira {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(expirada)"
+  },
+  "shopping_card_use_other": {
+    "other": "Usar um novo cartão"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Alterar cartão"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Inscrição"
+  },
+  "shopping_action_credit": {
+    "other": "Completar"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "a partir da data e horário do lançamento.."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Alterar cartão de crédito"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Atualizar detalhes do cartão de crédito"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Atualizar"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Expira {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Período de teste"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Cancelar minha assinaturan"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Cancelar"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Sim, cancelar minha assinatura"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Cancelar assinatura?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Isso cancelará a assinatura do plano {{.Name}}. Você ainda poderá assistir ao conteúdo do plano até que expire {{.Expiry}}."
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Atualize seu cartão de crédito. Os cartões suportados são Visa, Mastercard e American Express"
+  },
+  "availability_coming_soon": {
+    "other": "Em breve"
+  },
+  "availability_renting": {
+    "other": "Alugando"
+  },
+  "availability_not_available": {
+    "other": "Não disponível"
+  },
+  "availability_in_watch_window": {
+    "other": "availability_in_watch_window"
+  },
+  "availability_sold_out": {
+    "other": "Esgotado"
+  },
+  "availability_available_till": {
+    "other": "Disponível até {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Não disponível"
+  },
+  "availability_available": {
+    "other": "Disponível em {{.ReleaseDate}}"
+  },
+  "modal_cancel": {
+    "other": "Cancelar"
+  },
+  "play": {
+    "other": "Assistir"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Entrar"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Inscrever-se"
+  },
+  "combined_auth_terms": {
+    "other": "Eu aceito todos os <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termos &amp; condições</a>."
+  },
+  "signup_terms": {
+    "other": "Eu aceito todos os <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">termos &amp; condições</a>."
+  },
+  "validation_terms_required": {
+    "other": "Você deve aceitar os termos e condições."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Infelizmente, {{.Title}} já está esgotado."
+  },
+  "shopping_card_change": {
+    "other": "Cartão de crédito incorreto? <a href=\"{{.SubscriptionsURL}}\">Clique aqui para atualizar seu cartão.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Parece que você está com problemas.</p><p>Redefina seu PIN ou entre em contato conosco para <a href=\"{{.HelpURL}}\" target=\"_blank\">ajuda</a>"
+  },
+  "app_badge_title": {
+    "other": "Baixe o aplicativo para visualizar o conteúdo adquirido!"
+  },
+  "app_badge_ios": {
+    "other": "Baixar na loja de aplicativos"
+  },
+  "app_badge_android": {
+    "other": "Obtê-lo no Google Play"
+  },
+  "shopping_price_title_plan": {
+    "other": "Preço"
+  },
+  "shopping_price_plan_note": {
+    "zero": "Cobrado a cada {{ .Interval }} .",
+    "one": "Cobrado a cada {{ .Interval }} após o término da avaliação gratuita de 24 horas.",
+    "other": "Cobrado a cada {{ .Interval }} após o {{ .Count }} avaliação gratuita de .Count dias."
+  },
+  "shopping_price_plan_note_interval": {
+    "one": "{{ .Interval }}",
+    "other": "{{ .Count }} {{ .Interval }}"
+  },
+  "shopping_enter_card_prompt_plan": {
+    "other": "Insira os dados do seu cartão de crédito abaixo para iniciar a sua assinatura."
+  },
+  "shopping_action_plan": {
+    "other": "Completo"
+  },
+  "shopping_complete_subscription": {
+    "other": "Sua compra de assinatura foi bem-sucedida. Agora você está inscrito em {{ .Title }} ."
+  },
+  "shopping_complete_subscription_browse": {
+    "other": "Fique à vontade para <a href=\"/\">navegar pelo</a> site ou <a href=\"/search.html\">pesquisar</a> algo específico."
+  },
+  "shopping_info_plan_offer": {
+    "one": "Renova automaticamente a cada {{ .Interval }}",
+    "other": "Renova automaticamente cada {{ .Count }} {{ .Interval }}"
+  },
+  "shopping_info_trial_period_offer": {
+    "one": "Experimente agora o seu teste gratuito de 24 horas!",
+    "other": "Experimente o seu teste gratuito de {{ .Count }} dia!"
+  },
+  "plans_page_header": {
+    "other": "Planos Disponíveis"
+  },
+  "plan_label_owned": {
+    "other": "Você possui este plano"
+  },
+  "plan_expiry_date": {
+    "other": "Fechamento de vendas:"
+  },
+  "plan_read_more": {
+    "other": "Descubra mais"
+  },
+  "plan_page_read_more": {
+    "other": "Consulte Mais informação"
+  },
+  "plan_page_header_text": {
+    "other": "Aproveite {{ .Name }}"
+  },
+  "page_plan_explore_intro": {
+    "other": "OU"
+  },
+  "page_plan_explore_link": {
+    "other": "Explore outros passes"
+  },
+  "plan_showcase_page_ownership_button_buy": {
+    "other": "Compre Agora"
+  },
+  "plan_free_link_text": {
+    "other": "Cadastre-se gratuitamente"
+  },
+  "awards_in_competition": {
+    "other": "Em competição"
+  },
+  "awards_winner": {
+    "other": "Vencedora"
+  },
+  "donate_button_text": {
+    "other": "Doar"
+  },
+  "wcag_skip_links_header": {
+    "other": "Links de acessibilidade"
+  },
+  "wcag_skip_links_content": {
+    "other": "Ir para o conteúdo"
+  },
+  "wcag_homepage_h1": {
+    "other": "Pagina inicial"
+  },
+  "wcag_carousel_h2": {
+    "other": "Carrossel"
+  },
+  "wcag_collections_h2": {
+    "other": "Coleções"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Rodapé"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Principal"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Sub"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Alternar de navegação"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Itens do pacote"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Carrossel"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Página Coleções"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Coleções Lista"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Coleções Controle deslizante"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Lista de Desejos"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Compartilhar no Facebook"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Compartilhar no Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Compartilhar no LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Visualizar no Letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Você já tem este plano."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Este plano não está mais disponível."
+  },
+  "shopping_payment_method_header": {
+    "other": "Métodos de Pagamento"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Cartão de crédito"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Giropay"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Salgo deu errado com este pagamento. Por favor, tente novamente mais tarde."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "O pagamento foi recusado. Feche esta janela e tente novamente."
+  },
+  "header_banner": {
+    "other": "ABC Cinemas – 21st  Film Festival, June 1 – 6, 2021"
+  },
+  "account_form_pin_code": {
+    "other": "PIN"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Você não tem um PIN definido, que é necessário para comprar, alugar e assistir a alguns títulos."
+  },
+  "account_form_set_pin": {
+    "other": "Definir PIN"
+  },
+  "account_form_pin_changed": {
+    "other": "Atualizada"
+  },
+  "account_form_change_pin": {
+    "other": "Mudar PIN"
+  },
+  "user_set_pin_header": {
+    "other": "Defina seu PIN"
+  },
+  "user_set_pin_button": {
+    "other": "Defina PIN"
+  },
+  "user_submit_pin_heading": {
+    "other": "Digite seu PIN para {{.Action}} este conteúdo restrito"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Ops, você digitou um PIN incorreto"
+  },
+  "user_submit_pin_button": {
+    "other": "Entrar"
+  },
+  "user_reset_pin_button": {
+    "other": "Redefinir PIN"
+  },
+  "validation_pincode1_required": {
+    "other": "Insira um código PIN válido."
+  },
+  "validation_pincode2_required": {
+    "other": "Insira um código PIN válido."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Insira um código PIN válido."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Insira um código PIN válido."
+  },
+  "validation_pincode2_match": {
+    "other": "O código PIN não corresponde."
+  },
+  "userdevices_delete_limits": {
+    "other": "Você pode remover {{.Limit}} dispositivo(s) desta lista a cada {{.Period}} dia(s)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Você atingiu esse limite e não pode remover nenhum dispositivo agora. Você pode excluir um dispositivo em {{.Days}} dia(s)."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Este cartão será salvo e cobrado regularmente"
+  },
+  "changepincode_modal_header": {
+    "other": "Alterar seu PIN"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "Sua senha atual"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Seus novos 4 dígitos"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Confirme seus novos 4 dígitos PIN"
+  },
+  "changepincode_modal_submit": {
+    "other": "Definir PIN"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Essa senha está incorreta."
+  },
+  "user_set_pin_intro": {
+    "other": "Você precisa de um PIN para {{.Action}} conteúdo restrito"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Clique aqui para redefinir seu PIN"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Este conteúdo tem restrição de idade."
+  },
+  "shopping_error_close_button": {
+    "other": "OK"
+  },
+  "availability_expires": {
+    "other": "Expira {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Expirada"
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Você falhou ao fazer login muitas vezes. Por favor, tente novamente mais tarde."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Sua conta foi temporariamente suspensa. Entre em contato com um administrador se você acredita que isso é um erro."
   }
+}

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1,25 +1,44 @@
 {
-  "site_owner": { "other": "ABC Cinemas" },
-  "nav_homepage": { "other": "ABC Cinemas" },
-  "settings_title": { "other": "Settings" },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.shift72.com" },
-  "in_partnership_with": { "other": "в сотрудничестве с" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-  "en": { "other": "английский" },
-  "fr": { "other": "Французский" },
-
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Settings"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "в сотрудничестве с"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "английский"
+  },
+  "fr": {
+    "other": "Французский"
+  },
   "episode_name": {
     "other": "Эпизод"
   },
-
   "season_name": {
     "other": "Сезон"
   },
-
-  "seasons":{
+  "seasons": {
     "one": "один сезон",
     "few": "{{.Count}} сезоны",
     "many": "{{.Count}} сезоны"
@@ -41,135 +60,333 @@
     "few": "{{.Count}} Эпизоды",
     "many": "{{.Count}} Эпизоды"
   },
-
-  "date_day": { "other": "День" },
-  "date_month": { "other": "Месяц" },
-  "date_year": { "other": "Год" },
-
-  "404_page_header": { "other": "Этой страницы не существует..." },
-  "404_page_content": { "other": "<p>К сожалению, вы ищете страницу, которая не существует.</p><p>Файл может быть перемещен или удален, или, возможно, вы что-то неправильно сделали.</p><p>Вернитесь к главной странице, чтобы найти то, что вы искали.</p><p><a href=\"{{.URL}}\">Вернуться на главную страницу</a></p>" },
-
-  "nav_signin": { "other": "Войти в систему" },
-  "nav_signup": { "other": "Создать аккаунт" },
-  "nav_signed_in_as": { "other": "Войти под аккаунтом" },
-  "nav_library": { "other": "Моя видеотека" },
-  "nav_devices": { "other": "Мои устройства" },
-  "nav_wishlist": { "other": "Мой список" },
-  "nav_account": { "other": "Мой аккаунт" },
-  "nav_signout": { "other": "Выйти" },
-  "play_trailer": { "other": "трейлер" },
-  "runtime_hours": { "other": "час" },
-  "runtime_minutes": { "other": "мин" },
-
-  "datetime_today": { "other": "сегодня {{.Date}}" },
-  "datetime_tomorrow": { "other": "завтра {{.Date}}" },
-  "datetime_yesterday": { "other": "вчера {{.Date}}" },
-  "datetime_next": { "other": "{{.Date}}" },
-  "datetime_last": { "other": "последняя {{.Date}}" },
-
-  "search_control_placeholder": { "other": "Поиск" },
-  "search_control_submit": { "other": "Начать поиск" },
-
-  "play_button_watch": { "other" : "Запустить сейчас"},
-  "play_button_resume": { "other" : "Поделиться"},
-
-  "social_media_buttons_title": { "other": "Поделиться" },
-  "social_media_buttons_facebook": { "other": "Поделиться через фейсбук" },
-  "social_media_buttons_twitter": { "other": "Поделиться в Твиттере" },
-  "social_media_buttons_linkedin": { "other": "Поделиться в Linkedin" },
-  "social_media_buttons_email": { "other": "Поделиться по электронной почте" },
-  "social_media_buttons_email_subject": { "other": "Поделиться ссылкой" },
-  "social_media_buttons_copied_link": { "other": "Ссылка скопирована в буфер обмена!" },
-  "social_media_buttons_copy_link": { "other": "Скопировать в буфер обмена" },
-
-  "accept_invite_page_header": { "other": "Добро пожаловать " },
-  "acceptinvite_form_invalid_reset_password_token": { "other": "Вы уже подтвердили регистрацию, вам надо <a href=\"{{.SigninURL}}\">войти</a> . Если вы забыли свой пароль, вы можете <a href=\"{{.ForgotPasswordURL}}\">сбросить пароль</a>." },
-  "acceptinvite_complete": { "other": "Спасибо. Ваш аккаунт был создан." },
-  "acceptinvite_form_submit": { "other": "Принять приглашение" },
-  "acceptinvite_agreement": { "other": "Нажимая кнопку \"Принять приглашение\" вы подтверждаете, что вы прочитали и приняли наши <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">правила &amp; условия</a> и <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">и политику конфиденциальности</a>." },
-
-  "signup_page_header": { "other": "Создать новый аккаунт" },
-  "signup_form_name": { "other": "имя" },
-  "signup_form_email": { "other": "Адрес электронной почты" },
-  "signup_form_password": { "other": "пароль" },
-  "signup_form_password_confirmation": { "other": "Подтвердите ваш пароль" },
-  "signup_form_gender": { "other": "Гендер" },
-  "signup_form_dob": { "other": "Дата рождения" },
-  "signup_form_submit": { "other": "подтвердить" },
-
-  "signin_page_header": { "other": "Войти в систему" },
-  "signin_form_email": { "other": "Адрес электронной почты" },
-  "signin_form_password": { "other": "пароль" },
-  "signin_form_remember": { "other": "Запомнить меня" },
-  "signin_form_submit": { "other": "Отправить" },
-  "signin_page_forgotpassword": { "other": "Забыли пароль?" },
-  "signin_page_createnewaccount": { "other": "Не зарегистрированы? Создать новый аккаунт" },
-  "signup_page_alreadyhaveanaccount": { "other": "Уже есть учетная запись? войти в систему" },
-  "signup_form_error_email_already_in_use": { "other": "Этот адрес электронной почты уже используется." },
-  "signin_form_error_incorrect_credentials": { "other": "Имя пользователя или пароль неверен." },
-  "signin_form_error_ip_throttled": { "other": "Вы слишком много раз не могли войти в систему. Пожалуйста, попробуйте позже." },
-  "signin_form_error_account_suspended": { "other": "Ваша учетная запись была временно приостановлена. Пожалуйста, свяжитесь с администратором, если вы считаете, что это ошибка." },
-
-  "signup_form_error_forbidden": { "other": "Произошла ошибка." },
-
-  "combined_auth_continue": { "other": "Продолжить" },
-  "combined_auth_change": { "other": "изменить" },
-  "combined_auth_signin": { "other": "войти в систему" },
-  "combined_auth_signup": { "other": "Создать аккаунт" },
-  "combined_auth_signin_password": { "other": "Введите ваш пароль для входа в аккаунт." },
-  "combined_auth_signin_error_incorrect_credentials": { "other": "Это неверный пароль." },
-  "combined_auth_error_forbidden": { "other": "Произошла ошибка." },
-  "combined_auth_error_too_many_requests": { "other": "Пожалуйста, повторите попытку позже." },
-
-  "forgotpassword_page_header": { "other": "Сбросить пароль" },
-  "forgotpassword_form_email": { "other": "Адрес электронной почты" },
-  "forgotpassword_form_submit": { "other": "Сброс" },
-  "forgotpassword_form_error_email_doesnt_exist": { "other": "Учетная запись, соответствующая адресу электронной почты, не существует." },
-  "forgotpassword_form_error_account_suspended": { "other": "Эта учетная запись приостановлена." },
-  "forgotpassword_complete": { "other": "Спасибо. Новый пароль электронной почты должен появиться в вашем почтовом ящике в ближайшее время." },
-  "forgotpassword_form_error_forbidden": { "other": "Произошла ошибка." },
-  "forgotpassword_form_error_too_many_requests": { "other": "Пожалуйста, повторите попытку позже." },
-
-  "resetpassword_page_header": { "other": "Измените свой пароль" },
-  "resetpassword_form_invalid_reset_password_token": { "other": "Сборс пароля более не действителен, пожалуйста, заполните <a href=\"{{.URL}}\">Забыл_а пароль</a> сформировать снова." },
-  "resetpassword_form_password": { "other": "Новый пароль" },
-  "resetpassword_form_password2": { "other": "Подтвердите новый пароль" },
-  "resetpassword_form_submit": { "other": "Изменить" },
-  "resetpassword_complete": { "other": "Спасибо. Ваш пароль был изменен, и вы были зарегистрированы." },
-  "resetpassword_form_error_invalid_reset_password_token": { "other": "Запрос сброса пароля не действителен. Пожалуйста, попробуйте позже." },
-  "resetpassword_form_error_reset_password_token_expired": { "other": "Сборс пароля истек. Пожалуйста, запросите новый." },
-  "resetpassword_form_error_too_many_requests": { "other": "Пожалуйста, повторите попытку позже." },
-
-  "account_page_header": { "other": "Мой аккаунт" },
-  "account_form_name": { "other": "имя" },
-  "account_form_email": { "other": "Адрес электронной почты" },
-  "account_form_password": { "other": "пароль" },
-  "account_form_change_password": { "other": "изменить" },
-  "account_form_gender": { "other": "гендер" },
-  "account_form_dob": { "other": "Дата рождения" },
-  "account_form_submit": { "other": "обновить" },
-  "account_form_submitted": { "other": "обновлено" },
-  "account_form_password_changed": { "other": "обновлено" },
-  "account_form_error_incorrect_password": { "other": "Это неверный пароль." },
-
-  "signup_form_optin": {"other": "Подпишитесь на нашу бесплатную рассылку"},
-
-  "passwordconfirmation_modal_header": { "other": "Подтвердите ваш пароль" },
-  "passwordconfirmation_modal_label": { "other": "Пожалуйста, введите пароль, чтобы обновить изменения" },
-  "passwordconfirmation_modal_confirm": { "other": "подтвердите" },
-
-  "changepassword_modal_header": { "other": "Измените ваш пароль" },
-  "changepassword_modal_currentpassword": { "other": "ваш текущий пароль" },
-  "changepassword_modal_password": { "other": "ваш новый пароль" },
-  "changepassword_modal_password2": { "other": "Подтвердите ваш новый пароль" },
-  "changepassword_modal_submit": { "other": "Обновить" },
-  "changepassword_modal_error_incorrect_password": { "other": "Это неверный пароль." },
-
-  "userlibrary_page_header": { "other": "Моя видеотека" },
-  "userlibrary_empty_header":  { "other": "Ваша библиотека пуста." },
-  "userlibrary_empty_content": { "other": "Заполните ее <a href=\"{{.HomeURL}}\">у нас</a> большой выбор." },
-
-  "searchresults_page_header": { "other": "результаты поиска" },
+  "date_day": {
+    "other": "День"
+  },
+  "date_month": {
+    "other": "Месяц"
+  },
+  "date_year": {
+    "other": "Год"
+  },
+  "404_page_header": {
+    "other": "Этой страницы не существует..."
+  },
+  "404_page_content": {
+    "other": "<p>К сожалению, вы ищете страницу, которая не существует.</p><p>Файл может быть перемещен или удален, или, возможно, вы что-то неправильно сделали.</p><p>Вернитесь к главной странице, чтобы найти то, что вы искали.</p><p><a href=\"{{.URL}}\">Вернуться на главную страницу</a></p>"
+  },
+  "nav_signin": {
+    "other": "Войти в систему"
+  },
+  "nav_signup": {
+    "other": "Создать аккаунт"
+  },
+  "nav_signed_in_as": {
+    "other": "Войти под аккаунтом"
+  },
+  "nav_library": {
+    "other": "Моя видеотека"
+  },
+  "nav_devices": {
+    "other": "Мои устройства"
+  },
+  "nav_wishlist": {
+    "other": "Мой список"
+  },
+  "nav_account": {
+    "other": "Мой аккаунт"
+  },
+  "nav_signout": {
+    "other": "Выйти"
+  },
+  "play_trailer": {
+    "other": "трейлер"
+  },
+  "runtime_hours": {
+    "other": "час"
+  },
+  "runtime_minutes": {
+    "other": "мин"
+  },
+  "datetime_today": {
+    "other": "сегодня {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "завтра {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "вчера {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "последняя {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Поиск"
+  },
+  "search_control_submit": {
+    "other": "Начать поиск"
+  },
+  "play_button_watch": {
+    "other": "Запустить сейчас"
+  },
+  "play_button_resume": {
+    "other": "Поделиться"
+  },
+  "social_media_buttons_title": {
+    "other": "Поделиться"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Поделиться через фейсбук"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Поделиться в Твиттере"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Поделиться в Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Поделиться по электронной почте"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Поделиться ссылкой"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Ссылка скопирована в буфер обмена!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Скопировать в буфер обмена"
+  },
+  "accept_invite_page_header": {
+    "other": "Добро пожаловать "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Вы уже подтвердили регистрацию, вам надо <a href=\"{{.SigninURL}}\">войти</a> . Если вы забыли свой пароль, вы можете <a href=\"{{.ForgotPasswordURL}}\">сбросить пароль</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Спасибо. Ваш аккаунт был создан."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Принять приглашение"
+  },
+  "acceptinvite_agreement": {
+    "other": "Нажимая кнопку \"Принять приглашение\" вы подтверждаете, что вы прочитали и приняли наши <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">правила &amp; условия</a> и <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">и политику конфиденциальности</a>."
+  },
+  "signup_page_header": {
+    "other": "Создать новый аккаунт"
+  },
+  "signup_form_name": {
+    "other": "имя"
+  },
+  "signup_form_email": {
+    "other": "Адрес электронной почты"
+  },
+  "signup_form_password": {
+    "other": "пароль"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Подтвердите ваш пароль"
+  },
+  "signup_form_gender": {
+    "other": "Гендер"
+  },
+  "signup_form_dob": {
+    "other": "Дата рождения"
+  },
+  "signup_form_submit": {
+    "other": "подтвердить"
+  },
+  "signin_page_header": {
+    "other": "Войти в систему"
+  },
+  "signin_form_email": {
+    "other": "Адрес электронной почты"
+  },
+  "signin_form_password": {
+    "other": "пароль"
+  },
+  "signin_form_remember": {
+    "other": "Запомнить меня"
+  },
+  "signin_form_submit": {
+    "other": "Отправить"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Забыли пароль?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Не зарегистрированы? Создать новый аккаунт"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Уже есть учетная запись? войти в систему"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Этот адрес электронной почты уже используется."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Имя пользователя или пароль неверен."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Вы слишком много раз не могли войти в систему. Пожалуйста, попробуйте позже."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Ваша учетная запись была временно приостановлена. Пожалуйста, свяжитесь с администратором, если вы считаете, что это ошибка."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Произошла ошибка."
+  },
+  "combined_auth_continue": {
+    "other": "Продолжить"
+  },
+  "combined_auth_change": {
+    "other": "изменить"
+  },
+  "combined_auth_signin": {
+    "other": "войти в систему"
+  },
+  "combined_auth_signup": {
+    "other": "Создать аккаунт"
+  },
+  "combined_auth_signin_password": {
+    "other": "Введите ваш пароль для входа в аккаунт."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Это неверный пароль."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Произошла ошибка."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Пожалуйста, повторите попытку позже."
+  },
+  "forgotpassword_page_header": {
+    "other": "Сбросить пароль"
+  },
+  "forgotpassword_form_email": {
+    "other": "Адрес электронной почты"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Сброс"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Учетная запись, соответствующая адресу электронной почты, не существует."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Эта учетная запись приостановлена."
+  },
+  "forgotpassword_complete": {
+    "other": "Спасибо. Новый пароль электронной почты должен появиться в вашем почтовом ящике в ближайшее время."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Произошла ошибка."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Пожалуйста, повторите попытку позже."
+  },
+  "resetpassword_page_header": {
+    "other": "Измените свой пароль"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Сборс пароля более не действителен, пожалуйста, заполните <a href=\"{{.URL}}\">Забыл_а пароль</a> сформировать снова."
+  },
+  "resetpassword_form_password": {
+    "other": "Новый пароль"
+  },
+  "resetpassword_form_password2": {
+    "other": "Подтвердите новый пароль"
+  },
+  "resetpassword_form_submit": {
+    "other": "Изменить"
+  },
+  "resetpassword_complete": {
+    "other": "Спасибо. Ваш пароль был изменен, и вы были зарегистрированы."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Запрос сброса пароля не действителен. Пожалуйста, попробуйте позже."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Сборс пароля истек. Пожалуйста, запросите новый."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Пожалуйста, повторите попытку позже."
+  },
+  "account_page_header": {
+    "other": "Мой аккаунт"
+  },
+  "account_form_name": {
+    "other": "имя"
+  },
+  "account_form_email": {
+    "other": "Адрес электронной почты"
+  },
+  "account_form_password": {
+    "other": "пароль"
+  },
+  "account_form_change_password": {
+    "other": "изменить"
+  },
+  "account_form_gender": {
+    "other": "гендер"
+  },
+  "account_form_dob": {
+    "other": "Дата рождения"
+  },
+  "account_form_submit": {
+    "other": "обновить"
+  },
+  "account_form_submitted": {
+    "other": "обновлено"
+  },
+  "account_form_password_changed": {
+    "other": "обновлено"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Это неверный пароль."
+  },
+  "signup_form_optin": {
+    "other": "Подпишитесь на нашу бесплатную рассылку"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Подтвердите ваш пароль"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Пожалуйста, введите пароль, чтобы обновить изменения"
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "подтвердите"
+  },
+  "changepassword_modal_header": {
+    "other": "Измените ваш пароль"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "ваш текущий пароль"
+  },
+  "changepassword_modal_password": {
+    "other": "ваш новый пароль"
+  },
+  "changepassword_modal_password2": {
+    "other": "Подтвердите ваш новый пароль"
+  },
+  "changepassword_modal_submit": {
+    "other": "Обновить"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Это неверный пароль."
+  },
+  "userlibrary_page_header": {
+    "other": "Моя видеотека"
+  },
+  "userlibrary_empty_header": {
+    "other": "Ваша библиотека пуста."
+  },
+  "userlibrary_empty_content": {
+    "other": "Заполните ее <a href=\"{{.HomeURL}}\">у нас</a> большой выбор."
+  },
+  "searchresults_page_header": {
+    "other": "результаты поиска"
+  },
   "searchresults_load_more": {
     "few": "Загрузить {{.Count}} больше",
     "many": "Загрузить {{.Count}} больше"
@@ -179,44 +396,99 @@
     "few": "Найдены {{.Count}} результаты для \"{{.Query}}\".",
     "many": "Найдены {{.Count}} результаты для \"{{.Query}}\"."
   },
-  "searchresults_empty_header":  { "other": "Не было никаких результатов поиска для \"{{.Query}}\"" },
-  "searchresults_empty_content": { "other": "Попробуйте другой поиск или <a href=\"{{.HomeURL}}\">просмотрите наш контент</a>, чтобы найти то, что вы ищете." },
-
-  "validation_name_required": { "other": "Укажите Ваше имя." },
-  "validation_email_required": { "other": "Укажите адрес Вашей электронной почты." },
-  "validation_email_email": { "other": "Укажите действительный адрес электронной почты." },
-  "validation_currentpassword_required": { "other": "Введите ваш текущий пароль." },
-  "validation_password_required": { "other": "Введите пароль." },
-  "validation_password2_required": { "other": "Подтвердите ваш пароль." },
-  "validation_password2_match": { "other": "Ваши пароли не совпадают." },
+  "searchresults_empty_header": {
+    "other": "Не было никаких результатов поиска для \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Попробуйте другой поиск или <a href=\"{{.HomeURL}}\">просмотрите наш контент</a>, чтобы найти то, что вы ищете."
+  },
+  "validation_name_required": {
+    "other": "Укажите Ваше имя."
+  },
+  "validation_email_required": {
+    "other": "Укажите адрес Вашей электронной почты."
+  },
+  "validation_email_email": {
+    "other": "Укажите действительный адрес электронной почты."
+  },
+  "validation_currentpassword_required": {
+    "other": "Введите ваш текущий пароль."
+  },
+  "validation_password_required": {
+    "other": "Введите пароль."
+  },
+  "validation_password2_required": {
+    "other": "Подтвердите ваш пароль."
+  },
+  "validation_password2_match": {
+    "other": "Ваши пароли не совпадают."
+  },
   "validation_password_minlength": {
     "few": "Введите по крайней мере, {{.Count}} символов.",
     "many": "Введите по крайней мере, {{.Count}} символов."
   },
-  "validation_promocode_required": { "other": "Введите промо-код." },
-  "validation_pincode_required": { "other": "Пожалуйста, введите PIN-код." },
-  "validation_gender_required": { "other": "Выберите тот гендер, с которым вы себя идентифицируете." },
-  "validation_dob_required": { "other": "Введите дату рождения." },
-  "validation_dob_date": { "other": "Введите правильную дату рождения." },
-
-  "shopping_info_subtitle_hd": { "other": "HD-видео по запросу." },
-  "shopping_info_subtitle_sd": { "other": "SD-видео по запросу." },
-  "shopping_info_subtitle_wallet": { "other": "Средства в вашем бумажнике можно использовать для покупки или аренды любого контента на ScreenPlus." },
-  "shopping_info_subtitle_help": { "other": "Смотрите здесь для  требований системы." },
-  "shopping_info_ownership_buy": { "other": "покупка" },
-  "shopping_info_ownership_rent": { "other": "аренда" },
-
-  "shopping_info_sd_only": { "other": "Ограничено только воспроизведением SD." },
-  "shopping_info_release_date_title": { "other": "Новые фильмы {{.Date}}. " },
-  "shopping_info_release_date_explanation_rent": { "other": "Вы можете арендовать фильм прямо сейчас, но вы не сможете посмотреть его до этого срока." },
-  "shopping_info_release_date_explanation_buy": { "other": "Вы можете купить фильм прямо сейчас, но вы не сможете посмотреть его до этого срока. " },
-
-  "shopping_info_available_until_date_title": { "other": "Доступно до {{.Date}}. " },
-  "shopping_info_available_until_date_explanation_rent": { "other": "Вы не сможете просматривать содержимое после этого." },
-  "shopping_info_available_until_date_explanation_buy": { "other": "Вы не сможете просматривать содержимое после этого." },
-  
-  "duration_hour": { "one": "1 час", "other": "{{.Count}} часа" },
-  "duration_day": { "one": "1 день", "other": "{{.Count}} дня" },
+  "validation_promocode_required": {
+    "other": "Введите промо-код."
+  },
+  "validation_pincode_required": {
+    "other": "Пожалуйста, введите PIN-код."
+  },
+  "validation_gender_required": {
+    "other": "Выберите тот гендер, с которым вы себя идентифицируете."
+  },
+  "validation_dob_required": {
+    "other": "Введите дату рождения."
+  },
+  "validation_dob_date": {
+    "other": "Введите правильную дату рождения."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "HD-видео по запросу."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD-видео по запросу."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Средства в вашем бумажнике можно использовать для покупки или аренды любого контента на ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Смотрите здесь для  требований системы."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "покупка"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "аренда"
+  },
+  "shopping_info_sd_only": {
+    "other": "Ограничено только воспроизведением SD."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Новые фильмы {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Вы можете арендовать фильм прямо сейчас, но вы не сможете посмотреть его до этого срока."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Вы можете купить фильм прямо сейчас, но вы не сможете посмотреть его до этого срока. "
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Доступно до {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Вы не сможете просматривать содержимое после этого."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Вы не сможете просматривать содержимое после этого."
+  },
+  "duration_hour": {
+    "one": "1 час",
+    "other": "{{.Count}} часа"
+  },
+  "duration_day": {
+    "one": "1 день",
+    "other": "{{.Count}} дня"
+  },
   "shopping_info_rental_period_duration": {
     "few": "{{.ValueUnit}} аренды ",
     "many": "{{.ValueUnit}} аренды "
@@ -255,66 +527,152 @@
     "few": "После нажатия кнопки PLAY на эпизоде, период аренды стартует и у вас есть {{.Count}} часов, чтобы посмотреть этот эпизод, как столько раз, сколько вам нравится.",
     "many": "После нажатия кнопки PLAY на эпизоде, период аренды стартует и у вас есть {{.Count}} часов, чтобы посмотреть этот эпизод, как столько раз, сколько вам нравится."
   },
-  "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% бонус" },
-
-  "shopping_enter_card_prompt": { "other": "Введите данные кредитной карты ниже, чтобы ваш {{.Verb}}." },
-
-  "shopping_terms": { "other": "Завершив эту трансакцию, я согласен_а <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">сроки и условия</a>."},
-  "shopping_discount_applied": { "other": "{{.DiscountAmount}} скидка учитывается." },
-  "shopping_discount_apply": { "other": "Применить" },
-  "shopping_discount_code": { "other": "Введите промо-код." },
-  "shopping_discount_have_code": { "other": "У меня есть промо-код." },
-
-  "shopping_price_you_pay": { "other": "Вы платите" },
-  "shopping_price_nothing": { "other": "Ничего" },
-  "shopping_price_free": { "other": "Бесплатно" },
-
-  "shopping_auth_directions": { "other": "Сначала необходимо войти в учетную запись. Введите Ваш адрес электронной почты." },
-
-  "shopping_error_in_library": { "other": "{{.Title}} уже в вашей видеотеке." },
-
-  "shopping_error_missing_card": { "other": "Пожалуйста, введите  данные вашей кредитной карты." },
-  "shopping_error_title": { "other": "Произошла ошибка" },
-  "shopping_error_incorrect_cvc": { "other": "Пожалуйста, введите правильный код CVV." },
-  "shopping_error_invalid_cvc": { "other": "Пожалуйста, введите правильный код CVV." },
-  "shopping_error_incorrect_number": { "other": "Пожалуйста, введите действительную кредитную карту Number." },
-  "shopping_error_invalid_number": { "other": "Пожалуйста, введите действительную кредитную карту Number." },
-  "shopping_error_card_declined": { "other": "Кредитная карта была отклонена." },
-  "shopping_error_invalid_expiry_month": { "other": "Пожалуйста, введите действительный срока действия карты" },
-  "shopping_error_invalid_expiry_year": { "other": "Пожалуйста, введите действительный срока действия карты" },
-  "shopping_error_expired_card": { "other": "Кредитная карта истекла." },
-  "shopping_error_creditcard_country_mismatch": { "other": "Ваше {{.Ownership}} не подтвреждена. Вы должны быть в стране, где была выдана ваша кредитная карта. Используйте другую карту для совершения платежа." },
-  "shopping_error_proxy_detected": { "other": "Ваше {{.Ownership}} не подтвреждена.  Мы обнаружили, что вы используете Unblocker или прокси-сервис. Выключите любой из этих услуг и попробуйте еще раз." },
-
-  "shopping_error_discount_worn_out": { "other": "Этот промо-код больше не может быть использован." },
-  "shopping_error_discount_blank": { "other": "Пожалуйста, введите промо-код." },
-  "shopping_error_discount_not_applied": { "other": "Пожалуйста, введите действительный промо код." },
-  "shopping_error_discount_invalid": { "other": "Пожалуйста, введите действительный промо код." },
-  "shopping_error_discount_disabled": { "other": "Пожалуйста, введите действительный промо код." },
-  "shopping_error_discount_already_applied": { "other": "Промокод уже использовался для этой сессии." },
-  "shopping_error_discount_already_redeemed": { "other": "Это промо-код уже был использован." },
-  "shopping_error_discount_used_previously": { "other": "Это промо-код уже был использован." },
-  "shopping_error_discount_max_limit": { "other": "Это не промо-код больше не может быть использован." },
-  "shopping_error_discount_expired": { "other": "Это промо-код истек." },
-  "shopping_error_discount_invalid_ownership_buy": { "other": "Это промо-код не может быть использован при покупке." },
-  "shopping_error_discount_invalid_ownership_rent": { "other": "Это промо-код не может быть использован при аренде." },
-  "shopping_error_discount_invalid_item": { "other": "Это промо-код не может быть использован с этим пунктом." },
-  "shopping_error_discount_invalid_pricing_region": { "other": "Это промо-код не может быть использован в вашей стране." },
-  "shopping_error_discounts_not_allowed": { "other": "Это промо-код не может быть использован." },
-  "shopping_error_discount_disallowed_on_bundles": { "other": "Это промо-код не может быть использован для абонементов." },
-  "shopping_error_payment_intent_authentication_failure": { "other": "Кредитная карта была отклонена. Пожалуйста, попробуйте еще раз." },
-
-  "shopping_complete_rental": { "other": "Успех!" },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% бонус"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Введите данные кредитной карты ниже, чтобы ваш {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Завершив эту трансакцию, я согласен_а <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">сроки и условия</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} скидка учитывается."
+  },
+  "shopping_discount_apply": {
+    "other": "Применить"
+  },
+  "shopping_discount_code": {
+    "other": "Введите промо-код."
+  },
+  "shopping_discount_have_code": {
+    "other": "У меня есть промо-код."
+  },
+  "shopping_price_you_pay": {
+    "other": "Вы платите"
+  },
+  "shopping_price_nothing": {
+    "other": "Ничего"
+  },
+  "shopping_price_free": {
+    "other": "Бесплатно"
+  },
+  "shopping_auth_directions": {
+    "other": "Сначала необходимо войти в учетную запись. Введите Ваш адрес электронной почты."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} уже в вашей видеотеке."
+  },
+  "shopping_error_missing_card": {
+    "other": "Пожалуйста, введите  данные вашей кредитной карты."
+  },
+  "shopping_error_title": {
+    "other": "Произошла ошибка"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Пожалуйста, введите правильный код CVV."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Пожалуйста, введите правильный код CVV."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Пожалуйста, введите действительную кредитную карту Number."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Пожалуйста, введите действительную кредитную карту Number."
+  },
+  "shopping_error_card_declined": {
+    "other": "Кредитная карта была отклонена."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Пожалуйста, введите действительный срока действия карты"
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Пожалуйста, введите действительный срока действия карты"
+  },
+  "shopping_error_expired_card": {
+    "other": "Кредитная карта истекла."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Ваше {{.Ownership}} не подтвреждена. Вы должны быть в стране, где была выдана ваша кредитная карта. Используйте другую карту для совершения платежа."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Ваше {{.Ownership}} не подтвреждена.  Мы обнаружили, что вы используете Unblocker или прокси-сервис. Выключите любой из этих услуг и попробуйте еще раз."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Этот промо-код больше не может быть использован."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Пожалуйста, введите промо-код."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Пожалуйста, введите действительный промо код."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Пожалуйста, введите действительный промо код."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Пожалуйста, введите действительный промо код."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Промокод уже использовался для этой сессии."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Это промо-код уже был использован."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Это промо-код уже был использован."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Это не промо-код больше не может быть использован."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Это промо-код истек."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Это промо-код не может быть использован при покупке."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Это промо-код не может быть использован при аренде."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Это промо-код не может быть использован с этим пунктом."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Это промо-код не может быть использован в вашей стране."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Это промо-код не может быть использован."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Это промо-код не может быть использован для абонементов."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Кредитная карта была отклонена. Пожалуйста, попробуйте еще раз."
+  },
+  "shopping_complete_rental": {
+    "other": "Успех!"
+  },
   "shopping_complete_rental_period": {
     "one": "Теперь вы можете смотреть это так часто, как вам нравится в течение следующего дня.",
     "few": "Теперь вы можете смотреть фильм так часто, как вам нравится в течение следующих {{.Count}} дней.",
     "many": "Теперь вы можете смотреть фильм так часто, как вам нравится в течение следующих {{.Count}} дней."
   },
-  "shopping_complete_purchase": { "other": "Благодарим Вас за покупку {{.Title}}." },
-  "shopping_complete_credit_purchase": { "other": "Благодарим Вас за покупку {{.Title}}, {{.CreditTotal}} была добавлена ​​на ваш счет." },
-  "shopping_complete_purchase_coming_soon": { "other": "Вы сможете посмотреть его, начиная с {{.Date}}." },
-  "shopping_complete_receipt": { "other": "Квитанция по электронной почте." },
-  "shopping_complete_library_link": { "other": "Просмотр библиотеки" },
+  "shopping_complete_purchase": {
+    "other": "Благодарим Вас за покупку {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Благодарим Вас за покупку {{.Title}}, {{.CreditTotal}} была добавлена ​​на ваш счет."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Вы сможете посмотреть его, начиная с {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Квитанция по электронной почте."
+  },
+  "shopping_complete_library_link": {
+    "other": "Просмотр библиотеки"
+  },
   "shopping_complete_plan": {
     "other": "Ваша покупка {{ .Title }} прошла успешно."
   },
@@ -338,22 +696,48 @@
     "few": "Вы сможете смотреть его из {{.Date}} и ваша аренда будет  активной в течение {{.Count}} дней.",
     "many": "Вы сможете смотреть его из {{.Date}} и ваша аренда будет  активной в течение {{.Count}} дней."
   },
-
-  "shopping_action_rent": { "other": "Аренда" },
-  "shopping_action_buy": { "other": "купить" },
-
-  "meta_detail_cast_title": { "other": "В ролях" },
-  "meta_detail_crew_title": { "other": "Создатели" },
-  "meta_detail_languages": { "one": "язык", "other": "Языки" },
-  "meta_detail_studios": { "one": "студия", "other": "Студии" },
-  "meta_detail_countries": { "one": "Страна", "other": "страны" },
-  "meta_detail_subtitles": { "other": "Субтитры" },
-  "meta_detail_captions": { "other": "Субтитры [CC]" },
-  "meta_detail_episodes_title": { "other": "Эпизоды" },
-  "meta_detail_bonus_title": { "other": "Бонус" },
-  "meta_detail_recommendations_title": { "other": "Вам также может понравиться" },
-  "meta_detail_bundle_items_title": { "other": "Фильм включен в этот абонемент" },
-
+  "shopping_action_rent": {
+    "other": "Аренда"
+  },
+  "shopping_action_buy": {
+    "other": "купить"
+  },
+  "meta_detail_cast_title": {
+    "other": "В ролях"
+  },
+  "meta_detail_crew_title": {
+    "other": "Создатели"
+  },
+  "meta_detail_languages": {
+    "one": "язык",
+    "other": "Языки"
+  },
+  "meta_detail_studios": {
+    "one": "студия",
+    "other": "Студии"
+  },
+  "meta_detail_countries": {
+    "one": "Страна",
+    "other": "страны"
+  },
+  "meta_detail_subtitles": {
+    "other": "Субтитры"
+  },
+  "meta_detail_captions": {
+    "other": "Субтитры [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Эпизоды"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Бонус"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Вам также может понравиться"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Фильм включен в этот абонемент"
+  },
   "bundle_items_all_films": {
     "few": "{{.Count}} фильмы",
     "many": "{{.Count}} фильмы"
@@ -366,125 +750,275 @@
     "few": "{{.Count}} фильмы и сезоны",
     "many": "{{.Count}} фильмы и сезоны"
   },
-  "userwishlist_page_header": { "other": "Мой список" },
-  "userwishlist_slider_header": { "other": "Мой список" },
-  "userwishlist_empty_header":  { "other": "Ваш список пуст." },
-  "userwishlist_empty_content": { "other": "Заполните его <a href=\"{{.HomeURL}}\">просмотрите</a> нашу коллекцию." },
-  "userwishlist_button_add": { "other": "Добавить в мой список" },
-  "userwishlist_button_remove": { "other": "Мой список" },
-  "userwishlist_button_add_compact": { "other": "Мой список" },
-  "userwishlist_button_remove_compact": { "other": "Мой список" },
-
-  "activatedevice_page_header": { "other": "Активировать устройство" },
-  "activatedevice_page_content": { "other": "Следуйте инструкциям на вашем устройстве, чтобы получить PIN-код.Ваш компьютер и устройство должны быть подключены к Интернету для активации." },
-  "activatedevice_form_pin": { "other": "Пин-код" },
-  "activatedevice_form_submit": { "other": "Активировать" },
-  "activatedevice_form_error_invalid_code": { "other": "PIN-код не найден, пожалуйста, попробуйте еще раз." },
-  "activatedevice_form_error_pin_not_found": { "other": "PIN-код не найден, пожалуйста, попробуйте еще раз." },
-  "activatedevice_signin_prompt": { "other": "Пожалуйста, войдите, прежде чем активировать ваше устройство." },
-  "activatedevice_page_activated": { "other": "Спасибо за активируемость {{.DeviceName}}. Теперь вы должны иметь возможность просматривать вашу библиотеку на телевидении или устройстве." },
-
-  "userdevices_page_header": { "other": "устройства" },
+  "userwishlist_page_header": {
+    "other": "Мой список"
+  },
+  "userwishlist_slider_header": {
+    "other": "Мой список"
+  },
+  "userwishlist_empty_header": {
+    "other": "Ваш список пуст."
+  },
+  "userwishlist_empty_content": {
+    "other": "Заполните его <a href=\"{{.HomeURL}}\">просмотрите</a> нашу коллекцию."
+  },
+  "userwishlist_button_add": {
+    "other": "Добавить в мой список"
+  },
+  "userwishlist_button_remove": {
+    "other": "Мой список"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Мой список"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Мой список"
+  },
+  "activatedevice_page_header": {
+    "other": "Активировать устройство"
+  },
+  "activatedevice_page_content": {
+    "other": "Следуйте инструкциям на вашем устройстве, чтобы получить PIN-код.Ваш компьютер и устройство должны быть подключены к Интернету для активации."
+  },
+  "activatedevice_form_pin": {
+    "other": "Пин-код"
+  },
+  "activatedevice_form_submit": {
+    "other": "Активировать"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN-код не найден, пожалуйста, попробуйте еще раз."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN-код не найден, пожалуйста, попробуйте еще раз."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Пожалуйста, войдите, прежде чем активировать ваше устройство."
+  },
+  "activatedevice_page_activated": {
+    "other": "Спасибо за активируемость {{.DeviceName}}. Теперь вы должны иметь возможность просматривать вашу библиотеку на телевидении или устройстве."
+  },
+  "userdevices_page_header": {
+    "other": "устройства"
+  },
   "userdevices_page_content": {
     "one": "Устройства будут автоматически добавлены здесь, когда вы их используете. Вы ограничены только одно устройство.",
     "few": "Устройства будут автоматически добавлены здесь, когда вы их используете.У вас ограничение на  {{.Count }} устройство.",
     "many": "Устройства будут автоматически добавлены здесь, когда вы их используете.У вас ограничение на  {{.Count }} устройство."
   },
-  "userdevices_empty_content": { "other": "Сейчас у Вас 0 зарегистрированных устройств." },
-  "userdevices_header_type": { "other": "Тип устройства" },
-  "userdevices_header_description": { "other": "Описание" },
-  "userdevices_device_added": { "other": "Добавлено {{.Date}}" },
-  "userdevices_device_actions_delete": { "other": "Удалить" },
-  "userdevices_device_actions_cancel": { "other": "Отмена" },
-  "userdevices_device_actions_confirm": { "other": "Да, удалить устройство" },
-  "userdevices_device_deleted": { "other": "(Удаленный)" },
-
-  "playlist_page_header": { "other": "Плейлист" },
-  "playlist_sign_in_warning": { "other": "Пожалуйста, войдите, чтобы посмотреть живое телевидение."},
-  "playlist_share_title": { "other": "Плейлист" },
-  "playlist_up_next_title": { "other": "Следующий" },
-
-  "pricing_ownership_buy": { "other": "купить" },
-  "pricing_ownership_rent": { "other": "Аренда" },
-
-  "classification_intro": { "other": "Классификация: " },
-  "classification_divider": { "other": " - " },
-  "classification_outro": { "other": "" },
-
-  "cookie_banner_message": { "other": "Этот сайт использует куки-файлы для улучшения качества просмотра. Используя этот сайт, вы принимаете нашу политику <a href=\"{{.CookiePolicyURL}}\">куки-файлов</a>." },
-  "cookie_banner_accept": { "other": "Принимаю" },
-
-  "all_rights_reserved": { "other": "Все права защищены. Ни одна часть этого сайта не может быть воспроизведена без письменного разрешения." },
-
-  "users_gender_none": { "other": "не определён" },
-  "users_gender_female": { "other": "женский" },
-  "users_gender_male": { "other": "мужской" },
-  "users_gender_diverse": { "other": "разные" },
-  "users_gender_other": { "other": "Другой" },
-
-
-  "pricing_quality_hd": { "other": "HD" },
-  "pricing_quality_sd": { "other": "SD" },
-  "pricing_quality_hd_only": { "other": "HD только" },
-  "pricing_quality_sd_only": { "other": "SD Только" },
-
-  "shopping_card_save_card": { "other": "Сохраните эту карту для будущего использования" },
-  "shopping_card_button_change": { "other": "Показать все сохраненные карты" },
-  "shopping_card_existing_description": { "other": "{{.Card.Brand}} кончающийся на {{.Card.Number}}" },
-  "shopping_card_existing_expiry": { "other": "(истекает {{.Card.Expiry}})" },
-  "shopping_card_existing_expired": { "other": "(истекший)" },
-  "shopping_card_use_other": { "other": "Использовать новую карту" },
-  "shopping_card_use_new_card": { "other": "Изменить карту" },
-
-  "shopping_info_ownership_plan": { "other": "Подписка" },
-
-  "shopping_action_credit": { "other": "Пополнить" },
-
-  "shopping_info_rental_period_coming_soon": { "other": "с указанием даты и времени выпуска." },
-
-
-  "usersubscriptions_change_payment_method_change": { "other": "Изменить кредитную карту" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Обновить данные кредитной карты" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Обновлять" },
-
-  "usersubscriptions_subscription_expiry": { "other": "Истекает {{.Expiry}}" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Испытательный срок" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Отменить мою подписку" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Отмена" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Да, отмените мою подписку" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Отменить подписку?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "Это отменит подписку на {{.Name}} строить планы. Вы все равно сможете посмотреть контент в плане, пока он не истечет {{.Expiry}}." },
-
-  "shopping_card_update_reason_none": { "other": "Обновите свою кредитную карту.Поддерживаемые карты - виза, MasterCard и American Express." },
-
-  "availability_coming_soon": { "other": "Скоро в онлайне" },
-  "availability_renting": { "other": "аренда" },
-  "availability_not_available": { "other": "Недоступен" },
-  "availability_in_watch_window": { "other": "Доступен в окне часов" },
-  "availability_sold_out": { "other": "Продано" },
-  "availability_available_till": { "other": "Доступно до {{.ExpiryDate}}" },
-  "availability_not_available_in_country": { "other": "Недоступно" },
-  "availability_available": { "other": "Доступно до {{.ReleaseDate}}" },
-
-  "modal_cancel": { "other": "Отмена" },
-
-  "play": { "other": "Запустить сейчас" },
-
-  "combined_auth_signin_prompt": { "other": "Войти в систему" },
-  "combined_auth_signup_prompt": { "other": "зарегистрироваться" },
-  "combined_auth_terms": { "other": "Я согласен_а с <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">правилами &amp; условиями</a>." },
-  "signup_terms": { "other": "Я согласен_а с <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">правилами &amp; условиями</a>." },
-  "validation_terms_required": { "other": "Вы должны согласиться с правилами и условиями." },
-  "shopping_error_item_limit_exceeded": { "other": "К сожалению, {{.Title}} куплен." },
-
-  "shopping_card_change": { "other": "Кредитная карта не правильная? <a href=\"{{.SubscriptionsURL}}\">Нажмите здесь, чтобы обновить свою карту.</a>" },
-
-  "user_error_too_many_pin_errors": { "other": "<p>Похоже, у тебя проблемы.</p><p>Сбросьте свой PIN-код или свяжитесь с нами для <a href=\"{{.HelpURL}}\" target=\"_blank\">помощь</a>" },
-
-  "app_badge_title": { "other": "Загрузите приложение для просмотра вашего приобретенного контента!" },
-  "app_badge_ios": { "other": "Загрузить в App Store" },
-  "app_badge_android": { "other": "Получить его в Google Play" },
-
+  "userdevices_empty_content": {
+    "other": "Сейчас у Вас 0 зарегистрированных устройств."
+  },
+  "userdevices_header_type": {
+    "other": "Тип устройства"
+  },
+  "userdevices_header_description": {
+    "other": "Описание"
+  },
+  "userdevices_device_added": {
+    "other": "Добавлено {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Удалить"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Отмена"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Да, удалить устройство"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Удаленный)"
+  },
+  "playlist_page_header": {
+    "other": "Плейлист"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Пожалуйста, войдите, чтобы посмотреть живое телевидение."
+  },
+  "playlist_share_title": {
+    "other": "Плейлист"
+  },
+  "playlist_up_next_title": {
+    "other": "Следующий"
+  },
+  "pricing_ownership_buy": {
+    "other": "купить"
+  },
+  "pricing_ownership_rent": {
+    "other": "Аренда"
+  },
+  "classification_intro": {
+    "other": "Классификация: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Этот сайт использует куки-файлы для улучшения качества просмотра. Используя этот сайт, вы принимаете нашу политику <a href=\"{{.CookiePolicyURL}}\">куки-файлов</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Принимаю"
+  },
+  "all_rights_reserved": {
+    "other": "Все права защищены. Ни одна часть этого сайта не может быть воспроизведена без письменного разрешения."
+  },
+  "users_gender_none": {
+    "other": "не определён"
+  },
+  "users_gender_female": {
+    "other": "женский"
+  },
+  "users_gender_male": {
+    "other": "мужской"
+  },
+  "users_gender_diverse": {
+    "other": "разные"
+  },
+  "users_gender_other": {
+    "other": "Другой"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD только"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD Только"
+  },
+  "shopping_card_save_card": {
+    "other": "Сохраните эту карту для будущего использования"
+  },
+  "shopping_card_button_change": {
+    "other": "Показать все сохраненные карты"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} кончающийся на {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(истекает {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(истекший)"
+  },
+  "shopping_card_use_other": {
+    "other": "Использовать новую карту"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Изменить карту"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Подписка"
+  },
+  "shopping_action_credit": {
+    "other": "Пополнить"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "с указанием даты и времени выпуска."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Изменить кредитную карту"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Обновить данные кредитной карты"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Обновлять"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Истекает {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Испытательный срок"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Отменить мою подписку"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Отмена"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Да, отмените мою подписку"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Отменить подписку?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Это отменит подписку на {{.Name}} строить планы. Вы все равно сможете посмотреть контент в плане, пока он не истечет {{.Expiry}}."
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Обновите свою кредитную карту.Поддерживаемые карты - виза, MasterCard и American Express."
+  },
+  "availability_coming_soon": {
+    "other": "Скоро в онлайне"
+  },
+  "availability_renting": {
+    "other": "аренда"
+  },
+  "availability_not_available": {
+    "other": "Недоступен"
+  },
+  "availability_in_watch_window": {
+    "other": "Доступен в окне часов"
+  },
+  "availability_sold_out": {
+    "other": "Продано"
+  },
+  "availability_available_till": {
+    "other": "Доступно до {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Недоступно"
+  },
+  "availability_available": {
+    "other": "Доступно до {{.ReleaseDate}}"
+  },
+  "modal_cancel": {
+    "other": "Отмена"
+  },
+  "play": {
+    "other": "Запустить сейчас"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Войти в систему"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "зарегистрироваться"
+  },
+  "combined_auth_terms": {
+    "other": "Я согласен_а с <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">правилами &amp; условиями</a>."
+  },
+  "signup_terms": {
+    "other": "Я согласен_а с <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">правилами &amp; условиями</a>."
+  },
+  "validation_terms_required": {
+    "other": "Вы должны согласиться с правилами и условиями."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "К сожалению, {{.Title}} куплен."
+  },
+  "shopping_card_change": {
+    "other": "Кредитная карта не правильная? <a href=\"{{.SubscriptionsURL}}\">Нажмите здесь, чтобы обновить свою карту.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Похоже, у тебя проблемы.</p><p>Сбросьте свой PIN-код или свяжитесь с нами для <a href=\"{{.HelpURL}}\" target=\"_blank\">помощь</a>"
+  },
+  "app_badge_title": {
+    "other": "Загрузите приложение для просмотра вашего приобретенного контента!"
+  },
+  "app_badge_ios": {
+    "other": "Загрузить в App Store"
+  },
+  "app_badge_android": {
+    "other": "Получить его в Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Цена"
   },
@@ -556,74 +1090,181 @@
   "donate_button_text": {
     "other": "Пожертвовать"
   },
-  "wcag_skip_links_header": { "other": "Ссылки на доступность" },
-  "wcag_skip_links_content": { "other": "Перейти к содержанию" },
-
-  "wcag_homepage_h1": { "other": "Главная страница" },
-  "wcag_carousel_h2": { "other": "Карусель" },
-  "wcag_collections_h2": { "other": "Коллекции" },
-
-  "wcag_aria_label_footer": { "other": "Нижний колонтин" },
-  "wcag_aria_label_nav_main": { "other": "Основной" },
-  "wcag_aria_label_nav_sub": { "other": "Подразделение" },
-  "wcag_aria_label_toggle_nav": { "other": "Переключить навигацию" },
-  "wcag_aria_label_bundle_items": { "other": "Пучок предметов" },
-  "wcag_aria_label_carousel": { "other": "Карусель" },
-  "wcag_aria_label_page_collection": { "other": "Коллекция страницы" },
-  "wcag_aria_label_collection_list": { "other": "Список коллекции" },
-  "wcag_aria_label_collection_slider": { "other": "Сладер коллекции" },
-  "wcag_aria_label_wishlist": { "other": "Список желаний" },
-  "wcag_aria_label_facebook": { "other": "Поделиться через фейсбук" },
-  "wcag_aria_label_twitter": { "other": "Поделиться в Твиттере" },
-  "wcag_aria_label_linkedin": { "other": "Поделиться на LinkedIn" },
-  "wcag_aria_label_letterboxd": { "other": "Просмотр на letterboxd" },
-
-  "shopping_error_plan_already_owned": { "other": "У вас уже есть этот план." },
-  "shopping_error_plan_expired": { "other": "Этот план больше не доступен." },
-  "shopping_payment_method_header": { "other": "Способы оплаты" },
-  "shopping_payment_method_credit_card": { "other": "Кредитная карта" },
-  "shopping_payment_method_giropay": { "other": "Гиропай" },
-  "shopping_error_stripe_unknown_error": { "other": "Что-то пошло не так с этим платежом.Пожалуйста, попробуйте позже." },
-  "shopping_error_payment_complete_failed": { "other": "Оплата была отклонена.Закройте это окно и попробуйте снова." },
-
-  "header_banner": { "other": "Знамя заголовка" },
-
-  "account_form_pin_code": { "other": "ПРИКОЛОТЬ" },
-  "account_form_pin_code_not_set": { "other": "У вас нет набора PIN, который требуется для покупки, аренды и наблюдения за некоторыми названиями."},
-  "account_form_set_pin": { "other": "Установить PIN-код" },
-  "account_form_pin_changed": { "other": "Обновленный" },
-  "account_form_change_pin": { "other": "Изменить PIN-код" },
-
-  "user_set_pin_header": { "other": "Установите свой PIN-код" },
-  "user_set_pin_button": { "other": "Установить PIN-код" },
-  "user_submit_pin_heading": { "other": "Введите свой PIN-код в {{.Action}} Это ограниченный контент" },
-  "user_error_wrong_pin_retry": { "other": "Упс, вы ввели неверный PIN-код" },
-  "user_submit_pin_button": { "other": "Войти" },
-  "user_reset_pin_button": { "other": "Сбросить PIN-код" },
-
-  "validation_pincode1_required": { "other": "Пожалуйста, введите действительный PIN-код." },
-  "validation_pincode2_required": { "other": "Пожалуйста, введите действительный PIN-код." },
-  "validation_pincode1_pattern": { "other": "Пожалуйста, введите действительный PIN-код." },
-  "validation_pincode2_pattern": { "other": "Пожалуйста, введите действительный PIN-код." },
-  "validation_pincode2_match": { "other": "PIN-код не совпадает." },
-
-  "userdevices_delete_limits": { "other": "Вы можете удалить {{.Limit}} устройства (ы) из этого списка каждый {{.Period}} день (ы)."},
-  "userdevices_delete_limit_reached": { "other": "Вы достигли этого предела и не можете удалить какие-либо устройства прямо сейчас.Вы можете удалить устройство в {{.Days}} день (ы)." },
-  "shopping_card_new_subscription": { "other": "Эта карта будет спасена и регулярно заряжена" },
-
-  "changepincode_modal_header": { "other": "Изменить свой PIN-код" },
-  "changepincode_modal_currentpassword": { "other": "ваш текущий пароль" },
-  "changepincode_modal_pincode1": { "other": "Ваш новый 4-значный PIN-код" },
-  "changepincode_modal_pincode2": { "other": "Подтвердите свой новый 4-значный PIN-код" },
-  "changepincode_modal_submit": { "other": "Установить PIN-код" },
-  "changepincode_modal_error_wrong_password": { "other": "Этот пароль неверный." },
-
-  "user_set_pin_intro": { "other": "Вам нужен PIN-код до {{.Action}} ограниченный контент"},
-  "user_error_wrong_pin_reset": { "other": "Нажмите здесь, чтобы сбросить PIN-код" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Этот контент ограничен возрастом." },
-  "shopping_error_close_button": { "other": "Ok" },
-
-  "availability_expires": { "other": "Истекает {{.Expiry}}" },
-  "availability_expired": { "other": "Истекший"}
+  "wcag_skip_links_header": {
+    "other": "Ссылки на доступность"
+  },
+  "wcag_skip_links_content": {
+    "other": "Перейти к содержанию"
+  },
+  "wcag_homepage_h1": {
+    "other": "Главная страница"
+  },
+  "wcag_carousel_h2": {
+    "other": "Карусель"
+  },
+  "wcag_collections_h2": {
+    "other": "Коллекции"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Нижний колонтин"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Основной"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Подразделение"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Переключить навигацию"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Пучок предметов"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Карусель"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Коллекция страницы"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Список коллекции"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Сладер коллекции"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Список желаний"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Поделиться через фейсбук"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Поделиться в Твиттере"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Поделиться на LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Просмотр на letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "У вас уже есть этот план."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Этот план больше не доступен."
+  },
+  "shopping_payment_method_header": {
+    "other": "Способы оплаты"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Кредитная карта"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Гиропай"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Что-то пошло не так с этим платежом.Пожалуйста, попробуйте позже."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Оплата была отклонена.Закройте это окно и попробуйте снова."
+  },
+  "header_banner": {
+    "other": "Знамя заголовка"
+  },
+  "account_form_pin_code": {
+    "other": "ПРИКОЛОТЬ"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "У вас нет набора PIN, который требуется для покупки, аренды и наблюдения за некоторыми названиями."
+  },
+  "account_form_set_pin": {
+    "other": "Установить PIN-код"
+  },
+  "account_form_pin_changed": {
+    "other": "Обновленный"
+  },
+  "account_form_change_pin": {
+    "other": "Изменить PIN-код"
+  },
+  "user_set_pin_header": {
+    "other": "Установите свой PIN-код"
+  },
+  "user_set_pin_button": {
+    "other": "Установить PIN-код"
+  },
+  "user_submit_pin_heading": {
+    "other": "Введите свой PIN-код в {{.Action}} Это ограниченный контент"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Упс, вы ввели неверный PIN-код"
+  },
+  "user_submit_pin_button": {
+    "other": "Войти"
+  },
+  "user_reset_pin_button": {
+    "other": "Сбросить PIN-код"
+  },
+  "validation_pincode1_required": {
+    "other": "Пожалуйста, введите действительный PIN-код."
+  },
+  "validation_pincode2_required": {
+    "other": "Пожалуйста, введите действительный PIN-код."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Пожалуйста, введите действительный PIN-код."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Пожалуйста, введите действительный PIN-код."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN-код не совпадает."
+  },
+  "userdevices_delete_limits": {
+    "other": "Вы можете удалить {{.Limit}} устройства (ы) из этого списка каждый {{.Period}} день (ы)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Вы достигли этого предела и не можете удалить какие-либо устройства прямо сейчас.Вы можете удалить устройство в {{.Days}} день (ы)."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Эта карта будет спасена и регулярно заряжена"
+  },
+  "changepincode_modal_header": {
+    "other": "Изменить свой PIN-код"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "ваш текущий пароль"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Ваш новый 4-значный PIN-код"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Подтвердите свой новый 4-значный PIN-код"
+  },
+  "changepincode_modal_submit": {
+    "other": "Установить PIN-код"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Этот пароль неверный."
+  },
+  "user_set_pin_intro": {
+    "other": "Вам нужен PIN-код до {{.Action}} ограниченный контент"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Нажмите здесь, чтобы сбросить PIN-код"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Этот контент ограничен возрастом."
+  },
+  "shopping_error_close_button": {
+    "other": "Ok"
+  },
+  "availability_expires": {
+    "other": "Истекает {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Истекший"
+  }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1,594 +1,1248 @@
 {
-    "site_owner": { "other": "ABC Cinemas" },
-    "settings_title": { "other": "Settings" },
-    "powered_by": { "other": "Powered by" },
-    "powered_by_name": { "other": "Shift72" },
-    "powered_by_url": { "other": "https://www.shift72.com" },
-    "in_partnership_with": { "other": "у сарадњи са" },
-    "festival_scope": { "other": "Festival Scope" },
-    "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-    "en": { "other": "английский" },
-    "fr": { "other": "Французский" },
-  
-    "episode_name": {
-      "other": "Епизода"
-    },
-  
-    "season_name": {
-      "other": "Сезона"
-    },
-  
-    "seasons":{
-      "one": "один сезон",
-      "other": "{{.Count}} сезоны"
-    },
-    "tvseason": {
-      "other": "{{.ShowInfo.Title}} Ряд {{.Season.SeasonNumber}}"
-    },
-    "tvseason_html": {
-      "other": "{{.ShowInfo.Title}} <span>Ряд {{.Season.SeasonNumber}}</span>"
-    },
-    "tvepisode": {
-      "other": "{{.Episode.Title}}"
-    },
-    "tvseason_number": {
-      "other": "Ряд {{.Season.SeasonNumber}}"
-    },
-    "episode_count": {
-      "one": "1 Эпизод",
-      "other": "{{.Count}} Эпизоды"
-    },
-  
-    "date_day": { "other": "Дан" },
-    "date_month": { "other": "Месец" },
-    "date_year": { "other": "Година" },
-  
-    "404_page_header": { "other": "Таква страница не постоји..." },
-    "404_page_content": { "other": "<p>Нажалост, изледа да страница коју тражите не постоји.</p><p>Можда је премештена или обрисана или сте направили грешку при писању.</p><p>Покушајте да се вратите на почетну страницу и пронађете то што тражите.</p><p><a href=\"{{.URL}}\">Назад на почетну страницу</a></p>" },
-  
-  
-    "nav_homepage": { "other": "ABC Cinemas" },
-    "nav_signin": { "other": "Пријавите се" },
-    "nav_signup": { "other": "Направите налог" },
-    "nav_signed_in_as": { "other": "Пријављени сте као" },
-    "nav_library": { "other": "Моја библиотека" },
-    "nav_devices": { "other": "Моји уређаји" },
-    "nav_wishlist": { "other": "Моја листа" },
-    "nav_account": { "other": "Мој налог" },
-    "nav_signout": { "other": "Одјављени сте" },
-    "play_trailer": { "other": "Трејлер" },
-    "runtime_hours": { "other": "ч" },
-    "runtime_minutes": { "other": "м" },
-  
-    "datetime_today": { "other": "данас {{.Date}}" },
-    "datetime_tomorrow": { "other": "сутра {{.Date}}" },
-    "datetime_yesterday": { "other": "јуче {{.Date}}" },
-    "datetime_next": { "other": "следеће {{.Date}}" },
-    "datetime_last": { "other": "претходно {{.Date}}" },
-  
-    "search_control_placeholder": { "other": "Претрага" },
-    "search_control_submit": { "other": "Пошаљите претрагу" },
-  
-    "play_button_watch": { "other" : "Гледајте одмах"},
-    "play_button_resume": { "other" : "Наставите"},
-  
-    "social_media_buttons_title": { "other": "Поделите" },
-    "social_media_buttons_facebook": { "other": "Поделите на Фејсбуку" },
-    "social_media_buttons_twitter": { "other": "Делите на Твитеру" },
-    "social_media_buttons_linkedin": { "other": "Делите на Линкедину" },
-    "social_media_buttons_email": { "other": "Делите путем е-поште" },
-    "social_media_buttons_email_subject": { "other": "Дељење везе" },
-    "social_media_buttons_copied_link": { "other": "Линк је копиран у међуспремник!" },
-    "social_media_buttons_copy_link": { "other": "Копирај у међуспремник" },
-  
-    "accept_invite_page_header": { "other": "Добродошли " },
-    "acceptinvite_form_invalid_reset_password_token": { "other": "Изгледа да сте већ активирали овај позив. Потребно је да се <a href=\"{{.SigninURL}}\">пријавите</a>. Ако сте заборавили лозинку, можете и да <a href=\"{{.ForgotPasswordURL}}\">ресетујете лозинку</a>." },
-    "acceptinvite_complete": { "other": "Хвала Вам. Ваш налог је направљен." },
-    "acceptinvite_form_submit": { "other": "Прихватите позив." },
-    "acceptinvite_agreement": { "other": "Кликом на „Прихватите позив” потврђујете сте да сте прочитали и разумели <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">услове и одредбе</a> and <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">наше политике приватности.</a>." },
-  
-    "signup_page_header": { "other": "Направите нови налог" },
-    "signup_form_name": { "other": "Име" },
-    "signup_form_email": { "other": "Имејл адреса" },
-    "signup_form_password": { "other": "Лозинка" },
-    "signup_form_password_confirmation": { "other": "Потврдите лозинку" },
-    "signup_form_gender": { "other": "Пол" },
-    "signup_form_dob": { "other": "Датум рођења" },
-    "signup_form_submit": { "other": "Пошаљите" },
-  
-    "signin_page_header": { "other": "Пријавите се" },
-    "signin_form_email": { "other": "Имејл адреса" },
-    "signin_form_password": { "other": "Лозинка" },
-    "signin_form_remember": { "other": "Запамти ме" },
-    "signin_form_submit": { "other": "Пошаљите" },
-    "signin_page_forgotpassword": { "other": "Заборавили сте лозинку?" },
-    "signin_page_createnewaccount": { "other": "Немате налог? Направите нови налог" },
-    "signup_page_alreadyhaveanaccount": { "other": "Већ имате налог? Пријавите се" },
-    "signup_form_error_email_already_in_use": { "other": "Ова имејл адреса је већ употребљена." },
-    "signin_form_error_incorrect_credentials": { "other": "Корисничко име или лозинка нису тачни." },
-    "signin_form_error_ip_throttled": { "other": "Не успели сте да се пријавите превише пута.Покушајте поново касније." },
-    "signin_form_error_account_suspended": { "other": "Ваш налог је привремено суспендован.Молимо контактирајте администратора ако верујете да је то грешка." },
-  
-    "signup_form_error_forbidden": { "other": "Догодила се грешка." },
-  
-    "combined_auth_continue": { "other": "Наставите" },
-    "combined_auth_change": { "other": "промените" },
-    "combined_auth_signin": { "other": "Пријавите се" },
-    "combined_auth_signup": { "other": "Направите налог" },
-    "combined_auth_signin_password": { "other": "Молимо Вас унесите лозинку да бисте се пријавили." },
-    "combined_auth_signin_error_incorrect_credentials": { "other": "Лозинка је нетачна." },
-    "combined_auth_error_forbidden": { "other": "Догодила се грешка." },
-    "combined_auth_error_too_many_requests": { "other": "Превише захтева. Покушајте поново касније." },
-  
-    "forgotpassword_page_header": { "other": "Ресетујте лозинку" },
-    "forgotpassword_form_email": { "other": "Имејл адреса" },
-    "forgotpassword_form_submit": { "other": "Ресетуј" },
-    "forgotpassword_form_error_email_doesnt_exist": { "other": "Налог са том имејл адресом не постоји." },
-    "forgotpassword_form_error_account_suspended": { "other": "Овај налог је суспендован." },
-    "forgotpassword_complete": { "other": "Хвала Вам. Имејл за ресетовање лозинке ће Вам убрзо стићи у инбокс." },
-    "forgotpassword_form_error_forbidden": { "other": "Догодила се грешка." },
-    "forgotpassword_form_error_too_many_requests": { "other": "Превише захтева. Покушајте поново касније." },
-  
-    "resetpassword_page_header": { "other": "Промените лозинку" },
-    "resetpassword_form_invalid_reset_password_token": { "other": "Изгледа да је захтев за ресетовање лозинке неправилан, молимо Вас попуните <a href=\"{{.URL}}\">Образац за заборављену лозинку</a> поново." },
-    "resetpassword_form_password": { "other": "Нова лозинка" },
-    "resetpassword_form_password2": { "other": "Потврдите нову лозинку" },
-    "resetpassword_form_submit": { "other": "Промените" },
-    "resetpassword_complete": { "other": "Хвала. Ваша лозинка је промењена и пријављени сте." },
-    "resetpassword_form_error_invalid_reset_password_token": { "other": "Захтев за ресетовање лозинке је неправилан." },
-    "resetpassword_form_error_reset_password_token_expired": { "other": "Токен за ресетовање лозинке је истекао. Молимо Вас, тражите нови." },
-    "resetpassword_form_error_too_many_requests": { "other": "Превише захтева. Покушајте поново касније." },
-  
-    "account_page_header": { "other": "Мој налог" },
-    "account_form_name": { "other": "Име" },
-    "account_form_email": { "other": "Имејл адреса" },
-    "account_form_password": { "other": "Лозинка" },
-    "account_form_change_password": { "other": "Промените" },
-    "account_form_gender": { "other": "Пол" },
-    "account_form_dob": { "other": "Датум рођења" },
-    "account_form_submit": { "other": "Ажурирајте" },
-    "account_form_submitted": { "other": "Ажурирано" },
-    "account_form_password_changed": { "other": "Ажурирано" },
-    "account_form_error_incorrect_password": { "other": "Лозинка је нетачна." },
-    "account_form_pin_code": { "other": "ПРИКОЛОТЬ" },
-    "account_form_pin_code_not_set": { "other": "У вас нет набора PIN, который требуется для покупки, аренды и наблюдения за некоторыми названиями."},
-    "account_form_set_pin": { "other": "Установить PIN-код" },
-    "account_form_pin_changed": { "other": "Обновленный" },
-    "account_form_change_pin": { "other": "Изменить PIN-код" },
-  
-
-  
-    "signup_form_optin": {"other": "Пријавите се за бесплатни билтен"},
-  
-    "passwordconfirmation_modal_header": { "other": "Потврдите лозинку" },
-    "passwordconfirmation_modal_label": { "other": "Молимо Вас упишите лозинку да бисте ажурирали измене које сте направили." },
-    "passwordconfirmation_modal_confirm": { "other": "Потврдите" },
-  
-    "changepassword_modal_header": { "other": "Промените лозинку" },
-    "changepassword_modal_currentpassword": { "other": "Ваша тренутна лозинка" },
-    "changepassword_modal_password": { "other": "Ваша нова лозинка" },
-    "changepassword_modal_password2": { "other": "Потврдите нову лозинку" },
-    "changepassword_modal_submit": { "other": "Ажурирајте" },
-    "changepassword_modal_error_incorrect_password": { "other": "Лозинка је нетачна." },
-  
-    "userlibrary_page_header": { "other": "Резултати претраге" },
-    "userlibrary_empty_header":  { "other": "Ваша библиотека је празна." },
-    "userlibrary_empty_content": { "other": "<a href=\"{{.HomeURL}}\">Прелистајте</a> нашу селекцију да је попуните." },
-  
-    "searchresults_page_header": { "other": "результаты поиска" },
-    "searchresults_load_more": { "other": "Учитај још {{.Count}} " },
-    "searchresults_total": {
-      "one": "Пронађен је 1 резултат за \"{{.Query}}\".",
-      "other": "Пронађено је {{.Count}} резултата за \"{{.Query}}\"."
-    },
-    "searchresults_empty_header":  { "other": "Нема резултата за \"{{.Query}}\"" },
-    "searchresults_empty_content": { "other": "Пробајте са новом претрагом или <a href=\"{{.HomeURL}}\"> прелистајте садржај</a> како бисте нашлито што тражите." },
-  
-    "validation_name_required": { "other": "Молимо Вас упишите своје име." },
-    "validation_email_required": { "other": "Молимо Вас упишите Вашу имејл адресу." },
-    "validation_email_email": { "other": "Молимо Вас упишите исправну имејл адресу." },
-    "validation_currentpassword_required": { "other": "Молимо Вас упишите важећу лозинку." },
-    "validation_password_required": { "other": "Молимо Вас упишите своју лозинку." },
-    "validation_password2_required": { "other": "Молимо Вас потврдите лозинку." },
-    "validation_password2_match": { "other": "Лозинке се не подударају." },
-    "validation_password_minlength": { "other": "Молимо Вас упишите најмање {{.Count}} карактера. " },
-    "validation_promocode_required": { "other": "Молимо Вас упишите промотивни код." },
-    "validation_pincode_required": { "other": "Унесите ПИН код." },
-    "validation_gender_required": { "other": "Молимо Вас да одаберете пол са којим се идентификујете." },
-    "validation_dob_required": { "other": "Молимо Вас упишите свој датум рођења." },
-    "validation_dob_date": { "other": "Молимо Вас упишите исправан датум рођења." },
-  
-    "shopping_info_subtitle_hd": { "other": "ХД видео на захтев." },
-    "shopping_info_subtitle_sd": { "other": "SD видео по требованию." },
-    "shopping_info_subtitle_wallet": { "other": "Средства в вашем кошельке могут использоваться для покупки или аренда любого содержимого на ScreenPlus." },
-    "shopping_info_subtitle_help": { "other": "Погледајте системске захтеве." },
-    "shopping_info_ownership_buy": { "other": "куповина" },
-    "shopping_info_ownership_rent": { "other": "изнајмљивање" },
-  
-    "shopping_info_sd_only": { "other": "Ограничено только для воспроизведения SD." },
-    "shopping_info_release_date_title": { "other": "Излази {{.Date}}. " },
-    "shopping_info_release_date_explanation_rent": { "other": "Можете одмах да изнајмите, али нећете моћи да гледате пре тога." },
-    "shopping_info_release_date_explanation_buy": { "other": "Можете одмах да купите, али нећете моћи да гледате пре тога." },
-  
-    "shopping_info_available_until_date_title": { "other": "Доступно до {{.Date}}. " },
-    "shopping_info_available_until_date_explanation_rent": { "other": "Нећете моћи да гледате садржај након тога." },
-    "shopping_info_available_until_date_explanation_buy": { "other": "Нећете моћи да гледате садржај након тога." },
-  
-    "duration_hour": { "one": "1 сат", "other": "{{.Count}} сата" },
-    "duration_day": { "one": "1 дан", "other": "{{.Count}} дана" },
-    "shopping_info_rental_period_duration": { "other": "Изнајмљено на {{.ValueUnit}} " },
-    "shopping_info_watch_window_duration": { "other": "{{.Count}} ч. за гледање. " },
-    "shopping_info_watch_window_explanation_film": {
-      "one": "Када изнајмите филм, биће доступан на Вашем налогу {{.ValueUnit}}. ",
-      "other": "Када изнајмите филм, биће доступан на Вашем налогу {{.ValueUnit}}. "
-    },
-    "shopping_info_watch_window_explanation2_film": {
-      "one": "Када притиснете дугме за гледање, имаћете један сат да погледате филм колико год пута желите.",
-      "other": "Када притиснете дугме за гледање, имаћете {{.Count}} ч. да погледате филм колико год пута желите."
-    },
-    "shopping_info_watch_window_explanation_bundle": {
-      "one": "Наслови из пакета биће Вам доступни један дан кадага изнајмите.",
-      "other": "Наслови из пакета биће Вам доступни {{.Count}} дана када га изнајмите."
-    },
-    "shopping_info_watch_window_explanation2_bundle": {
-      "one": "Када притиснете дугме за гледање изабраног филма, имаћете један сат да погледате филм колико год пута желите.",
-      "other": "Када притиснете дугме за гледање изабраног филма, имаћете{{.Count}} ч. да погледате филм колико год пута желите."
-    },
-    "shopping_info_watch_window_explanation_season": {
-      "one": "Сезона ће вам бити доступна један дан када јеизнајмите.",
-      "other": "Сезона ће Вам бити доступна {{.Count}} дана када је изнајмите."
-    },
-    "shopping_info_watch_window_explanation2_season": {
-      "one": "Када притиснете дугме за гледање епизоде имаћете један сат да погледате епизоду колико год пута желите.",
-      "other": "Када притиснете дугме за гледање епизоде, имаћете{{.Count}} ч. да погледате епизоду колико год пута желите."
-    },
-    "shopping_info_credit_bonus_title": { "other": "Бонус {{.BonusPercentage}}% " },
-  
-    "shopping_enter_card_prompt": { "other": "Унесите детаље са Ваше кредитне картице да довршите {{.Verb}}." },
-  
-    "shopping_terms": { "other": "Обављањем ове трансакције прихватате <a href=\"{{.TermsAndConditionsURL}}\"target=\"_blank\" tabindex=\"-1\">услове и одредбе</a>."},
-    "shopping_discount_applied": { "other": "Примењено снижење {{.DiscountAmount}}." },
-    "shopping_discount_apply": { "other": "Примените" },
-    "shopping_discount_code": { "other": "Унесите промотивни код." },
-    "shopping_discount_have_code": { "other": "Имам промотивни код." },
-  
-    "shopping_price_you_pay": { "other": "Ви не плаћате" },
-    "shopping_price_nothing": { "other": "Ништа" },
-    "shopping_price_free": { "other": "Бесплатно" },
-  
-    "shopping_auth_directions": { "other": "Неопходно је да имате налог. Молимо Вас унесите своју имејл адресу." },
-  
-    "shopping_error_in_library": { "other": "{{.Title}} је већ у Вашој библиотеци." },
-  
-    "shopping_error_missing_card": { "other": "Молимо Вас унесите податке са ваше кредитне картице." },
-    "shopping_error_title": { "other": "Догодила се грешка" },
-    "shopping_error_incorrect_cvc": { "other": "Молимо Вас унесите исправан сигурносни код." },
-    "shopping_error_invalid_cvc": { "other": "Молимо Вас унесите исправан сигурносни код." },
-    "shopping_error_incorrect_number": { "other": "Молимо Вас унесите исправан број кредитне картице." },
-    "shopping_error_invalid_number": { "other": "Молимо Вас унесите исправан број кредитне картице." },
-    "shopping_error_card_declined": { "other": "Кредитна картица је одбијена." },
-    "shopping_error_invalid_expiry_month": { "other": "Молимо Вас унесите исправан датум истека." },
-    "shopping_error_invalid_expiry_year": { "other": "Молимо Вас унесите исправан датум истека." },
-    "shopping_error_expired_card": { "other": "Кредитна картица је истекла." },
-    "shopping_error_creditcard_country_mismatch": { "other": "Ваш {{.Ownership}} није довршен. Морате бити у земљи у којој је кредитна картицаиздата. Молимо Вас користите другу картицу за плаћање." },
-    "shopping_error_proxy_detected": { "other": "Ваш {{.Ownership}} није довршен. Препознали смо да користите деблокатор или прокси сервис. Молимо Вас искључите ове сервисе и покушајте поново." },
-  
-    "shopping_error_discount_worn_out": { "other": "Тај промо код се више не може користити." },
-    "shopping_error_discount_blank": { "other": "Молимо Вас унесите промотивни код." },
-    "shopping_error_discount_not_applied": { "other": "Молимо Вас унесите исправан промотивни код." },
-    "shopping_error_discount_invalid": { "other": "Молимо Вас унесите исправан промотивни код." },
-    "shopping_error_discount_disabled": { "other": "Молимо Вас унесите исправан промотивни код." },
-    "shopping_error_discount_already_applied": { "other": "Промотивни код је већ искоришћен у овој сесији." },
-    "shopping_error_discount_already_redeemed": { "other": "Тај промотивни код је већ искоришћен." },
-    "shopping_error_discount_used_previously": { "other": "Тај промотивни код је већ искоришћен." },
-    "shopping_error_discount_max_limit": { "other": "Тај промотивни код више не може да се користи." },
-    "shopping_error_discount_expired": { "other": "Тај промотивни код је истекао." },
-    "shopping_error_discount_invalid_ownership_buy": { "other": "Тај промотивни код не може да се користи при куповини." },
-    "shopping_error_discount_invalid_ownership_rent": { "other": "Тај промотивни код не може да се користи при изнајмљивању." },
-    "shopping_error_discount_invalid_item": { "other": "Тај промотивни код не може да се користи са овим насловом." },
-    "shopping_error_discount_invalid_pricing_region": { "other": "Тај промотивни код не може да се користи у Вашој земљи." },
-    "shopping_error_discounts_not_allowed": { "other": "Тај промотивни код не може да се користи." },
-    "shopping_error_discount_disallowed_on_bundles": { "other": "Тај промотивни код не може да се користи за пакете." },
-    "shopping_error_payment_intent_authentication_failure": { "other": "Кредитна картица је одбијена. Молимо Вас покушајте поново." },
-  
-    "shopping_complete_rental": { "other": "Успешно!" },
-    "shopping_complete_rental_period": {
-      "one": "Сада можете да га гледате колико год желите током наредног дана.",
-      "other": "Сада можете да га гледате колико год пута желите током наредних {.Count}} дана."
-    },
-    "shopping_complete_purchase": { "other": "Хвала што сте купили {{.Title}}." },
-    "shopping_complete_credit_purchase": { "other": "Хвала што сте купили {{.Title}}, {{.CreditTotal}} је додато на ваш налог." },
-    "shopping_complete_purchase_coming_soon": { "other": "Моћи ћете да гледате од {{.Date}}." },
-    "shopping_complete_receipt": { "other": "Рачун вам је послат имејлом." },
-    "shopping_complete_library_link": { "other": "Почните са гледањем {{.BundleItems}} у вашој библиотеци." },
-    "shopping_complete_plan": {
-      "other": "Ваша куповина {{ .Title }} је била успешна."
-    },
-    "shopping_complete_rental_watch_window_start": {
-      "one": "Можете да почнете са гледањем до краја наредног дана.",
-      "other": "Можете да почнете са гледањем одмах или у наредних {{.Count}} дана."
-    },
-    "shopping_complete_rental_watch_window_end": {
-      "one": "Када пројекција почне, имате сат времена да погледате наслов колико год пута желите.",
-      "other": "Када пројекција почне, имате {{.Count}} часова да погледате наслов колико год пута желите."
-    },
-    "shopping_complete_rental_coming_soon": {
-      "one": "Моћи ћете да гледате од {{.Date}}, а изнајмљивање ће трајати један дан.",
-      "other": "Моћи ћете да гледате од {{.Date}}, а изнајмљивање ће трајати {{.Count}} дана."
-    },
-    "shopping_complete_rental_coming_soon_watch_window_start": {
-      "one": "Моћи ћете да гледате од {{.Date}}, а изнајмљивање ће трајати један дан.",
-      "other": "Моћи ћете да гледате од {{.Date}}, а изнајмљивање ће трајати {{.Count}} дана."
-    },
-  
-    "shopping_action_rent": { "other": "Изнајмите" },
-    "shopping_action_buy": { "other": "Купите" },
-  
-    "meta_detail_cast_title": { "other": "Улоге" },
-    "meta_detail_crew_title": { "other": "Екипа" },
-    "meta_detail_languages": { "one": "Језик", "other": "Језици" },
-    "meta_detail_studios": { "one": "Студио", "other": "Студији" },
-    "meta_detail_countries": { "one": "Држава", "other": "Државе" },
-    "meta_detail_subtitles": { "other": "Титлови" },
-    "meta_detail_captions": { "other": "Титлови [CC]" },
-    "meta_detail_episodes_title": { "other": "Епизоде" },
-    "meta_detail_bonus_title": { "other": "Додатни садржај" },
-    "meta_detail_recommendations_title": { "other": "Можда Вам се допадне" },
-    "meta_detail_bundle_items_title": { "other": "Садржај овог пакета" },
-  
-    "bundle_items_all_films": { "other": "{{.Count}} филмова" },
-    "bundle_items_all_seasons": { "other": "{{.Count}} сезона" },
-    "bundle_items_mixed": { "other": "{{.Count}} филмова и сезона" },
-    "userwishlist_page_header": { "other": "Моја листа" },
-    "userwishlist_slider_header": { "other": "Моја листа" },
-    "userwishlist_empty_header":  { "other": "Ваша листа је празна." },
-    "userwishlist_empty_content": { "other": "<a href=\"{{.HomeURL}}\">Прелистајте</a> нашу селекцију да је попуните." },
-    "userwishlist_button_add": { "other": "Додај на Моју листу" },
-    "userwishlist_button_remove": { "other": "Моја листа" },
-    "userwishlist_button_add_compact": { "other": "Моја листа" },
-    "userwishlist_button_remove_compact": { "other": "Моја листа" },
-  
-    "activatedevice_page_header": { "other": "Активировать устройство" },
-    "activatedevice_page_content": { "other": "Следуйте инструкциям на вашем устройстве, чтобы получить PIN-код.Ваш компьютер и устройство должны быть подключены к Интернету для активации." },
-    "activatedevice_form_pin": { "other": "Пин-код" },
-    "activatedevice_form_submit": { "other": "Активировать" },
-    "activatedevice_form_error_invalid_code": { "other": "PIN-код не найден, пожалуйста, попробуйте еще раз." },
-    "activatedevice_form_error_pin_not_found": { "other": "PIN-код не найден, пожалуйста, попробуйте еще раз." },
-    "activatedevice_signin_prompt": { "other": "Пожалуйста, войдите, прежде чем активировать ваше устройство." },
-    "activatedevice_page_activated": { "other": "Спасибо за активируемость {{.DeviceName}}. Теперь вы должны иметь возможность просматривать вашу библиотеку на вашем телевизоре или устройстве." },
-  
-    "userdevices_page_header": { "other": "Уређаји" },
-    "userdevices_page_content": {
-      "one": "Уређаји ће бити аутоматски додати овде када их будете користили. Ограничени сте на само један уређај. ",
-      "other": "Уређаји ће аутоматски бити додати овде када их будете користили. Ограничени сте на{{.Count}} уређаја."
-    },
-    "userdevices_empty_content": { "other": "Тренутно имате 0 регистрованих уређаја." },
-    "userdevices_header_type": { "other": "Тип уређаја" },
-    "userdevices_header_description": { "other": "Опис" },
-    "userdevices_device_added": { "other": "Додато {{.Date}}" },
-    "userdevices_device_actions_delete": { "other": "Уклоните" },
-    "userdevices_device_actions_cancel": { "other": "Откажите" },
-    "userdevices_device_actions_confirm": { "other": "Да, уклони уређај" },
-    "userdevices_device_deleted": { "other": "(Уклоњено)" },
-    "userdevices_delete_limits": { "other": "Вы можете удалить {{.Limit}} Устройство (ы) из этого списка каждый {{.Period}} День (ы)." },
-    "userdevices_delete_limit_reached": { "other": "Вы достигли этого предела и не можете удалить какие-либо устройства прямо сейчас.Вы можете удалить устройство в {{.Days}} День (ы)." },
-  
-    "playlist_page_header": { "other": "Плейлист" },
-    "playlist_sign_in_warning": { "other": "Пожалуйста, войдите, чтобы смотреть живое телевидение."},
-    "playlist_share_title": { "other": "Плейлист" },
-    "playlist_up_next_title": { "other": "Следующий" },
-  
-    "pricing_ownership_buy": { "other": "Купите" },
-    "pricing_ownership_rent": { "other": "Изнајмите" },
-  
-    "classification_intro": { "other": "Класификација: " },
-    "classification_divider": { "other": " - " },
-    "classification_outro": { "other": "" },
-  
-    "cookie_banner_message": { "other":"Овај сајт користи колачиће да би побољшао Ваш доживљај.Коришћењем сајта прихватате <a href=\"{{.CookiePolicyURL}}\">употребу колачића</a>." },
-    "cookie_banner_accept": { "other": "Прихвати" },
-  
-    "all_rights_reserved": { "other": "Сва права су задржана. Ниједан део овог сајта не сме се репродуковати без наше писмене дозволе." },
-  
-    "users_gender_none": { "other": "Није одређен" },
-    "users_gender_female": { "other": "Женски" },
-    "users_gender_male": { "other": "Мушки" },
-    "users_gender_diverse": { "other": "Свакојаки" },
-    "users_gender_other": { "other": "Друго" },
-
-  
-    "pricing_quality_hd": { "other": "HD" },
-    "pricing_quality_sd": { "other": "SD" },
-    "pricing_quality_hd_only": { "other": "HD только" },
-    "pricing_quality_sd_only": { "other": "Только SD" },
-  
-    "shopping_card_save_card": { "other": "Сохраните эту карту для будущего использования" },
-    "shopping_card_button_change": { "other": "Показать все сохраненные карты" },
-    "shopping_card_existing_description": { "other": "{{.Card.Brand}} кончающийся на {{.Card.Number}}" },
-    "shopping_card_existing_expiry": { "other": "(истекает {{.Card.Expiry}})" },
-    "shopping_card_existing_expired": { "other": "(истекший)" },
-    "shopping_card_use_other": { "other": "Использовать новую карту" },
-    "shopping_card_use_new_card": { "other": "Изменить карту" },
-    "shopping_card_update_reason_none": { "other": "Обновите свою кредитную карту.Поддерживаемые карты - виза, MasterCard и American Express." },
-    "shopping_card_new_subscription": { "other": "Эта карта будет спасена и регулярно планировать" },
-    "shopping_card_change": { "other": "Кредитная карта не правильная? <a href=\"{{.SubscriptionsURL}}\">Нажмите здесь, чтобы обновить свою карту.</a>" },
-  
-    "shopping_info_ownership_plan": { "other": "Подписка" },
-  
-
-  
-
-  
-    "shopping_action_credit": { "other": "Пополнить" },
-
-    "shopping_info_rental_period_coming_soon": { "other": "fод датума и времена " },
-
-    "usersubscriptions_change_payment_method_change": { "other": "Изменить кредитную карту" },
-    "usersubscriptions_change_payment_method_modal_title": { "other": "Обновить данные кредитной карты" },
-    "usersubscriptions_change_payment_method_modal_submit": { "other": "Обновлять" },
-
-    "usersubscriptions_subscription_expiry": { "other": "Истекает {{.Expiry}}" },
-    "usersubscriptions_subscription_status_trialing": { "other": "Испытательный срок" },
-    "usersubscriptions_subscription_unsubscribe": { "other": "Отменить мою подписку" },
-    "usersubscriptions_unsubscribe_modal_cancel": { "other": "Отмена" },
-    "usersubscriptions_unsubscribe_modal_confirm": { "other": "Да, отмените мою подписку" },
-    "usersubscriptions_unsubscribe_modal_title": { "other": "Отменить подписку?" },
-    "usersubscriptions_unsubscribe_modal_body": { "other": "Это отменит подписку на{{.Name}} строить планы.Вы все равно сможете посмотреть контент в плане, пока он не истечет {{.Expiry}}." },
-  
-  
-    "availability_coming_soon": { "other": "Ускоро" },
-    "availability_renting": { "other": "Изнајмљивање" },
-    "availability_not_available": { "other": "Није доступно" },
-    "availability_in_watch_window": { "other": "Доступно" },
-    "availability_sold_out": { "other": "Распродато" },
-    "availability_available_till": { "other": "Доступно до {{.ExpiryDate}}" },
-    "availability_not_available_in_country": { "other": "Недоступно" },
-    "availability_available": { "other": "Доступно од {{.ReleaseDate}}" },
-    "availability_expires": { "other": "Истиче {{.Expiry}}" },
-    "availability_expired": { "other": "Истекло"},
-  
-    "modal_cancel": { "other": "Откажите" },
-  
-    "play": { "other": "Гледајте" },
-  
-    "combined_auth_signin_prompt": { "other": "Пријавите се" },
-    "combined_auth_signup_prompt": { "other": "Направите налог" },
-    "combined_auth_terms": { "other": "Сагласан сам са свим <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">условима и одредбама</a>." },
-    "signup_terms": { "other": "Сагласан сам са свим <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">условима и одредбама</a>." },
-    "validation_terms_required": { "other": "Потребно је да се сагласите са одредбама и условима." },
-    "shopping_error_item_limit_exceeded": { "other": "Нажалост, {{.Title}} је распродат." },
-  
-    "changepincode_modal_header": { "other": "Изменить свой PIN-код" },
-    "changepincode_modal_currentpassword": { "other": "ваш текущий пароль" },
-    "changepincode_modal_pincode1": { "other": "Ваш новый 4-значный PIN-код" },
-    "changepincode_modal_pincode2": { "other": "Подтвердите свой новый 4-значный PIN-код" },
-    "changepincode_modal_submit": { "other": "Установить PIN-код" },
-    "changepincode_modal_error_wrong_password": { "other": "Этот пароль неверный." },
-  
-    "user_submit_pin_heading": { "other": "Введите свой PIN-код в {{.Action}} Это ограниченный контент"},
-    "user_submit_pin_button": { "other": "Войти" },
-    "user_set_pin_intro": { "other": "Вам нужен PIN-код до {{.Action}} Ограниченный контент"},
-    "user_set_pin_header": { "other": "Установите свой PIN-код" },
-    "user_set_pin_button": { "other": "Установить PIN-код" },
-    "user_reset_pin_button": { "other": "Сбросить PIN-код" },
-    "user_error_wrong_pin_retry": { "other": "Упс, вы ввели неверный PIN-код" },
-    "user_error_wrong_pin_reset": { "other": "Нажмите здесь, чтобы сбросить PIN-код" },
-    "user_error_too_many_pin_errors": { "other": "<p>Похоже, у тебя проблемы.</p><p>Сбросьте свой PIN-код или свяжитесь с нами для <a href=\"{{.HelpURL}}\" target=\"_blank\">помощь</a>" },
-    "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-    "shopping_error_age_restricted": { "other": "Этот контент ограничен возрастом." },
-    "shopping_error_close_button": { "other": "Ok" },
-
-    "app_badge_title": { "other": "Загрузите приложение для просмотра вашего приобретенного контента!" },
-    "app_badge_ios": { "other": "Загрузить в App Store" },
-    "app_badge_android": { "other": "Получить его в Google Play" },
-
-    "shopping_price_title_plan": {
-      "other": "Цена"
-    },
-    "shopping_price_plan_note": {
-      "zero": "Наплаћује се сваки {{ .Interval }} .",
-      "one": "Наплаћује се сваки {{ .Interval }} након завршетка бесплатног пробног периода од 24 сата.",
-      "other": "Оптужен сваки {{ .Interval }} после ваших {{ .Count }} дневни бесплатни пробни крајевима."
-    },
-    "shopping_price_plan_note_interval": {
-      "one": "{{ .Interval }}",
-      "other": "{{ .Count }} {{ .Interval }} а"
-    },
-    "shopping_enter_card_prompt_plan": {
-      "other": "Унесите податке о својој кредитној картици испод да бисте започели претплату."
-    },
-    "shopping_action_plan": {
-      "other": "комплетан"
-    },
-    "shopping_complete_subscription": {
-      "other": "Ваша куповина претплате је била успешна. Сада сте претплаћени на {{ .Title }} ."
-    },
-    "shopping_complete_subscription_browse": {
-      "other": "Слободно <a href=\"/\">претражујте по</a> сајту или <a href=\"/search.html\">тражите</a> нешто специфично."
-    },
-    "shopping_info_plan_offer": {
-      "one": "Аутоматски обнавља сваки {{ .Interval }}",
-      "other": "Аутоматски обнавља на сваких {{ .Count }} {{ .Interval }} с"
-    },
-    "shopping_info_trial_period_offer": {
-      "one": "Испробајте своју бесплатну пробну верзију од 24 сата сада!",
-      "other": "Испробајте своју бесплатну пробну верзију {{ .Count }}"
-    },
-    "plans_page_header": {
-      "other": "Доступни планови"
-    },
-    "plan_label_owned": {
-      "other": "Ви сте власник овог плана"
-    },
-    "plan_expiry_date": {
-      "other": "Завршена продаја:"
-    },
-    "plan_read_more": {
-      "other": "Откриј више"
-    },
-    "plan_page_read_more": {
-      "other": "Опширније"
-    },
-    "plan_page_header_text": {
-      "other": "Уживајте у {{ .Name }}"
-    },
-    "page_plan_explore_intro": {
-      "other": "ИЛИ"
-    },
-    "page_plan_explore_link": {
-      "other": "Истражите друге пролазе"
-    },
-    "plan_showcase_page_ownership_button_buy": {
-      "other": "Купите сада"
-    },
-    "plan_free_link_text": {
-      "other": "Бесплатно се пријави"
-    },
-    "awards_in_competition": {
-      "other": "Ин Цомпетитион"
-    },
-    "awards_winner": {
-      "other": "Победник"
-    },
-    "donate_button_text": {
-      "other": "Донирајте"
-    },
-    "wcag_skip_links_header": { "other": "Ссылки на доступность" },
-    "wcag_skip_links_content": { "other": "Перейти к содержанию" },
-  
-    "wcag_homepage_h1": { "other": "Главная страница" },
-    "wcag_carousel_h2": { "other": "Карусель" },
-    "wcag_collections_h2": { "other": "Коллекции" },
-  
-    "wcag_aria_label_footer": { "other": "Нижний колонтин" },
-    "wcag_aria_label_nav_main": { "other": "Основной" },
-    "wcag_aria_label_nav_sub": { "other": "Подразделение" },
-    "wcag_aria_label_toggle_nav": { "other": "Переключить навигацию" },
-    "wcag_aria_label_bundle_items": { "other": "Пучок предметаs" },
-    "wcag_aria_label_carousel": { "other": "Карусель" },
-    "wcag_aria_label_page_collection": { "other": "Коллекция страницы" },
-    "wcag_aria_label_collection_list": { "other": "Список коллекции" },
-    "wcag_aria_label_collection_slider": { "other": "Сладер коллекции" },
-    "wcag_aria_label_wishlist": { "other": "Список желаний" },
-    "wcag_aria_label_facebook": { "other": "Поделиться через фейсбук" },
-    "wcag_aria_label_twitter": { "other": "Поделиться в Twitter" },
-    "wcag_aria_label_linkedin": { "other": "Поделиться на LinkedIn" },
-    "wcag_aria_label_letterboxd": { "other": "Просмотр на letterboxd" },
-
-    "shopping_error_plan_already_owned": { "other": "У вас уже есть этот план." },
-    "shopping_error_plan_expired": { "other": "Этот план больше не доступен." },
-    "shopping_payment_method_header": { "other": "Способы оплаты" },
-    "shopping_payment_method_credit_card": { "other": "Кредитная карта" },
-    "shopping_payment_method_giropay": { "other": "Гиропай" },
-    "shopping_error_stripe_unknown_error": { "other": "Что-то пошло не так с этим платежом.Пожалуйста, попробуйте позже." },
-    "shopping_error_payment_complete_failed": { "other": "Оплата была отклонена.Закройте это окно и попробуйте снова." },
-
-    "validation_pincode1_required": { "other": "Пожалуйста, введите действительный PIN-код." },
-  "validation_pincode2_required": { "other": "Пожалуйста, введите действительный PIN-код." },
-  "validation_pincode1_pattern": { "other": "Пожалуйста, введите действительный PIN-код." },
-  "validation_pincode2_pattern": { "other": "Пожалуйста, введите действительный PIN-код." },
-  "validation_pincode2_match": { "other": "PIN-код не совпадает." },
-
-  "header_banner": { "other": "Знамя заголовка" }
-  
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Settings"
+  },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "у сарадњи са"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "английский"
+  },
+  "fr": {
+    "other": "Французский"
+  },
+  "episode_name": {
+    "other": "Епизода"
+  },
+  "season_name": {
+    "other": "Сезона"
+  },
+  "seasons": {
+    "one": "один сезон",
+    "other": "{{.Count}} сезоны"
+  },
+  "tvseason": {
+    "other": "{{.ShowInfo.Title}} Ряд {{.Season.SeasonNumber}}"
+  },
+  "tvseason_html": {
+    "other": "{{.ShowInfo.Title}} <span>Ряд {{.Season.SeasonNumber}}</span>"
+  },
+  "tvepisode": {
+    "other": "{{.Episode.Title}}"
+  },
+  "tvseason_number": {
+    "other": "Ряд {{.Season.SeasonNumber}}"
+  },
+  "episode_count": {
+    "one": "1 Эпизод",
+    "other": "{{.Count}} Эпизоды"
+  },
+  "date_day": {
+    "other": "Дан"
+  },
+  "date_month": {
+    "other": "Месец"
+  },
+  "date_year": {
+    "other": "Година"
+  },
+  "404_page_header": {
+    "other": "Таква страница не постоји..."
+  },
+  "404_page_content": {
+    "other": "<p>Нажалост, изледа да страница коју тражите не постоји.</p><p>Можда је премештена или обрисана или сте направили грешку при писању.</p><p>Покушајте да се вратите на почетну страницу и пронађете то што тражите.</p><p><a href=\"{{.URL}}\">Назад на почетну страницу</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Пријавите се"
+  },
+  "nav_signup": {
+    "other": "Направите налог"
+  },
+  "nav_signed_in_as": {
+    "other": "Пријављени сте као"
+  },
+  "nav_library": {
+    "other": "Моја библиотека"
+  },
+  "nav_devices": {
+    "other": "Моји уређаји"
+  },
+  "nav_wishlist": {
+    "other": "Моја листа"
+  },
+  "nav_account": {
+    "other": "Мој налог"
+  },
+  "nav_signout": {
+    "other": "Одјављени сте"
+  },
+  "play_trailer": {
+    "other": "Трејлер"
+  },
+  "runtime_hours": {
+    "other": "ч"
+  },
+  "runtime_minutes": {
+    "other": "м"
+  },
+  "datetime_today": {
+    "other": "данас {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "сутра {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "јуче {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "следеће {{.Date}}"
+  },
+  "datetime_last": {
+    "other": "претходно {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Претрага"
+  },
+  "search_control_submit": {
+    "other": "Пошаљите претрагу"
+  },
+  "play_button_watch": {
+    "other": "Гледајте одмах"
+  },
+  "play_button_resume": {
+    "other": "Наставите"
+  },
+  "social_media_buttons_title": {
+    "other": "Поделите"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Поделите на Фејсбуку"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Делите на Твитеру"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Делите на Линкедину"
+  },
+  "social_media_buttons_email": {
+    "other": "Делите путем е-поште"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Дељење везе"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Линк је копиран у међуспремник!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Копирај у међуспремник"
+  },
+  "accept_invite_page_header": {
+    "other": "Добродошли "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Изгледа да сте већ активирали овај позив. Потребно је да се <a href=\"{{.SigninURL}}\">пријавите</a>. Ако сте заборавили лозинку, можете и да <a href=\"{{.ForgotPasswordURL}}\">ресетујете лозинку</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Хвала Вам. Ваш налог је направљен."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Прихватите позив."
+  },
+  "acceptinvite_agreement": {
+    "other": "Кликом на „Прихватите позив” потврђујете сте да сте прочитали и разумели <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">услове и одредбе</a> and <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">наше политике приватности.</a>."
+  },
+  "signup_page_header": {
+    "other": "Направите нови налог"
+  },
+  "signup_form_name": {
+    "other": "Име"
+  },
+  "signup_form_email": {
+    "other": "Имејл адреса"
+  },
+  "signup_form_password": {
+    "other": "Лозинка"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Потврдите лозинку"
+  },
+  "signup_form_gender": {
+    "other": "Пол"
+  },
+  "signup_form_dob": {
+    "other": "Датум рођења"
+  },
+  "signup_form_submit": {
+    "other": "Пошаљите"
+  },
+  "signin_page_header": {
+    "other": "Пријавите се"
+  },
+  "signin_form_email": {
+    "other": "Имејл адреса"
+  },
+  "signin_form_password": {
+    "other": "Лозинка"
+  },
+  "signin_form_remember": {
+    "other": "Запамти ме"
+  },
+  "signin_form_submit": {
+    "other": "Пошаљите"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Заборавили сте лозинку?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Немате налог? Направите нови налог"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Већ имате налог? Пријавите се"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Ова имејл адреса је већ употребљена."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Корисничко име или лозинка нису тачни."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Не успели сте да се пријавите превише пута.Покушајте поново касније."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Ваш налог је привремено суспендован.Молимо контактирајте администратора ако верујете да је то грешка."
+  },
+  "signup_form_error_forbidden": {
+    "other": "Догодила се грешка."
+  },
+  "combined_auth_continue": {
+    "other": "Наставите"
+  },
+  "combined_auth_change": {
+    "other": "промените"
+  },
+  "combined_auth_signin": {
+    "other": "Пријавите се"
+  },
+  "combined_auth_signup": {
+    "other": "Направите налог"
+  },
+  "combined_auth_signin_password": {
+    "other": "Молимо Вас унесите лозинку да бисте се пријавили."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Лозинка је нетачна."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Догодила се грешка."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Превише захтева. Покушајте поново касније."
+  },
+  "forgotpassword_page_header": {
+    "other": "Ресетујте лозинку"
+  },
+  "forgotpassword_form_email": {
+    "other": "Имејл адреса"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Ресетуј"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Налог са том имејл адресом не постоји."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Овај налог је суспендован."
+  },
+  "forgotpassword_complete": {
+    "other": "Хвала Вам. Имејл за ресетовање лозинке ће Вам убрзо стићи у инбокс."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Догодила се грешка."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Превише захтева. Покушајте поново касније."
+  },
+  "resetpassword_page_header": {
+    "other": "Промените лозинку"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Изгледа да је захтев за ресетовање лозинке неправилан, молимо Вас попуните <a href=\"{{.URL}}\">Образац за заборављену лозинку</a> поново."
+  },
+  "resetpassword_form_password": {
+    "other": "Нова лозинка"
+  },
+  "resetpassword_form_password2": {
+    "other": "Потврдите нову лозинку"
+  },
+  "resetpassword_form_submit": {
+    "other": "Промените"
+  },
+  "resetpassword_complete": {
+    "other": "Хвала. Ваша лозинка је промењена и пријављени сте."
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Захтев за ресетовање лозинке је неправилан."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Токен за ресетовање лозинке је истекао. Молимо Вас, тражите нови."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Превише захтева. Покушајте поново касније."
+  },
+  "account_page_header": {
+    "other": "Мој налог"
+  },
+  "account_form_name": {
+    "other": "Име"
+  },
+  "account_form_email": {
+    "other": "Имејл адреса"
+  },
+  "account_form_password": {
+    "other": "Лозинка"
+  },
+  "account_form_change_password": {
+    "other": "Промените"
+  },
+  "account_form_gender": {
+    "other": "Пол"
+  },
+  "account_form_dob": {
+    "other": "Датум рођења"
+  },
+  "account_form_submit": {
+    "other": "Ажурирајте"
+  },
+  "account_form_submitted": {
+    "other": "Ажурирано"
+  },
+  "account_form_password_changed": {
+    "other": "Ажурирано"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Лозинка је нетачна."
+  },
+  "account_form_pin_code": {
+    "other": "ПРИКОЛОТЬ"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "У вас нет набора PIN, который требуется для покупки, аренды и наблюдения за некоторыми названиями."
+  },
+  "account_form_set_pin": {
+    "other": "Установить PIN-код"
+  },
+  "account_form_pin_changed": {
+    "other": "Обновленный"
+  },
+  "account_form_change_pin": {
+    "other": "Изменить PIN-код"
+  },
+  "signup_form_optin": {
+    "other": "Пријавите се за бесплатни билтен"
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Потврдите лозинку"
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Молимо Вас упишите лозинку да бисте ажурирали измене које сте направили."
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Потврдите"
+  },
+  "changepassword_modal_header": {
+    "other": "Промените лозинку"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Ваша тренутна лозинка"
+  },
+  "changepassword_modal_password": {
+    "other": "Ваша нова лозинка"
+  },
+  "changepassword_modal_password2": {
+    "other": "Потврдите нову лозинку"
+  },
+  "changepassword_modal_submit": {
+    "other": "Ажурирајте"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Лозинка је нетачна."
+  },
+  "userlibrary_page_header": {
+    "other": "Резултати претраге"
+  },
+  "userlibrary_empty_header": {
+    "other": "Ваша библиотека је празна."
+  },
+  "userlibrary_empty_content": {
+    "other": "<a href=\"{{.HomeURL}}\">Прелистајте</a> нашу селекцију да је попуните."
+  },
+  "searchresults_page_header": {
+    "other": "результаты поиска"
+  },
+  "searchresults_load_more": {
+    "other": "Учитај још {{.Count}} "
+  },
+  "searchresults_total": {
+    "one": "Пронађен је 1 резултат за \"{{.Query}}\".",
+    "other": "Пронађено је {{.Count}} резултата за \"{{.Query}}\"."
+  },
+  "searchresults_empty_header": {
+    "other": "Нема резултата за \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Пробајте са новом претрагом или <a href=\"{{.HomeURL}}\"> прелистајте садржај</a> како бисте нашлито што тражите."
+  },
+  "validation_name_required": {
+    "other": "Молимо Вас упишите своје име."
+  },
+  "validation_email_required": {
+    "other": "Молимо Вас упишите Вашу имејл адресу."
+  },
+  "validation_email_email": {
+    "other": "Молимо Вас упишите исправну имејл адресу."
+  },
+  "validation_currentpassword_required": {
+    "other": "Молимо Вас упишите важећу лозинку."
+  },
+  "validation_password_required": {
+    "other": "Молимо Вас упишите своју лозинку."
+  },
+  "validation_password2_required": {
+    "other": "Молимо Вас потврдите лозинку."
+  },
+  "validation_password2_match": {
+    "other": "Лозинке се не подударају."
+  },
+  "validation_password_minlength": {
+    "other": "Молимо Вас упишите најмање {{.Count}} карактера. "
+  },
+  "validation_promocode_required": {
+    "other": "Молимо Вас упишите промотивни код."
+  },
+  "validation_pincode_required": {
+    "other": "Унесите ПИН код."
+  },
+  "validation_gender_required": {
+    "other": "Молимо Вас да одаберете пол са којим се идентификујете."
+  },
+  "validation_dob_required": {
+    "other": "Молимо Вас упишите свој датум рођења."
+  },
+  "validation_dob_date": {
+    "other": "Молимо Вас упишите исправан датум рођења."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "ХД видео на захтев."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "SD видео по требованию."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Средства в вашем кошельке могут использоваться для покупки или аренда любого содержимого на ScreenPlus."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Погледајте системске захтеве."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "куповина"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "изнајмљивање"
+  },
+  "shopping_info_sd_only": {
+    "other": "Ограничено только для воспроизведения SD."
+  },
+  "shopping_info_release_date_title": {
+    "other": "Излази {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": "Можете одмах да изнајмите, али нећете моћи да гледате пре тога."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Можете одмах да купите, али нећете моћи да гледате пре тога."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "Доступно до {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Нећете моћи да гледате садржај након тога."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Нећете моћи да гледате садржај након тога."
+  },
+  "duration_hour": {
+    "one": "1 сат",
+    "other": "{{.Count}} сата"
+  },
+  "duration_day": {
+    "one": "1 дан",
+    "other": "{{.Count}} дана"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "Изнајмљено на {{.ValueUnit}} "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} ч. за гледање. "
+  },
+  "shopping_info_watch_window_explanation_film": {
+    "one": "Када изнајмите филм, биће доступан на Вашем налогу {{.ValueUnit}}. ",
+    "other": "Када изнајмите филм, биће доступан на Вашем налогу {{.ValueUnit}}. "
+  },
+  "shopping_info_watch_window_explanation2_film": {
+    "one": "Када притиснете дугме за гледање, имаћете један сат да погледате филм колико год пута желите.",
+    "other": "Када притиснете дугме за гледање, имаћете {{.Count}} ч. да погледате филм колико год пута желите."
+  },
+  "shopping_info_watch_window_explanation_bundle": {
+    "one": "Наслови из пакета биће Вам доступни један дан кадага изнајмите.",
+    "other": "Наслови из пакета биће Вам доступни {{.Count}} дана када га изнајмите."
+  },
+  "shopping_info_watch_window_explanation2_bundle": {
+    "one": "Када притиснете дугме за гледање изабраног филма, имаћете један сат да погледате филм колико год пута желите.",
+    "other": "Када притиснете дугме за гледање изабраног филма, имаћете{{.Count}} ч. да погледате филм колико год пута желите."
+  },
+  "shopping_info_watch_window_explanation_season": {
+    "one": "Сезона ће вам бити доступна један дан када јеизнајмите.",
+    "other": "Сезона ће Вам бити доступна {{.Count}} дана када је изнајмите."
+  },
+  "shopping_info_watch_window_explanation2_season": {
+    "one": "Када притиснете дугме за гледање епизоде имаћете један сат да погледате епизоду колико год пута желите.",
+    "other": "Када притиснете дугме за гледање епизоде, имаћете{{.Count}} ч. да погледате епизоду колико год пута желите."
+  },
+  "shopping_info_credit_bonus_title": {
+    "other": "Бонус {{.BonusPercentage}}% "
+  },
+  "shopping_enter_card_prompt": {
+    "other": "Унесите детаље са Ваше кредитне картице да довршите {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Обављањем ове трансакције прихватате <a href=\"{{.TermsAndConditionsURL}}\"target=\"_blank\" tabindex=\"-1\">услове и одредбе</a>."
+  },
+  "shopping_discount_applied": {
+    "other": "Примењено снижење {{.DiscountAmount}}."
+  },
+  "shopping_discount_apply": {
+    "other": "Примените"
+  },
+  "shopping_discount_code": {
+    "other": "Унесите промотивни код."
+  },
+  "shopping_discount_have_code": {
+    "other": "Имам промотивни код."
+  },
+  "shopping_price_you_pay": {
+    "other": "Ви не плаћате"
+  },
+  "shopping_price_nothing": {
+    "other": "Ништа"
+  },
+  "shopping_price_free": {
+    "other": "Бесплатно"
+  },
+  "shopping_auth_directions": {
+    "other": "Неопходно је да имате налог. Молимо Вас унесите своју имејл адресу."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} је већ у Вашој библиотеци."
+  },
+  "shopping_error_missing_card": {
+    "other": "Молимо Вас унесите податке са ваше кредитне картице."
+  },
+  "shopping_error_title": {
+    "other": "Догодила се грешка"
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Молимо Вас унесите исправан сигурносни код."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Молимо Вас унесите исправан сигурносни код."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Молимо Вас унесите исправан број кредитне картице."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Молимо Вас унесите исправан број кредитне картице."
+  },
+  "shopping_error_card_declined": {
+    "other": "Кредитна картица је одбијена."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Молимо Вас унесите исправан датум истека."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Молимо Вас унесите исправан датум истека."
+  },
+  "shopping_error_expired_card": {
+    "other": "Кредитна картица је истекла."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "Ваш {{.Ownership}} није довршен. Морате бити у земљи у којој је кредитна картицаиздата. Молимо Вас користите другу картицу за плаћање."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "Ваш {{.Ownership}} није довршен. Препознали смо да користите деблокатор или прокси сервис. Молимо Вас искључите ове сервисе и покушајте поново."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Тај промо код се више не може користити."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Молимо Вас унесите промотивни код."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Молимо Вас унесите исправан промотивни код."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Молимо Вас унесите исправан промотивни код."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Молимо Вас унесите исправан промотивни код."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Промотивни код је већ искоришћен у овој сесији."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Тај промотивни код је већ искоришћен."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Тај промотивни код је већ искоришћен."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Тај промотивни код више не може да се користи."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Тај промотивни код је истекао."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Тај промотивни код не може да се користи при куповини."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Тај промотивни код не може да се користи при изнајмљивању."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Тај промотивни код не може да се користи са овим насловом."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Тај промотивни код не може да се користи у Вашој земљи."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Тај промотивни код не може да се користи."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "Тај промотивни код не може да се користи за пакете."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Кредитна картица је одбијена. Молимо Вас покушајте поново."
+  },
+  "shopping_complete_rental": {
+    "other": "Успешно!"
+  },
+  "shopping_complete_rental_period": {
+    "one": "Сада можете да га гледате колико год желите током наредног дана.",
+    "other": "Сада можете да га гледате колико год пута желите током наредних {.Count}} дана."
+  },
+  "shopping_complete_purchase": {
+    "other": "Хвала што сте купили {{.Title}}."
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "Хвала што сте купили {{.Title}}, {{.CreditTotal}} је додато на ваш налог."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "Моћи ћете да гледате од {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Рачун вам је послат имејлом."
+  },
+  "shopping_complete_library_link": {
+    "other": "Почните са гледањем {{.BundleItems}} у вашој библиотеци."
+  },
+  "shopping_complete_plan": {
+    "other": "Ваша куповина {{ .Title }} је била успешна."
+  },
+  "shopping_complete_rental_watch_window_start": {
+    "one": "Можете да почнете са гледањем до краја наредног дана.",
+    "other": "Можете да почнете са гледањем одмах или у наредних {{.Count}} дана."
+  },
+  "shopping_complete_rental_watch_window_end": {
+    "one": "Када пројекција почне, имате сат времена да погледате наслов колико год пута желите.",
+    "other": "Када пројекција почне, имате {{.Count}} часова да погледате наслов колико год пута желите."
+  },
+  "shopping_complete_rental_coming_soon": {
+    "one": "Моћи ћете да гледате од {{.Date}}, а изнајмљивање ће трајати један дан.",
+    "other": "Моћи ћете да гледате од {{.Date}}, а изнајмљивање ће трајати {{.Count}} дана."
+  },
+  "shopping_complete_rental_coming_soon_watch_window_start": {
+    "one": "Моћи ћете да гледате од {{.Date}}, а изнајмљивање ће трајати један дан.",
+    "other": "Моћи ћете да гледате од {{.Date}}, а изнајмљивање ће трајати {{.Count}} дана."
+  },
+  "shopping_action_rent": {
+    "other": "Изнајмите"
+  },
+  "shopping_action_buy": {
+    "other": "Купите"
+  },
+  "meta_detail_cast_title": {
+    "other": "Улоге"
+  },
+  "meta_detail_crew_title": {
+    "other": "Екипа"
+  },
+  "meta_detail_languages": {
+    "one": "Језик",
+    "other": "Језици"
+  },
+  "meta_detail_studios": {
+    "one": "Студио",
+    "other": "Студији"
+  },
+  "meta_detail_countries": {
+    "one": "Држава",
+    "other": "Државе"
+  },
+  "meta_detail_subtitles": {
+    "other": "Титлови"
+  },
+  "meta_detail_captions": {
+    "other": "Титлови [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Епизоде"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Додатни садржај"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Можда Вам се допадне"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Садржај овог пакета"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} филмова"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} сезона"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} филмова и сезона"
+  },
+  "userwishlist_page_header": {
+    "other": "Моја листа"
+  },
+  "userwishlist_slider_header": {
+    "other": "Моја листа"
+  },
+  "userwishlist_empty_header": {
+    "other": "Ваша листа је празна."
+  },
+  "userwishlist_empty_content": {
+    "other": "<a href=\"{{.HomeURL}}\">Прелистајте</a> нашу селекцију да је попуните."
+  },
+  "userwishlist_button_add": {
+    "other": "Додај на Моју листу"
+  },
+  "userwishlist_button_remove": {
+    "other": "Моја листа"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Моја листа"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Моја листа"
+  },
+  "activatedevice_page_header": {
+    "other": "Активировать устройство"
+  },
+  "activatedevice_page_content": {
+    "other": "Следуйте инструкциям на вашем устройстве, чтобы получить PIN-код.Ваш компьютер и устройство должны быть подключены к Интернету для активации."
+  },
+  "activatedevice_form_pin": {
+    "other": "Пин-код"
+  },
+  "activatedevice_form_submit": {
+    "other": "Активировать"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN-код не найден, пожалуйста, попробуйте еще раз."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN-код не найден, пожалуйста, попробуйте еще раз."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Пожалуйста, войдите, прежде чем активировать ваше устройство."
+  },
+  "activatedevice_page_activated": {
+    "other": "Спасибо за активируемость {{.DeviceName}}. Теперь вы должны иметь возможность просматривать вашу библиотеку на вашем телевизоре или устройстве."
+  },
+  "userdevices_page_header": {
+    "other": "Уређаји"
+  },
+  "userdevices_page_content": {
+    "one": "Уређаји ће бити аутоматски додати овде када их будете користили. Ограничени сте на само један уређај. ",
+    "other": "Уређаји ће аутоматски бити додати овде када их будете користили. Ограничени сте на{{.Count}} уређаја."
+  },
+  "userdevices_empty_content": {
+    "other": "Тренутно имате 0 регистрованих уређаја."
+  },
+  "userdevices_header_type": {
+    "other": "Тип уређаја"
+  },
+  "userdevices_header_description": {
+    "other": "Опис"
+  },
+  "userdevices_device_added": {
+    "other": "Додато {{.Date}}"
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Уклоните"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "Откажите"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Да, уклони уређај"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Уклоњено)"
+  },
+  "userdevices_delete_limits": {
+    "other": "Вы можете удалить {{.Limit}} Устройство (ы) из этого списка каждый {{.Period}} День (ы)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Вы достигли этого предела и не можете удалить какие-либо устройства прямо сейчас.Вы можете удалить устройство в {{.Days}} День (ы)."
+  },
+  "playlist_page_header": {
+    "other": "Плейлист"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Пожалуйста, войдите, чтобы смотреть живое телевидение."
+  },
+  "playlist_share_title": {
+    "other": "Плейлист"
+  },
+  "playlist_up_next_title": {
+    "other": "Следующий"
+  },
+  "pricing_ownership_buy": {
+    "other": "Купите"
+  },
+  "pricing_ownership_rent": {
+    "other": "Изнајмите"
+  },
+  "classification_intro": {
+    "other": "Класификација: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Овај сајт користи колачиће да би побољшао Ваш доживљај.Коришћењем сајта прихватате <a href=\"{{.CookiePolicyURL}}\">употребу колачића</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Прихвати"
+  },
+  "all_rights_reserved": {
+    "other": "Сва права су задржана. Ниједан део овог сајта не сме се репродуковати без наше писмене дозволе."
+  },
+  "users_gender_none": {
+    "other": "Није одређен"
+  },
+  "users_gender_female": {
+    "other": "Женски"
+  },
+  "users_gender_male": {
+    "other": "Мушки"
+  },
+  "users_gender_diverse": {
+    "other": "Свакојаки"
+  },
+  "users_gender_other": {
+    "other": "Друго"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD только"
+  },
+  "pricing_quality_sd_only": {
+    "other": "Только SD"
+  },
+  "shopping_card_save_card": {
+    "other": "Сохраните эту карту для будущего использования"
+  },
+  "shopping_card_button_change": {
+    "other": "Показать все сохраненные карты"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} кончающийся на {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(истекает {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(истекший)"
+  },
+  "shopping_card_use_other": {
+    "other": "Использовать новую карту"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Изменить карту"
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Обновите свою кредитную карту.Поддерживаемые карты - виза, MasterCard и American Express."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Эта карта будет спасена и регулярно планировать"
+  },
+  "shopping_card_change": {
+    "other": "Кредитная карта не правильная? <a href=\"{{.SubscriptionsURL}}\">Нажмите здесь, чтобы обновить свою карту.</a>"
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Подписка"
+  },
+  "shopping_action_credit": {
+    "other": "Пополнить"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "fод датума и времена "
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Изменить кредитную карту"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Обновить данные кредитной карты"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Обновлять"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Истекает {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Испытательный срок"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Отменить мою подписку"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Отмена"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Да, отмените мою подписку"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Отменить подписку?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Это отменит подписку на{{.Name}} строить планы.Вы все равно сможете посмотреть контент в плане, пока он не истечет {{.Expiry}}."
+  },
+  "availability_coming_soon": {
+    "other": "Ускоро"
+  },
+  "availability_renting": {
+    "other": "Изнајмљивање"
+  },
+  "availability_not_available": {
+    "other": "Није доступно"
+  },
+  "availability_in_watch_window": {
+    "other": "Доступно"
+  },
+  "availability_sold_out": {
+    "other": "Распродато"
+  },
+  "availability_available_till": {
+    "other": "Доступно до {{.ExpiryDate}}"
+  },
+  "availability_not_available_in_country": {
+    "other": "Недоступно"
+  },
+  "availability_available": {
+    "other": "Доступно од {{.ReleaseDate}}"
+  },
+  "availability_expires": {
+    "other": "Истиче {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Истекло"
+  },
+  "modal_cancel": {
+    "other": "Откажите"
+  },
+  "play": {
+    "other": "Гледајте"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Пријавите се"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Направите налог"
+  },
+  "combined_auth_terms": {
+    "other": "Сагласан сам са свим <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">условима и одредбама</a>."
+  },
+  "signup_terms": {
+    "other": "Сагласан сам са свим <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">условима и одредбама</a>."
+  },
+  "validation_terms_required": {
+    "other": "Потребно је да се сагласите са одредбама и условима."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": "Нажалост, {{.Title}} је распродат."
+  },
+  "changepincode_modal_header": {
+    "other": "Изменить свой PIN-код"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "ваш текущий пароль"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Ваш новый 4-значный PIN-код"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Подтвердите свой новый 4-значный PIN-код"
+  },
+  "changepincode_modal_submit": {
+    "other": "Установить PIN-код"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Этот пароль неверный."
+  },
+  "user_submit_pin_heading": {
+    "other": "Введите свой PIN-код в {{.Action}} Это ограниченный контент"
+  },
+  "user_submit_pin_button": {
+    "other": "Войти"
+  },
+  "user_set_pin_intro": {
+    "other": "Вам нужен PIN-код до {{.Action}} Ограниченный контент"
+  },
+  "user_set_pin_header": {
+    "other": "Установите свой PIN-код"
+  },
+  "user_set_pin_button": {
+    "other": "Установить PIN-код"
+  },
+  "user_reset_pin_button": {
+    "other": "Сбросить PIN-код"
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Упс, вы ввели неверный PIN-код"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "Нажмите здесь, чтобы сбросить PIN-код"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Похоже, у тебя проблемы.</p><p>Сбросьте свой PIN-код или свяжитесь с нами для <a href=\"{{.HelpURL}}\" target=\"_blank\">помощь</a>"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Этот контент ограничен возрастом."
+  },
+  "shopping_error_close_button": {
+    "other": "Ok"
+  },
+  "app_badge_title": {
+    "other": "Загрузите приложение для просмотра вашего приобретенного контента!"
+  },
+  "app_badge_ios": {
+    "other": "Загрузить в App Store"
+  },
+  "app_badge_android": {
+    "other": "Получить его в Google Play"
+  },
+  "shopping_price_title_plan": {
+    "other": "Цена"
+  },
+  "shopping_price_plan_note": {
+    "zero": "Наплаћује се сваки {{ .Interval }} .",
+    "one": "Наплаћује се сваки {{ .Interval }} након завршетка бесплатног пробног периода од 24 сата.",
+    "other": "Оптужен сваки {{ .Interval }} после ваших {{ .Count }} дневни бесплатни пробни крајевима."
+  },
+  "shopping_price_plan_note_interval": {
+    "one": "{{ .Interval }}",
+    "other": "{{ .Count }} {{ .Interval }} а"
+  },
+  "shopping_enter_card_prompt_plan": {
+    "other": "Унесите податке о својој кредитној картици испод да бисте започели претплату."
+  },
+  "shopping_action_plan": {
+    "other": "комплетан"
+  },
+  "shopping_complete_subscription": {
+    "other": "Ваша куповина претплате је била успешна. Сада сте претплаћени на {{ .Title }} ."
+  },
+  "shopping_complete_subscription_browse": {
+    "other": "Слободно <a href=\"/\">претражујте по</a> сајту или <a href=\"/search.html\">тражите</a> нешто специфично."
+  },
+  "shopping_info_plan_offer": {
+    "one": "Аутоматски обнавља сваки {{ .Interval }}",
+    "other": "Аутоматски обнавља на сваких {{ .Count }} {{ .Interval }} с"
+  },
+  "shopping_info_trial_period_offer": {
+    "one": "Испробајте своју бесплатну пробну верзију од 24 сата сада!",
+    "other": "Испробајте своју бесплатну пробну верзију {{ .Count }}"
+  },
+  "plans_page_header": {
+    "other": "Доступни планови"
+  },
+  "plan_label_owned": {
+    "other": "Ви сте власник овог плана"
+  },
+  "plan_expiry_date": {
+    "other": "Завршена продаја:"
+  },
+  "plan_read_more": {
+    "other": "Откриј више"
+  },
+  "plan_page_read_more": {
+    "other": "Опширније"
+  },
+  "plan_page_header_text": {
+    "other": "Уживајте у {{ .Name }}"
+  },
+  "page_plan_explore_intro": {
+    "other": "ИЛИ"
+  },
+  "page_plan_explore_link": {
+    "other": "Истражите друге пролазе"
+  },
+  "plan_showcase_page_ownership_button_buy": {
+    "other": "Купите сада"
+  },
+  "plan_free_link_text": {
+    "other": "Бесплатно се пријави"
+  },
+  "awards_in_competition": {
+    "other": "Ин Цомпетитион"
+  },
+  "awards_winner": {
+    "other": "Победник"
+  },
+  "donate_button_text": {
+    "other": "Донирајте"
+  },
+  "wcag_skip_links_header": {
+    "other": "Ссылки на доступность"
+  },
+  "wcag_skip_links_content": {
+    "other": "Перейти к содержанию"
+  },
+  "wcag_homepage_h1": {
+    "other": "Главная страница"
+  },
+  "wcag_carousel_h2": {
+    "other": "Карусель"
+  },
+  "wcag_collections_h2": {
+    "other": "Коллекции"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Нижний колонтин"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Основной"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Подразделение"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Переключить навигацию"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Пучок предметаs"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Карусель"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Коллекция страницы"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Список коллекции"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Сладер коллекции"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Список желаний"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Поделиться через фейсбук"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Поделиться в Twitter"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Поделиться на LinkedIn"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Просмотр на letterboxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "У вас уже есть этот план."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Этот план больше не доступен."
+  },
+  "shopping_payment_method_header": {
+    "other": "Способы оплаты"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Кредитная карта"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Гиропай"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Что-то пошло не так с этим платежом.Пожалуйста, попробуйте позже."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Оплата была отклонена.Закройте это окно и попробуйте снова."
+  },
+  "validation_pincode1_required": {
+    "other": "Пожалуйста, введите действительный PIN-код."
+  },
+  "validation_pincode2_required": {
+    "other": "Пожалуйста, введите действительный PIN-код."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Пожалуйста, введите действительный PIN-код."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Пожалуйста, введите действительный PIN-код."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN-код не совпадает."
+  },
+  "header_banner": {
+    "other": "Знамя заголовка"
   }
+}

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1,597 +1,1248 @@
 {
-    "site_owner": { "other": "ABC Cinemas" },
-    "settings_title": { "other": "Settings" },
-    "powered_by": { "other": "Tarafından desteklenmektedir" },
-    "powered_by_name": { "other": "Shift72" },
-    "powered_by_url": { "other": "https://www.shift72.com" },
-    "in_partnership_with": { "other": "İle ortaklığa" },
-    "festival_scope": { "other": "Festival Scope" },
-    "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
-    "en": { "other": "ingilizce" },
-    "fr": { "other": "Fransızca" },
-  
-    "episode_name": {
-      "other": "Bölüm"
-    },
-  
-    "season_name": {
-      "other": "Sezonf"
-    },
-  
-    "seasons":{
-      "one": "bir sezon",
-      "other": "{{.Count}} sezon"
-    },
-    "tvseason": {
-      "other": "{{.ShowInfo.Title}} Dizi {{.Season.SeasonNumber}}"
-    },
-    "tvseason_html": {
-      "other": "{{.ShowInfo.Title}} <span>Dizi {{.Season.SeasonNumber}}</span>"
-    },
-    "tvepisode": {
-      "other": "{{.Episode.Title}}"
-    },
-    "tvseason_number": {
-      "other": "Dizi {{.Season.SeasonNumber}}"
-    },
-    "episode_count": {
-      "one": "1 Bölüm",
-      "other": "{{.Count}} Epizotlar"
-    },
-  
-    "date_day": { "other": "Gün" },
-    "date_month": { "other": "Ay" },
-    "date_year": { "other": "Yıl" },
-  
-    "404_page_header": { "other": "Sayfa bulunamadı…" },
-    "404_page_content": { "other": "<p>Üzgünüz, aradığınız sayfa var gibi görünmüyor.</p><p>Taşınmış veya silinmiş olabilir veya belki bir şey yanlış yazdı.</p><p>Aradığınızı bulmak için ana sayfaya geri dönmeyi deneyin.</p><p><a href=\"{{.URL}}\">Ana sayfaya geri dön</a></p>" },
-  
-  
-    "nav_homepage": { "other": "ABC Cinemas" },
-    "nav_signin": { "other": "Oturum Aç" },
-    "nav_signup": { "other": "Hesap Oluştur" },
-    "nav_signed_in_as": { "other": "olarak oturum aç" },
-    "nav_library": { "other": "Kitaplığım" },
-    "nav_devices": { "other": "Cihazlarım" },
-    "nav_wishlist": { "other": "Listem" },
-    "nav_account": { "other": "Hesabım" },
-    "nav_signout": { "other": "Oturumu Kapat" },
-    "play_trailer": { "other": "Fragman" },
-    "runtime_hours": { "other": "sa" },
-    "runtime_minutes": { "other": "dk" },
-  
-    "datetime_today": { "other": "bugün {{.Date}}" },
-    "datetime_tomorrow": { "other": "yarın {{.Date}}" },
-    "datetime_yesterday": { "other": "dün {{.Date}}" },
-    "datetime_next": { "other": "{{.Date}}" },
-    "datetime_last": { "other": "son {{.Date}}" },
-  
-    "search_control_placeholder": { "other": "Arama" },
-    "search_control_submit": { "other": "Aramayı gönder" },
-  
-    "play_button_watch": { "other" : "Şimdi Oynat"},
-    "play_button_resume": { "other" : "Devam et"},
-  
-    "social_media_buttons_title": { "other": "Paylaş" },
-    "social_media_buttons_facebook": { "other": "Facebook'ta Paylaş" },
-    "social_media_buttons_twitter": { "other": "Twitter'da paylaş" },
-    "social_media_buttons_linkedin": { "other": "Linkedin'de paylaş" },
-    "social_media_buttons_email": { "other": "E-mail ile paylaş" },
-    "social_media_buttons_email_subject": { "other": "Bağlantı paylaşımı" },
-    "social_media_buttons_copied_link": { "other": "Link kopyalandı!" },
-    "social_media_buttons_copy_link": { "other": "Panoya kopyala" },
-
-    "accept_invite_page_header": { "other": "Hoşgeldiniz " },
-    "acceptinvite_form_invalid_reset_password_token": { "other": "Görünüşe göre bu davet talebini zaten yapmışsınız, onun yerine <a href=\"{{.SigninURL}}\">kayıt olmak</a> denemelisiniz. Parolanızı unuttuysanız, parolanızı ayrıca <a href=\"{{.ForgotPasswordURL}}\"> sıfırlayabilirsiniz</a>." },
-    "acceptinvite_complete": { "other": "Teşekkürler. Hesabınız oluşturuldu." },
-    "acceptinvite_form_submit": { "other": "Daveti Kabul Et." },
-    "acceptinvite_agreement": { "other": "Daveti Kabul Et butonuna tıklayarak, <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terimler &amp; koşullar</a> ve <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">Gizlilik Politikası</a> okuyup anladığınızı kabul etmiş olacaksınız." },
-  
-    "signup_page_header": { "other": "Yeni Hesap Oluştur" },
-    "signup_form_name": { "other": "İsim" },
-    "signup_form_email": { "other": "E-posta adresi" },
-    "signup_form_password": { "other": "Şifre" },
-    "signup_form_password_confirmation": { "other": "Şifrenizi onaylayın" },
-    "signup_form_gender": { "other": "Cinsiyet" },
-    "signup_form_dob": { "other": "Doğum tarihi" },
-    "signup_form_submit": { "other": "Gönder" },
-  
-    "signin_page_header": { "other": "Oturum aç" },
-    "signin_form_email": { "other": "E-posta adresi" },
-    "signin_form_password": { "other": "Parola" },
-    "signin_form_remember": { "other": "Beni hatırla" },
-    "signin_form_submit": { "other": "Gönder" },
-    "signin_page_forgotpassword": { "other": "Şifrenizi mi unuttunuz?" },
-    "signin_page_createnewaccount": { "other": "Hesabınız yok mu? Yeni hesap oluştur" },
-    "signup_page_alreadyhaveanaccount": { "other": "Zaten bir hesabınız var mı? Oturum Aç" },
-    "signup_form_error_email_already_in_use": { "other": "Bu e-posta adresi zaten kullanılıyor." },
-    "signin_form_error_incorrect_credentials": { "other": "Kullanıcı adı veya parola yanlış." },
-    "signin_form_error_ip_throttled": { "other": "Çok fazla giriş yapamadınız.Lütfen daha sonra tekrar deneyiniz." },
-    "signin_form_error_account_suspended": { "other": "Hesabınız geçici olarak askıya alındı.Lütfen bunun hatalı olduğuna inanıyorsanız, lütfen bir yönetici ile iletişime geçin. "},
-  
-    "signup_form_error_forbidden": { "other": "Bir hata oluştu." },
-  
-    "combined_auth_continue": { "other": "Devam et" },
-    "combined_auth_change": { "other": "Değiştir" },
-    "combined_auth_signin": { "other": "Oturum Aç" },
-    "combined_auth_signup": { "other": "Hesap oluştur" },
-    "combined_auth_signin_password": { "other": "Lütfen hesabınızda oturum açmak için şifrenizi girin." },
-    "combined_auth_signin_error_incorrect_credentials": { "other": "Bu şifre hatalı." },
-    "combined_auth_error_forbidden": { "other": "Bir hata oluştu." },
-    "combined_auth_error_too_many_requests": { "other": "Çok fazla talep var.Lütfen daha sonra tekrar deneyin." },
-  
-    "forgotpassword_page_header": { "other": "Parolanızı Sıfırlayın" },
-    "forgotpassword_form_email": { "other": "E-posta adresi" },
-    "forgotpassword_form_submit": { "other": "Sıfırla" },
-    "forgotpassword_form_error_email_doesnt_exist": { "other": "Bu e-posta adresiyle eşleşen bir hesap mevcut değil." },
-    "forgotpassword_form_error_account_suspended": { "other": "Bu hesap askıya alınmıştır." },
-    "forgotpassword_complete": { "other": "Teşekkürler. Kısa süre içinde gelen kutunuzda bir şifre sıfırlama e-postası görünecektir." },
-    "forgotpassword_form_error_forbidden": { "other": "Bir hata gerçekleşti." },
-    "forgotpassword_form_error_too_many_requests": { "other": "Çok fazla talep var.Lütfen daha sonra tekrar deneyin." },
-  
-    "resetpassword_page_header": { "other": "Şifrenizi değiştirin" },
-    "resetpassword_form_invalid_reset_password_token": { "other": "Eğer şifrenizi sıfırlama talebi geçersiz görünüyorsa, lütfen <a href=\"{{.URL}}\">Şifremi Unuttum </a> formunu tekrar doldurun." },
-    "resetpassword_form_password": { "other": "Yeni şifre" },
-    "resetpassword_form_password2": { "other": "Yeni şifrenizi onaylayın" },
-    "resetpassword_form_submit": { "other": "Değiştir" },
-    "resetpassword_complete": { "other": "Teşekkürler. Şifreniz değiştirildi ve oturumunuz açıldı. " },
-    "resetpassword_form_error_invalid_reset_password_token": { "other": "Şifre sıfırlama talebi geçersizdir. Lütfen daha sonra tekrar deneyin." },
-    "resetpassword_form_error_reset_password_token_expired": { "other": "Şifre sıfırlama talebi geçersizdir. Lütfen daha sonra tekrar deneyin." },
-    "resetpassword_form_error_too_many_requests": { "other": "Çok fazla talep var.Lütfen daha sonra tekrar deneyin." },
-  
-    "account_page_header": { "other": "Hesabım" },
-    "account_form_name": { "other": "İsim" },
-    "account_form_email": { "other": "E-posta adresi" },
-    "account_form_password": { "other": "Şifre" },
-    "account_form_change_password": { "other": "Değiştir" },
-    "account_form_gender": { "other": "Cinsiyet" },
-    "account_form_dob": { "other": "Doğum tarihi" },
-    "account_form_submit": { "other": "Güncelleyin" },
-    "account_form_submitted": { "other": "Güncellendi" },
-    "account_form_password_changed": { "other": "Güncellendi" },
-    "account_form_error_incorrect_password": { "other": "Bu şifre hatalı." },
-  
-    "signup_form_optin": {"other": "Ücretsiz bültenimize kaydolun. "},
-  
-    "passwordconfirmation_modal_header": { "other": "Şifrenizi doğrulayın." },
-    "passwordconfirmation_modal_label": { "other": "Lütfen değişikliklerinizi güncellemek için şifrenizi girin." },
-    "passwordconfirmation_modal_confirm": { "other": "Onayla" },
-  
-    "changepassword_modal_header": { "other": "Şifrenizi değiştirin" },
-    "changepassword_modal_currentpassword": { "other": "Mevcut şifreniz" },
-    "changepassword_modal_password": { "other": "Yeni şifreniz" },
-    "changepassword_modal_password2": { "other": "Yeni şifrenizi onaylayın" },
-    "changepassword_modal_submit": { "other": "Güncelle" },
-    "changepassword_modal_error_incorrect_password": { "other": "Bu şifre hatalı." },
-  
-    "userlibrary_page_header": { "other": "Kütüphanem" },
-    "userlibrary_empty_header":  { "other": "Kütüphaneniz boş" },
-    "userlibrary_empty_content": { "other": "Geniş seçkimizi <a href=\"{{.HomeURL}}\">tarayarak</a> doldurun." },
-  
-    "searchresults_page_header": { "other": "Arama Sonuçları" },
-    "searchresults_load_more": { "other": "Daha fazla yükle {{.Count}}" },
-    "searchresults_total": {
-      "one": "için 1 sonuçlar bulundu \"{{.Query}}\".",
-      "other": "için {{.Count}} sonuçlar bulundu \"{{.Query}}\"."
-    },
-    "searchresults_empty_header":  { "other": "için arama sonucu bulunamadı. \"{{.Query}}\"" },
-    "searchresults_empty_content": { "other": "Başka bir şey aramayı deneyin ya da aradığınızı bulmak için<a href=\"{{.HomeURL}}\">içeriğimizi tarayın</a> " },
-  
-    "validation_name_required": { "other": "Lütfen isminizi giriniz." },
-    "validation_email_required": { "other": "Lütfen e-posta adresini giriniz." },
-    "validation_email_email": { "other": "Lütfen geçerli bir e-posta adresi giriniz." },
-    "validation_currentpassword_required": { "other": "Lütfen geçerli parolanızı giriniz." },
-    "validation_password_required": { "other": "Lütfen parolanızı giriniz." },
-    "validation_password2_required": { "other": "Lütfen parolanızı onaylayınız." },
-    "validation_password2_match": { "other": "Parola eşleşmemektedir." },
-    "validation_password_minlength": { "other": "Lütfen en az (sayı) karakter giriniz." },
-    "validation_promocode_required": { "other": "Lütfen bir promosyon kodu giriniz." },
-    "validation_pincode_required": { "other": "Lütfen bir PIN kodu girin." },
-    "validation_gender_required": { "other": "Lütfen size en yakın cinsiyeti belirtiniz." },
-    "validation_dob_required": { "other": "Lütfen doğum tarihinizi giriniz." },
-    "validation_dob_date": { "other": "Lütfen geçerli bir doğum tarihi giriniz." },
-
-    "shopping_info_subtitle_hd": { "other": "Talep Üzerine HD Video." },
-    "shopping_info_subtitle_sd": { "other": "Talep üzerine SD video." },
-    "shopping_info_subtitle_wallet": { "other": "Cüzdanınızdaki fonlar, ekrandaki herhangi bir içeriğin satın alınması veya kiralanması için kullanılabilir." },
-    "shopping_info_subtitle_help": { "other": "Sistem gereksinimleri için buraya bakınız." },
-    "shopping_info_ownership_buy": { "other": "satın al" },
-    "shopping_info_ownership_rent": { "other": "kirala" },
-
-    "shopping_info_sd_only": { "other": "Sadece SD oynatma ile sınırlıdır. " },
-    "shopping_info_release_date_title": { "other": "Yayın {{.Date}}. " },
-    "shopping_info_release_date_explanation_rent": { "other": " Şu an kiralayabilirsiniz ama o zamana kadar izleyemeyeceksiniz." },
-    "shopping_info_release_date_explanation_buy": { "other": "Şu an satın alabilirsiniz ama o zamana kadar izleyemeyeceksiniz." },
-
-    "shopping_info_available_until_date_title": { "other": "{{.Date}}'e kadar erişilebilir. " },
-    "shopping_info_available_until_date_explanation_rent": { "other": "Bundan sonra içeriği görüntüleyemeceksiniz." },
-    "shopping_info_available_until_date_explanation_buy": { "other": "Bundan sonra içeriği görüntüleyemeceksiniz." },
-
-    "duration_hour": { "one": "1 saat", "other": "{{.Count}} saat" },
-    "duration_day": { "one": "1 gün", "other": "{{.Count}} gün" },
-    "shopping_info_rental_period_duration": { "other": "{{.ValueUnit}} kiralama " },
-    "shopping_info_watch_window_duration": { "other": "{{.Count}} saat playback oynatma penceresi. " },
-    "shopping_info_watch_window_explanation_film": {
-      "one": "Oynata bastığınızda izleme penceresi başlar ve filmi istediğiniz kadar izlemek için {{.ValueUnit}} olacak. ",
-      "other": "Oynata bastığınızda izleme penceresi başlar ve filmi istediğiniz kadar izlemek için {{.ValueUnit}} olacak. "
-    },
-    "shopping_info_watch_window_explanation2_film": {
-      "one": "Oynata bastığınızda izleme penceresi başlar ve filmi istediğiniz kadar izlemek için bir saatiniz olacak. ",
-      "other": "Once you press play, the watch window begins and you have {{.Count}} hours to watch the film as many times as you like."
-    },
-    "shopping_info_watch_window_explanation_bundle": {
-      "one": "Kiralandığında, sepetinizdeki öğeler hesabınızda gün için erişilebilir olacaktır. ",
-      "other": "Kiralandığında, sepetinizdeki öğeler hesabınızda {{.Count}} gün için erişilebilir olacaktır. {{.Count}} "
-    },
-    "shopping_info_watch_window_explanation2_bundle": {
-      "one": "Belli bir film için oynata bastığınızda, izleme penceresi başlar ve filmi istediğiniz kadar izlemek için bir saatiniz olacak.",
-      "other": "Belli bir film için oynata bastığınızda, izleme penceresi başlar ve filmi istediğiniz kadar izlemek için bir saatiniz olacak."
-    },
-    "shopping_info_watch_window_explanation_season": {
-      "one": "Kiralandığında, sezonunuz hesabınızda bir gün erişilebilir olacak. ",
-      "other": "Kiralandığında, sezonunuz hesabınızda bir gün erişilebilir {{.Count}} olacak."
-    },
-    "shopping_info_watch_window_explanation2_season": {
-      "one": "Bir bölümü oynata bastığınızda, izleme penceresi başlar ve bölümü istediğiniz kadar izlemek için bir saatiniz olacak.",
-      "other": "Bir bölümü oynata bastığınızda, izleme penceresi başlar ve bölümü istediğiniz kadar izlemek için bir saatiniz olacak."
-    },
-    "shopping_info_credit_bonus_title": { "other": "{{.BonusPercentage}}% Bonus" },
-
-    "shopping_enter_card_prompt": { "other": "nizi tamamlamak için aşağıya kredi kartı bilgilerinizi giriniz {{.Verb}}." },
-
-    "shopping_terms": { "other": "Bu işlemi tamamlayarak, <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">terms and conditions</a> katılıyorum."},
-    "shopping_discount_applied": { "other": "{{.DiscountAmount}} indirim uygulanmıştır." },
-    "shopping_discount_apply": { "other": "Uygula" },
-    "shopping_discount_code": { "other": "Promosyon kodu girin." },
-    "shopping_discount_have_code": { "other": "Promosyon kodum var." },
-
-    "shopping_price_you_pay": { "other": "Ödüyorsunuz" },
-    "shopping_price_nothing": { "other": "Hiçbir şey" },
-    "shopping_price_free": { "other": "Ücretsiz" },
-
-    "shopping_auth_directions": { "other": "Öncelikle bir hesaba ihtiyaç var. Lütfen e-posta adresinizi girin." },
-
-    "shopping_error_in_library": { "other": "{{.Title}} zaten kütüphanenizde." },
-
-    "shopping_error_missing_card": { "other": "Lütfen kredi kartı bilgilerinizi girin." },
-    "shopping_error_title": { "other": "İlginiz için teşekkür ederiz." },
-    "shopping_error_incorrect_cvc": { "other": "Lütfen geçerli bir CVV girin." },
-    "shopping_error_invalid_cvc": { "other": "Lütfen geçerli bir CVV girin." },
-    "shopping_error_incorrect_number": { "other": "Lütfen geçerli bir Kredi Kart Numarası girin." },
-    "shopping_error_invalid_number": { "other": "Lütfen geçerli bir Kredi Kart Numarası girin." },
-    "shopping_error_card_declined": { "other": "Kredi Kartı reddedildi." },
-    "shopping_error_invalid_expiry_month": { "other": "Lütfen geçerli bir son kullanma tarihi girin." },
-    "shopping_error_invalid_expiry_year": { "other": "Lütfen geçerli bir son kullanma tarihi girin." },
-    "shopping_error_expired_card": { "other": "Kredi Kartının son kullanma tarihi geçmiştir." },
-    "shopping_error_creditcard_country_mismatch": { "other": "niz {{.Ownership}} tamamlanmadı. Kredi kartınızın basıldığı ülkede olmanız gerekiyor. Lütfen ödemeyi yapmak için başka bir kart kullanın." },
-    "shopping_error_proxy_detected": { "other": "niz {{.Ownership}} tamamlanmadı. Blok kaldırıcı ya da proxy hizmeti kullandığınızı tespit ettik. Lütfen bu hizmetlerin hepsini kapatıp tekrar deneyin." },
-
-    "shopping_error_discount_worn_out": { "other": "Bu promosyon kodu artık kullanılamaz." },
-    "shopping_error_discount_blank": { "other": "Lütfen promosyon kodu girin." },
-    "shopping_error_discount_not_applied": { "other": "Lütfen geçerli bir promosyon kodu girin." },
-    "shopping_error_discount_invalid": { "other": "Lütfen geçerli bir promosyon kodu girin." },
-    "shopping_error_discount_disabled": { "other": "Lütfen geçerli bir promosyon kodu girin." },
-    "shopping_error_discount_already_applied": { "other": "Bu seans için zaten bir promosyon kodu kullanıldı." },
-    "shopping_error_discount_already_redeemed": { "other": "Promosyon kodu zaten kullanıldı." },
-    "shopping_error_discount_used_previously": { "other": "Promosyon kodu zaten kullanıldı." },
-    "shopping_error_discount_max_limit": { "other": "Promosyon kodu artık kullanılamaz." },
-    "shopping_error_discount_expired": { "other": "Promo kodunun kullanım süresi dolmuştur." },
-    "shopping_error_discount_invalid_ownership_buy": { "other": "Bu promosyon kodu satın alırken kullanılamaz." },
-    "shopping_error_discount_invalid_ownership_rent": { "other": "Bu promosyon kodu kiralarken kullanılamaz." },
-    "shopping_error_discount_invalid_item": { "other": "Bu promosyon kodu bu ürünle kullanılamaz." },
-    "shopping_error_discount_invalid_pricing_region": { "other": "Bu promosyon kodu ülkenizde kullanılamaz." },
-    "shopping_error_discounts_not_allowed": { "other": "Bu promosyon kodu kullanılamaz." },
-    "shopping_error_discount_disallowed_on_bundles": { "other": "That promo code can not be used on bundles." },
-    "shopping_error_payment_intent_authentication_failure": { "other": "Kredi Kartınız reddedildi. Lütfen tekrar deneyin." },
-
-    "shopping_complete_rental": { "other": "Başardınız!" },
-    "shopping_complete_rental_period": {
-      "one": "Filmi önümüzdeki gün istediğiniz sıklıkta izleyebilirsiniz.",
-      "other": "Filmi önümüzdeki {{.Count}} gün istediğiniz sıklıkta izleyebilirsiniz."
-    },
-    "shopping_complete_purchase": { "other": "{{.Title}} yi satın aldığınız için teşekkürler" },
-    "shopping_complete_credit_purchase": { "other": "yi satın aldığınız için teşekkürler {{.Title}}, {{.CreditTotal}} hesabınıza eklenmiştir." },
-    "shopping_complete_purchase_coming_soon": { "other": "tarihinden itibaren filmi izleyebileceksiniz {{.Date}}." },
-    "shopping_complete_receipt": { "other": "Faturanız adresinize e-posta ile gönderilmiştir." },
-    "shopping_complete_library_link": { "other": "Kütüphanenizi görüntüle" },
-    "shopping_complete_plan": {
-      "other": "{{ .Title }} satın alma işleminiz başarılı oldu."
-    },
-    "shopping_complete_rental_watch_window_start": {
-      "one": "Artık önümüzdeki günde filmi izlemeye başlayabilirsiniz.",
-      "other": "Artık önümüzdeki {{.Count}} günde filmi izlemeye başlayabilirsiniz."
-    },
-    "shopping_complete_rental_watch_window_end": {
-      "one": "Geri oynatım başladığında, filmi istediğiniz kadar izlemek için saatiniz olacak. ",
-      "other": "Geri oynatım başladığında, filmi istediğiniz kadar izlemek için {{.Count}} saatiniz olacak."
-    },
-    "shopping_complete_rental_coming_soon": {
-      "one": "dan itibaren filmi izleyebileceksiniz ve kiraladığınız film {{.Date}} gün boyunca aktif kalacak",
-      "other": "dan itibaren filmi izleyebileceksiniz ve kiraladığınız film {{.Date}} gün boyunca aktif kalacak {{.Count}}.."
-    },   
-    "shopping_complete_rental_coming_soon_watch_window_start": {
-      "one": "dan itibaren filmi izleyebileceksiniz ve kiraladığınız film {{.Date}} gün boyunca aktif kalacak.",
-      "other": "dan itibaren filmi izleyebileceksiniz ve kiraladığınız film {{.Date}} gün boyunca aktif kalacak {{.Count}}."
-    },
-  
-    "shopping_action_rent": { "other": "Kirala" },
-    "shopping_action_buy": { "other": "Satın Al" },
-   
-    "meta_detail_cast_title": { "other": "Oyuncular" },
-    "meta_detail_crew_title": { "other": "Ekip" },
-    "meta_detail_languages": { "one": "Dil", "other": "Diller" },
-    "meta_detail_studios": { "one": "Stüdyo", "other": "Stüdyolar" },
-    "meta_detail_countries": { "one": "Ülke", "other": "Ülkeler" },
-    "meta_detail_subtitles": { "other": "Altyazılar" },
-    "meta_detail_captions": { "other": "Altyazılar [CC]" },
-    "meta_detail_episodes_title": { "other": "Bölümler" },
-    "meta_detail_bonus_title": { "other": "Bonus İçerik" },
-    "meta_detail_recommendations_title": { "other": "Bunu da beğenebilirsiniz" },
-    "meta_detail_bundle_items_title": { "other": "Content included in this bundle" },
-  
-    "bundle_items_all_films": { "other": "{{.Count}} film" },
-    "bundle_items_all_seasons": { "other": "{{.Count}} sezon" },
-    "bundle_items_mixed": { "other": "{{.Count}} film ve sezon" },
-    "userwishlist_page_header": { "other": "Benim Listem" },
-    "userwishlist_slider_header": { "other": "Benim Listem" },
-    "userwishlist_empty_header":  { "other": "Listeniz boş." },
-    "userwishlist_empty_content": { "other": "Geniş seçkimizi <a href=\"{{.HomeURL}}\">tarayarak</a> listenizi doldurun." },
-    "userwishlist_button_add": { "other": "Listeme Ekle" },
-    "userwishlist_button_remove": { "other": "Benim Listem" },
-    "userwishlist_button_add_compact": { "other": "Benim Listem" },
-    "userwishlist_button_remove_compact": { "other": "Benim Listem" },
-  
-    "activatedevice_page_header": { "other": "Cihazı Etkinleştir" },
-    "activatedevice_page_content": { "other": "PIN kodu almak için cihazınızdaki talimatları izleyin.Bilgisayarınız ve cihazınızın etkinleştirmek için İnternet'e bağlanması gerekir." },
-    "activatedevice_form_pin": { "other": "PIN kodu" },
-    "activatedevice_form_submit": { "other": "Aktif hale getirmek" },
-    "activatedevice_form_error_invalid_code": { "other": "PIN kodu bulunamadı, lütfen tekrar deneyin." },
-    "activatedevice_form_error_pin_not_found": { "other": "PIN kodu bulunamadı, lütfen tekrar deneyin." },
-    "activatedevice_signin_prompt": { "other": "Cihazınızı etkinleştirmeden önce lütfen giriş yapın." },
-    "activatedevice_page_activated": { "other": "Etkinleştirdiğiniz için teşekkür ederiz{{.DeviceName}}. Artık kütüphanenize televizyonunuzda veya cihazınıza gözden geçirmeniz gerekir." },
-  
-    "userdevices_page_header": { "other": "Cihazlar" },
-    "userdevices_page_content": {
-      "one": "Kullandığınızda cihazlar otomatik olarak buraya eklenecektir. Tek bir cihaz kullanabilirsiniz.",
-      "other": "Cihazları kullandığınızda otomatik olarak buraya eklenecektir. {{.Count}} cihazla sınırlısınız."
-    },
-    "userdevices_empty_content": { "other": "Şu an 0 kayıtlı cihazınız var." },
-    "userdevices_header_type": { "other": "Cihaz Türü" },
-    "userdevices_header_description": { "other": "Tanım" },
-    "userdevices_device_added": { "other": "Eklendi {{.Date}}." },
-    "userdevices_device_actions_delete": { "other": "Çıkar" },
-    "userdevices_device_actions_cancel": { "other": "İptal Et" },
-    "userdevices_device_actions_confirm": { "other": "Evet, cihazı çıkar" },
-    "userdevices_device_deleted": { "other": "(Çıkarıldı)" },
-  
-    "playlist_page_header": { "other": "Çalma listesi" },
-    "playlist_sign_in_warning": { "other": "Canlı TV izlemek için lütfen oturum açın."},
-    "playlist_share_title": { "other": "Çalma listesi" },
-    "playlist_up_next_title": { "other": "Bir sonraki" },
-  
-    "pricing_ownership_buy": { "other": "Satın Al" },
-    "pricing_ownership_rent": { "other": "Kirala" },
-  
-    "classification_intro": { "other": "Sınıflandırma: " },
-    "classification_divider": { "other": " - " },
-    "classification_outro": { "other": "" },
-  
-    "cookie_banner_message": { "other": "Bu site kullanıcı deneyimini artırmak için çerezler kullanmaktadır. Bu siteyi kullanırken, < çerez ve gizlilik ayarlarını kabul edin <a href=\"{{.CookiePolicyURL}}\">cookie usage</a>." },
-    "cookie_banner_accept": { "other": "Kabul" },
-  
-    "all_rights_reserved": { "other": "Her hakkı saklıdır. Bu sitenin hiçbir bölümü yazılı iznimiz olmadan çoğaltılamaz." },
-  
-    "users_gender_none": { "other": "Belirtilmemiş" },
-    "users_gender_female": { "other": "Kadın" },
-    "users_gender_male": { "other": "Erkek" },
-    "users_gender_diverse": { "other": "Farklı" },
-    "users_gender_other": { "other": "Diğer" },
-  
-  
-    "pricing_quality_hd": { "other": "HD" },
-    "pricing_quality_sd": { "other": "SD" },
-    "pricing_quality_hd_only": { "other": "HD Sadece" },
-    "pricing_quality_sd_only": { "other": "SD Sadece" },
-  
-    "shopping_card_save_card": { "other": "Gelecekteki kullanım için bu kartı kaydet " },
-    "shopping_card_button_change": { "other": "Tüm kayıtlı kartları göster" },
-    "shopping_card_existing_description": { "other": "{{.Card.Brand}} bitirmek {{.Card.Number}}" },
-    "shopping_card_existing_expiry": { "other": "(sona ermek {{.Card.Expiry}})" },
-    "shopping_card_existing_expired": { "other": "(günü geçmiş)" },
-    "shopping_card_use_other": { "other": "Yeni bir kart kullanın" },
-    "shopping_card_use_new_card": { "other": "Kartı değiştir " },
-  
-    "shopping_info_ownership_plan": { "other": "Abonelik" },
-  
-
-    "shopping_action_credit": { "other": "Doldurmak" },
-
-  
-    "shopping_info_rental_period_coming_soon": { "other": "...şu tarih ve yayınlanma vaktinden başlayarak." },
-
-  
-    "usersubscriptions_change_payment_method_change": { "other": "Kredi kartını değiştir" },
-    "usersubscriptions_change_payment_method_modal_title": { "other": "Kredi kartı bilgilerini güncelle" },
-    "usersubscriptions_change_payment_method_modal_submit": { "other": "Güncelleme" },
-  
-    "usersubscriptions_subscription_expiry": { "other": "Sona ermek {{.Expiry}}" },
-    "usersubscriptions_subscription_status_trialing": { "other": "Deneme süresi" },
-    "usersubscriptions_subscription_unsubscribe": { "other": "Aboneliğimi iptal et" },
-    "usersubscriptions_unsubscribe_modal_cancel": { "other": "İptal" },
-    "usersubscriptions_unsubscribe_modal_confirm": { "other": "Evet, aboneliğimi iptal et " },
-    "usersubscriptions_unsubscribe_modal_title": { "other": "Aboneliği iptal et?" },
-    "usersubscriptions_unsubscribe_modal_body": { "other": "Bu, aboneliği iptal edecektir.{{.Name}} plan.Yine de plandaki içeriği sona erene kadar izleyebileceksiniz. {{.Expiry}}." },
-  
-    "shopping_card_update_reason_none": { "other": "Kredi kartınızı güncelleyin.Desteklenen kartlar Visa, MasterCard ve American Express'dir." },
-  
-    "availability_coming_soon": { "other": "Yakında" },
-    "availability_renting": { "other": "Kiralama" },
-    "availability_not_available": { "other": "Mevcut Değil" },
-    "availability_in_watch_window": { "other": "Mevcut" },
-    "availability_sold_out": { "other": "Tükendi" },
-    "availability_available_till": { "other": "(bitiş tarihi)'ne dek erişilebilir." },
-    "availability_not_available_in_country": { "other": "Mevcut Değil" },
-    "availability_available": { "other": "(yayın tarihi)'nde erişilebilir." },
-
-    "modal_cancel": { "other": "İptal" },
-
-    "play": { "other": "Oynat" },
-
-    "availability_expires": { "other": "Son gösterim: {{.Expiry}}" },
-    "availability_expired": { "other": "Süresi doldu"},
-
-    "combined_auth_signin_prompt": { "other": "Oturum Aç" },
-    "combined_auth_signup_prompt": { "other": "Kaydol" },
-    "combined_auth_terms": { "other": "Tüm <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terimler &amp; koşullar</a> kabul ediyorum." },
-    "signup_terms": { "other": "Tüm <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terimler &amp; koşullar</a> kabul ediyorum." },
-    "validation_terms_required": { "other": "Hüküm ve şartları kabul etmelisiniz." },
-    "shopping_error_item_limit_exceeded": { "other": " Ne yazık ki{{.Title}} tükendi. ." },
-
-    "shopping_card_change": { "other": "Kredi kartı doğru değil? <a href=\"{{.SubscriptionsURL}}\">Kartınızı güncellemek için buraya tıklayın.</a>" },
-
-    "user_error_too_many_pin_errors": { "other": "<p>Sorun yaşıyor gibi görünüyor.</p><p>PIN'inizi sıfırlayın veya bizimle iletişime geçin. <a href=\"{{.HelpURL}}\" target=\"_blank\">Yardım Edin</a>" },
-
-    "app_badge_title": { "other": "Satın alınan içeriğinizi görüntülemek için uygulamayı indirin!" },
-    "app_badge_ios": { "other": "App Store'da indirin" },
-    "app_badge_android": { "other": "Google Play'den indirin" },
-
-    "shopping_price_title_plan": {
-      "other": "Fiyat"
-    },
-    "shopping_price_plan_note": {
-      "zero": "Her {{ .Interval }} .",
-      "one": "24 saatlik ücretsiz deneme süreniz sona erdikten sonra her {{ .Interval }}",
-      "other": "Her Ücretli {{ .Interval }} sizin sonra {{ .Count }} günlük ücretsiz deneme sürümü bitmeden."
-    },
-    "shopping_price_plan_note_interval": {
-      "one": "{{ .Interval }}",
-      "other": "{{ .Count }} {{ .Interval }}"
-    },
-    "shopping_enter_card_prompt_plan": {
-      "other": "Aboneliğinizi başlatmak için aşağıya kredi kartı bilgilerinizi girin."
-    },
-    "shopping_action_plan": {
-      "other": "Tamamlayınız"
-    },
-    "shopping_complete_subscription": {
-      "other": "Abonelik satın alma işleminiz başarılı oldu. Artık {{ .Title }} ."
-    },
-    "shopping_complete_subscription_browse": {
-      "other": "Sitede <a href=\"/\">gezinmekten</a> veya belirli bir şey <a href=\"/search.html\">aramaktan</a> çekinmeyin."
-    },
-    "shopping_info_plan_offer": {
-      "one": "{{ .Interval }} otomatik olarak yeniler",
-      "other": "Otomatik olarak her yeniler {{ .Count }} {{ .Interval }}"
-    },
-    "shopping_info_trial_period_offer": {
-      "one": "24 saatlik ücretsiz denemenizi şimdi deneyin!",
-      "other": "Ücretsiz {{ .Count }} günlük denemenizi deneyin!"
-    },
-    "plans_page_header": {
-      "other": "Mevcut Planlar"
-    },
-    "plan_label_owned": {
-      "other": "Bu plana sahipsin"
-    },
-    "plan_expiry_date": {
-      "other": "Satış kapanışı:"
-    },
-    "plan_read_more": {
-      "other": "Daha fazlasını bul"
-    },
-    "plan_page_read_more": {
-      "other": "Devamını oku"
-    },
-    "plan_page_header_text": {
-      "other": "Keyfini çıkarın {{ .Name }}"
-    },
-    "page_plan_explore_intro": {
-      "other": "VEYA"
-    },
-    "page_plan_explore_link": {
-      "other": "Diğer geçişleri keşfedin"
-    },
-    "plan_showcase_page_ownership_button_buy": {
-      "other": "Şimdi al"
-    },
-    "plan_free_link_text": {
-      "other": "Ücretsiz kaydol"
-    },
-    "awards_in_competition": {
-      "other": "Rekabette"
-    },
-    "awards_winner": {
-      "other": "kazanan"
-    },
-    "donate_button_text": {
-      "other": "Bağış yapmak"
-    },
-    "wcag_skip_links_header": { "other": "Erişilebilirlik Bağlantıları " },
-    "wcag_skip_links_content": { "other": "İçeriğe atla" },
-  
-    "wcag_homepage_h1": { "other": "Ana sayfa" },
-    "wcag_carousel_h2": { "other": "Atlıkarınca" },
-    "wcag_collections_h2": { "other": "Koleksiyonlar" },
-  
-    "wcag_aria_label_footer": { "other": "Altbilgi" },
-    "wcag_aria_label_nav_main": { "other": "Ana" },
-    "wcag_aria_label_nav_sub": { "other": "Alt" },
-    "wcag_aria_label_toggle_nav": { "other": "Gezinme geçişi" },
-    "wcag_aria_label_bundle_items": { "other": "Paket eşyaları" },
-    "wcag_aria_label_carousel": { "other": "Atlıkarınca" },
-    "wcag_aria_label_page_collection": { "other": "Sayfa Koleksiyonu" },
-    "wcag_aria_label_collection_list": { "other": "Koleksiyon Listesi" },
-    "wcag_aria_label_collection_slider": { "other": "Toplama kaydırıcısı" },
-    "wcag_aria_label_wishlist": { "other": "İstek listesi" },
-    "wcag_aria_label_facebook": { "other": "Facebook'ta Paylaş" },
-    "wcag_aria_label_twitter": { "other": "Twitter'da paylaş" },
-    "wcag_aria_label_linkedin": { "other": "LinkedIn'de Paylaş" },
-    "wcag_aria_label_letterboxd": { "other": "MektupBoxd'da Görüntüle" },
-    "shopping_error_plan_already_owned": { "other": "Zaten bu planın var." },
-    "shopping_error_plan_expired": { "other": "Bu plan artık mevcut değil." },
-    "shopping_payment_method_header": { "other": "Ödeme metodları" },
-    "shopping_payment_method_credit_card": { "other": "Kredi kartı" },
-    "shopping_payment_method_giropay": { "other": "GIROPAY" },
-    "shopping_error_stripe_unknown_error": { "other": "Bu ödeme ile bir şeyler ters gitti.Lütfen daha sonra tekrar deneyiniz." },
-    "shopping_error_payment_complete_failed": { "other": "Ödeme reddedildi.Bu pencereyi kapatın ve tekrar deneyin." },
-    
-    "header_banner": { "other": "Başlık afişi" },
-
-    "account_form_pin_code": { "other": "TOPLU İĞNE" },
-    "account_form_pin_code_not_set": { "other": "Bazı başlıkları satın almak, kiralamak ve izlemek için gerekli olan bir PIN setiniz yoktur."},
-    "account_form_set_pin": { "other": "Pim koymak" },
-    "account_form_pin_changed": { "other": "Güncellenmiş" },
-    "account_form_change_pin": { "other": "Pin'i değiştir" },
-
-    "user_set_pin_header": { "other": "PIN'inizi ayarlayın" },
-    "user_set_pin_button": { "other": "Pim koymak" },
-    "user_submit_pin_heading": { "other": "Bu sınırlı içerik için PIN'inizi {{.Action}} öğesine girin." },
-    "user_error_wrong_pin_retry": { "other": "Hata, yanlış bir pim girdiniz" },
-    "user_submit_pin_button": { "other": "Giriş" },
-    "user_reset_pin_button": { "other": "Sıfırlama pimi" },
-
-    "validation_pincode1_required": { "other": "Lütfen geçerli bir PIN kodu girin." },
-    "validation_pincode2_required": { "other": "Lütfen geçerli bir PIN kodu girin." },
-    "validation_pincode1_pattern": { "other": "Lütfen geçerli bir PIN kodu girin." },
-    "validation_pincode2_pattern": { "other": "Lütfen geçerli bir PIN kodu girin." },
-    "validation_pincode2_match": { "other": "PIN kodu eşleşmiyor." },
-  
-    "userdevices_delete_limits": { "other": "Kaldırabilirsin {{.Limit}} Bu listeden cihaz (lar) her {{.Period}} gün (ler)."},
-    "userdevices_delete_limit_reached": { "other": "Bu sınıra ulaştınız ve şu anda cihazları kaldıramazsınız.Bir cihazı silinebilirsiniz {{.Days}} gün (ler)." },
-    "shopping_card_new_subscription": { "other": "Bu kart düzenli olarak kaydedilir ve tahsil edilecektir." },
-
-  "changepincode_modal_header": { "other": "PIN'inizi değiştirin" },
-  "changepincode_modal_currentpassword": { "other": "mevcut şifreniz" },
-  "changepincode_modal_pincode1": { "other": "Yeni 4 basamaklı piminiz" },
-  "changepincode_modal_pincode2": { "other": "Yeni 4 basamaklı piminizi onaylayın " },
-  "changepincode_modal_submit": { "other": "Pim koymak" },
-  "changepincode_modal_error_wrong_password": { "other": "Bu şifre yanlış." },
-
-  "user_set_pin_intro": { "other": "Bir pim gerekir {{.Action}} Sınırlı içerik"},
-  "user_error_wrong_pin_reset": { "other": "PIN'inizi sıfırlamak için buraya tıklayın" },
-  "user_error_too_many_pin_errors_help_page_link": { "other": "" },
-  "shopping_error_age_restricted": { "other": "Bu içerik yaşı sınırlıdır." },
-  "shopping_error_close_button": { "other": "Tamam" }
-    
+  "site_owner": {
+    "other": "ABC Cinemas"
+  },
+  "settings_title": {
+    "other": "Settings"
+  },
+  "powered_by": {
+    "other": "Tarafından desteklenmektedir"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.shift72.com"
+  },
+  "in_partnership_with": {
+    "other": "İle ortaklığa"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
+  "en": {
+    "other": "ingilizce"
+  },
+  "fr": {
+    "other": "Fransızca"
+  },
+  "episode_name": {
+    "other": "Bölüm"
+  },
+  "season_name": {
+    "other": "Sezonf"
+  },
+  "seasons": {
+    "one": "bir sezon",
+    "other": "{{.Count}} sezon"
+  },
+  "tvseason": {
+    "other": "{{.ShowInfo.Title}} Dizi {{.Season.SeasonNumber}}"
+  },
+  "tvseason_html": {
+    "other": "{{.ShowInfo.Title}} <span>Dizi {{.Season.SeasonNumber}}</span>"
+  },
+  "tvepisode": {
+    "other": "{{.Episode.Title}}"
+  },
+  "tvseason_number": {
+    "other": "Dizi {{.Season.SeasonNumber}}"
+  },
+  "episode_count": {
+    "one": "1 Bölüm",
+    "other": "{{.Count}} Epizotlar"
+  },
+  "date_day": {
+    "other": "Gün"
+  },
+  "date_month": {
+    "other": "Ay"
+  },
+  "date_year": {
+    "other": "Yıl"
+  },
+  "404_page_header": {
+    "other": "Sayfa bulunamadı…"
+  },
+  "404_page_content": {
+    "other": "<p>Üzgünüz, aradığınız sayfa var gibi görünmüyor.</p><p>Taşınmış veya silinmiş olabilir veya belki bir şey yanlış yazdı.</p><p>Aradığınızı bulmak için ana sayfaya geri dönmeyi deneyin.</p><p><a href=\"{{.URL}}\">Ana sayfaya geri dön</a></p>"
+  },
+  "nav_homepage": {
+    "other": "ABC Cinemas"
+  },
+  "nav_signin": {
+    "other": "Oturum Aç"
+  },
+  "nav_signup": {
+    "other": "Hesap Oluştur"
+  },
+  "nav_signed_in_as": {
+    "other": "olarak oturum aç"
+  },
+  "nav_library": {
+    "other": "Kitaplığım"
+  },
+  "nav_devices": {
+    "other": "Cihazlarım"
+  },
+  "nav_wishlist": {
+    "other": "Listem"
+  },
+  "nav_account": {
+    "other": "Hesabım"
+  },
+  "nav_signout": {
+    "other": "Oturumu Kapat"
+  },
+  "play_trailer": {
+    "other": "Fragman"
+  },
+  "runtime_hours": {
+    "other": "sa"
+  },
+  "runtime_minutes": {
+    "other": "dk"
+  },
+  "datetime_today": {
+    "other": "bugün {{.Date}}"
+  },
+  "datetime_tomorrow": {
+    "other": "yarın {{.Date}}"
+  },
+  "datetime_yesterday": {
+    "other": "dün {{.Date}}"
+  },
+  "datetime_next": {
+    "other": "{{.Date}}"
+  },
+  "datetime_last": {
+    "other": "son {{.Date}}"
+  },
+  "search_control_placeholder": {
+    "other": "Arama"
+  },
+  "search_control_submit": {
+    "other": "Aramayı gönder"
+  },
+  "play_button_watch": {
+    "other": "Şimdi Oynat"
+  },
+  "play_button_resume": {
+    "other": "Devam et"
+  },
+  "social_media_buttons_title": {
+    "other": "Paylaş"
+  },
+  "social_media_buttons_facebook": {
+    "other": "Facebook'ta Paylaş"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Twitter'da paylaş"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Linkedin'de paylaş"
+  },
+  "social_media_buttons_email": {
+    "other": "E-mail ile paylaş"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Bağlantı paylaşımı"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Link kopyalandı!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Panoya kopyala"
+  },
+  "accept_invite_page_header": {
+    "other": "Hoşgeldiniz "
+  },
+  "acceptinvite_form_invalid_reset_password_token": {
+    "other": "Görünüşe göre bu davet talebini zaten yapmışsınız, onun yerine <a href=\"{{.SigninURL}}\">kayıt olmak</a> denemelisiniz. Parolanızı unuttuysanız, parolanızı ayrıca <a href=\"{{.ForgotPasswordURL}}\"> sıfırlayabilirsiniz</a>."
+  },
+  "acceptinvite_complete": {
+    "other": "Teşekkürler. Hesabınız oluşturuldu."
+  },
+  "acceptinvite_form_submit": {
+    "other": "Daveti Kabul Et."
+  },
+  "acceptinvite_agreement": {
+    "other": "Daveti Kabul Et butonuna tıklayarak, <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terimler &amp; koşullar</a> ve <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">Gizlilik Politikası</a> okuyup anladığınızı kabul etmiş olacaksınız."
+  },
+  "signup_page_header": {
+    "other": "Yeni Hesap Oluştur"
+  },
+  "signup_form_name": {
+    "other": "İsim"
+  },
+  "signup_form_email": {
+    "other": "E-posta adresi"
+  },
+  "signup_form_password": {
+    "other": "Şifre"
+  },
+  "signup_form_password_confirmation": {
+    "other": "Şifrenizi onaylayın"
+  },
+  "signup_form_gender": {
+    "other": "Cinsiyet"
+  },
+  "signup_form_dob": {
+    "other": "Doğum tarihi"
+  },
+  "signup_form_submit": {
+    "other": "Gönder"
+  },
+  "signin_page_header": {
+    "other": "Oturum aç"
+  },
+  "signin_form_email": {
+    "other": "E-posta adresi"
+  },
+  "signin_form_password": {
+    "other": "Parola"
+  },
+  "signin_form_remember": {
+    "other": "Beni hatırla"
+  },
+  "signin_form_submit": {
+    "other": "Gönder"
+  },
+  "signin_page_forgotpassword": {
+    "other": "Şifrenizi mi unuttunuz?"
+  },
+  "signin_page_createnewaccount": {
+    "other": "Hesabınız yok mu? Yeni hesap oluştur"
+  },
+  "signup_page_alreadyhaveanaccount": {
+    "other": "Zaten bir hesabınız var mı? Oturum Aç"
+  },
+  "signup_form_error_email_already_in_use": {
+    "other": "Bu e-posta adresi zaten kullanılıyor."
+  },
+  "signin_form_error_incorrect_credentials": {
+    "other": "Kullanıcı adı veya parola yanlış."
+  },
+  "signin_form_error_ip_throttled": {
+    "other": "Çok fazla giriş yapamadınız.Lütfen daha sonra tekrar deneyiniz."
+  },
+  "signin_form_error_account_suspended": {
+    "other": "Hesabınız geçici olarak askıya alındı.Lütfen bunun hatalı olduğuna inanıyorsanız, lütfen bir yönetici ile iletişime geçin. "
+  },
+  "signup_form_error_forbidden": {
+    "other": "Bir hata oluştu."
+  },
+  "combined_auth_continue": {
+    "other": "Devam et"
+  },
+  "combined_auth_change": {
+    "other": "Değiştir"
+  },
+  "combined_auth_signin": {
+    "other": "Oturum Aç"
+  },
+  "combined_auth_signup": {
+    "other": "Hesap oluştur"
+  },
+  "combined_auth_signin_password": {
+    "other": "Lütfen hesabınızda oturum açmak için şifrenizi girin."
+  },
+  "combined_auth_signin_error_incorrect_credentials": {
+    "other": "Bu şifre hatalı."
+  },
+  "combined_auth_error_forbidden": {
+    "other": "Bir hata oluştu."
+  },
+  "combined_auth_error_too_many_requests": {
+    "other": "Çok fazla talep var.Lütfen daha sonra tekrar deneyin."
+  },
+  "forgotpassword_page_header": {
+    "other": "Parolanızı Sıfırlayın"
+  },
+  "forgotpassword_form_email": {
+    "other": "E-posta adresi"
+  },
+  "forgotpassword_form_submit": {
+    "other": "Sıfırla"
+  },
+  "forgotpassword_form_error_email_doesnt_exist": {
+    "other": "Bu e-posta adresiyle eşleşen bir hesap mevcut değil."
+  },
+  "forgotpassword_form_error_account_suspended": {
+    "other": "Bu hesap askıya alınmıştır."
+  },
+  "forgotpassword_complete": {
+    "other": "Teşekkürler. Kısa süre içinde gelen kutunuzda bir şifre sıfırlama e-postası görünecektir."
+  },
+  "forgotpassword_form_error_forbidden": {
+    "other": "Bir hata gerçekleşti."
+  },
+  "forgotpassword_form_error_too_many_requests": {
+    "other": "Çok fazla talep var.Lütfen daha sonra tekrar deneyin."
+  },
+  "resetpassword_page_header": {
+    "other": "Şifrenizi değiştirin"
+  },
+  "resetpassword_form_invalid_reset_password_token": {
+    "other": "Eğer şifrenizi sıfırlama talebi geçersiz görünüyorsa, lütfen <a href=\"{{.URL}}\">Şifremi Unuttum </a> formunu tekrar doldurun."
+  },
+  "resetpassword_form_password": {
+    "other": "Yeni şifre"
+  },
+  "resetpassword_form_password2": {
+    "other": "Yeni şifrenizi onaylayın"
+  },
+  "resetpassword_form_submit": {
+    "other": "Değiştir"
+  },
+  "resetpassword_complete": {
+    "other": "Teşekkürler. Şifreniz değiştirildi ve oturumunuz açıldı. "
+  },
+  "resetpassword_form_error_invalid_reset_password_token": {
+    "other": "Şifre sıfırlama talebi geçersizdir. Lütfen daha sonra tekrar deneyin."
+  },
+  "resetpassword_form_error_reset_password_token_expired": {
+    "other": "Şifre sıfırlama talebi geçersizdir. Lütfen daha sonra tekrar deneyin."
+  },
+  "resetpassword_form_error_too_many_requests": {
+    "other": "Çok fazla talep var.Lütfen daha sonra tekrar deneyin."
+  },
+  "account_page_header": {
+    "other": "Hesabım"
+  },
+  "account_form_name": {
+    "other": "İsim"
+  },
+  "account_form_email": {
+    "other": "E-posta adresi"
+  },
+  "account_form_password": {
+    "other": "Şifre"
+  },
+  "account_form_change_password": {
+    "other": "Değiştir"
+  },
+  "account_form_gender": {
+    "other": "Cinsiyet"
+  },
+  "account_form_dob": {
+    "other": "Doğum tarihi"
+  },
+  "account_form_submit": {
+    "other": "Güncelleyin"
+  },
+  "account_form_submitted": {
+    "other": "Güncellendi"
+  },
+  "account_form_password_changed": {
+    "other": "Güncellendi"
+  },
+  "account_form_error_incorrect_password": {
+    "other": "Bu şifre hatalı."
+  },
+  "signup_form_optin": {
+    "other": "Ücretsiz bültenimize kaydolun. "
+  },
+  "passwordconfirmation_modal_header": {
+    "other": "Şifrenizi doğrulayın."
+  },
+  "passwordconfirmation_modal_label": {
+    "other": "Lütfen değişikliklerinizi güncellemek için şifrenizi girin."
+  },
+  "passwordconfirmation_modal_confirm": {
+    "other": "Onayla"
+  },
+  "changepassword_modal_header": {
+    "other": "Şifrenizi değiştirin"
+  },
+  "changepassword_modal_currentpassword": {
+    "other": "Mevcut şifreniz"
+  },
+  "changepassword_modal_password": {
+    "other": "Yeni şifreniz"
+  },
+  "changepassword_modal_password2": {
+    "other": "Yeni şifrenizi onaylayın"
+  },
+  "changepassword_modal_submit": {
+    "other": "Güncelle"
+  },
+  "changepassword_modal_error_incorrect_password": {
+    "other": "Bu şifre hatalı."
+  },
+  "userlibrary_page_header": {
+    "other": "Kütüphanem"
+  },
+  "userlibrary_empty_header": {
+    "other": "Kütüphaneniz boş"
+  },
+  "userlibrary_empty_content": {
+    "other": "Geniş seçkimizi <a href=\"{{.HomeURL}}\">tarayarak</a> doldurun."
+  },
+  "searchresults_page_header": {
+    "other": "Arama Sonuçları"
+  },
+  "searchresults_load_more": {
+    "other": "Daha fazla yükle {{.Count}}"
+  },
+  "searchresults_total": {
+    "one": "için 1 sonuçlar bulundu \"{{.Query}}\".",
+    "other": "için {{.Count}} sonuçlar bulundu \"{{.Query}}\"."
+  },
+  "searchresults_empty_header": {
+    "other": "için arama sonucu bulunamadı. \"{{.Query}}\""
+  },
+  "searchresults_empty_content": {
+    "other": "Başka bir şey aramayı deneyin ya da aradığınızı bulmak için<a href=\"{{.HomeURL}}\">içeriğimizi tarayın</a> "
+  },
+  "validation_name_required": {
+    "other": "Lütfen isminizi giriniz."
+  },
+  "validation_email_required": {
+    "other": "Lütfen e-posta adresini giriniz."
+  },
+  "validation_email_email": {
+    "other": "Lütfen geçerli bir e-posta adresi giriniz."
+  },
+  "validation_currentpassword_required": {
+    "other": "Lütfen geçerli parolanızı giriniz."
+  },
+  "validation_password_required": {
+    "other": "Lütfen parolanızı giriniz."
+  },
+  "validation_password2_required": {
+    "other": "Lütfen parolanızı onaylayınız."
+  },
+  "validation_password2_match": {
+    "other": "Parola eşleşmemektedir."
+  },
+  "validation_password_minlength": {
+    "other": "Lütfen en az (sayı) karakter giriniz."
+  },
+  "validation_promocode_required": {
+    "other": "Lütfen bir promosyon kodu giriniz."
+  },
+  "validation_pincode_required": {
+    "other": "Lütfen bir PIN kodu girin."
+  },
+  "validation_gender_required": {
+    "other": "Lütfen size en yakın cinsiyeti belirtiniz."
+  },
+  "validation_dob_required": {
+    "other": "Lütfen doğum tarihinizi giriniz."
+  },
+  "validation_dob_date": {
+    "other": "Lütfen geçerli bir doğum tarihi giriniz."
+  },
+  "shopping_info_subtitle_hd": {
+    "other": "Talep Üzerine HD Video."
+  },
+  "shopping_info_subtitle_sd": {
+    "other": "Talep üzerine SD video."
+  },
+  "shopping_info_subtitle_wallet": {
+    "other": "Cüzdanınızdaki fonlar, ekrandaki herhangi bir içeriğin satın alınması veya kiralanması için kullanılabilir."
+  },
+  "shopping_info_subtitle_help": {
+    "other": "Sistem gereksinimleri için buraya bakınız."
+  },
+  "shopping_info_ownership_buy": {
+    "other": "satın al"
+  },
+  "shopping_info_ownership_rent": {
+    "other": "kirala"
+  },
+  "shopping_info_sd_only": {
+    "other": "Sadece SD oynatma ile sınırlıdır. "
+  },
+  "shopping_info_release_date_title": {
+    "other": "Yayın {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation_rent": {
+    "other": " Şu an kiralayabilirsiniz ama o zamana kadar izleyemeyeceksiniz."
+  },
+  "shopping_info_release_date_explanation_buy": {
+    "other": "Şu an satın alabilirsiniz ama o zamana kadar izleyemeyeceksiniz."
+  },
+  "shopping_info_available_until_date_title": {
+    "other": "{{.Date}}'e kadar erişilebilir. "
+  },
+  "shopping_info_available_until_date_explanation_rent": {
+    "other": "Bundan sonra içeriği görüntüleyemeceksiniz."
+  },
+  "shopping_info_available_until_date_explanation_buy": {
+    "other": "Bundan sonra içeriği görüntüleyemeceksiniz."
+  },
+  "duration_hour": {
+    "one": "1 saat",
+    "other": "{{.Count}} saat"
+  },
+  "duration_day": {
+    "one": "1 gün",
+    "other": "{{.Count}} gün"
+  },
+  "shopping_info_rental_period_duration": {
+    "other": "{{.ValueUnit}} kiralama "
+  },
+  "shopping_info_watch_window_duration": {
+    "other": "{{.Count}} saat playback oynatma penceresi. "
+  },
+  "shopping_info_watch_window_explanation_film": {
+    "one": "Oynata bastığınızda izleme penceresi başlar ve filmi istediğiniz kadar izlemek için {{.ValueUnit}} olacak. ",
+    "other": "Oynata bastığınızda izleme penceresi başlar ve filmi istediğiniz kadar izlemek için {{.ValueUnit}} olacak. "
+  },
+  "shopping_info_watch_window_explanation2_film": {
+    "one": "Oynata bastığınızda izleme penceresi başlar ve filmi istediğiniz kadar izlemek için bir saatiniz olacak. ",
+    "other": "Once you press play, the watch window begins and you have {{.Count}} hours to watch the film as many times as you like."
+  },
+  "shopping_info_watch_window_explanation_bundle": {
+    "one": "Kiralandığında, sepetinizdeki öğeler hesabınızda gün için erişilebilir olacaktır. ",
+    "other": "Kiralandığında, sepetinizdeki öğeler hesabınızda {{.Count}} gün için erişilebilir olacaktır. {{.Count}} "
+  },
+  "shopping_info_watch_window_explanation2_bundle": {
+    "one": "Belli bir film için oynata bastığınızda, izleme penceresi başlar ve filmi istediğiniz kadar izlemek için bir saatiniz olacak.",
+    "other": "Belli bir film için oynata bastığınızda, izleme penceresi başlar ve filmi istediğiniz kadar izlemek için bir saatiniz olacak."
+  },
+  "shopping_info_watch_window_explanation_season": {
+    "one": "Kiralandığında, sezonunuz hesabınızda bir gün erişilebilir olacak. ",
+    "other": "Kiralandığında, sezonunuz hesabınızda bir gün erişilebilir {{.Count}} olacak."
+  },
+  "shopping_info_watch_window_explanation2_season": {
+    "one": "Bir bölümü oynata bastığınızda, izleme penceresi başlar ve bölümü istediğiniz kadar izlemek için bir saatiniz olacak.",
+    "other": "Bir bölümü oynata bastığınızda, izleme penceresi başlar ve bölümü istediğiniz kadar izlemek için bir saatiniz olacak."
+  },
+  "shopping_info_credit_bonus_title": {
+    "other": "{{.BonusPercentage}}% Bonus"
+  },
+  "shopping_enter_card_prompt": {
+    "other": "nizi tamamlamak için aşağıya kredi kartı bilgilerinizi giriniz {{.Verb}}."
+  },
+  "shopping_terms": {
+    "other": "Bu işlemi tamamlayarak, <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">terms and conditions</a> katılıyorum."
+  },
+  "shopping_discount_applied": {
+    "other": "{{.DiscountAmount}} indirim uygulanmıştır."
+  },
+  "shopping_discount_apply": {
+    "other": "Uygula"
+  },
+  "shopping_discount_code": {
+    "other": "Promosyon kodu girin."
+  },
+  "shopping_discount_have_code": {
+    "other": "Promosyon kodum var."
+  },
+  "shopping_price_you_pay": {
+    "other": "Ödüyorsunuz"
+  },
+  "shopping_price_nothing": {
+    "other": "Hiçbir şey"
+  },
+  "shopping_price_free": {
+    "other": "Ücretsiz"
+  },
+  "shopping_auth_directions": {
+    "other": "Öncelikle bir hesaba ihtiyaç var. Lütfen e-posta adresinizi girin."
+  },
+  "shopping_error_in_library": {
+    "other": "{{.Title}} zaten kütüphanenizde."
+  },
+  "shopping_error_missing_card": {
+    "other": "Lütfen kredi kartı bilgilerinizi girin."
+  },
+  "shopping_error_title": {
+    "other": "İlginiz için teşekkür ederiz."
+  },
+  "shopping_error_incorrect_cvc": {
+    "other": "Lütfen geçerli bir CVV girin."
+  },
+  "shopping_error_invalid_cvc": {
+    "other": "Lütfen geçerli bir CVV girin."
+  },
+  "shopping_error_incorrect_number": {
+    "other": "Lütfen geçerli bir Kredi Kart Numarası girin."
+  },
+  "shopping_error_invalid_number": {
+    "other": "Lütfen geçerli bir Kredi Kart Numarası girin."
+  },
+  "shopping_error_card_declined": {
+    "other": "Kredi Kartı reddedildi."
+  },
+  "shopping_error_invalid_expiry_month": {
+    "other": "Lütfen geçerli bir son kullanma tarihi girin."
+  },
+  "shopping_error_invalid_expiry_year": {
+    "other": "Lütfen geçerli bir son kullanma tarihi girin."
+  },
+  "shopping_error_expired_card": {
+    "other": "Kredi Kartının son kullanma tarihi geçmiştir."
+  },
+  "shopping_error_creditcard_country_mismatch": {
+    "other": "niz {{.Ownership}} tamamlanmadı. Kredi kartınızın basıldığı ülkede olmanız gerekiyor. Lütfen ödemeyi yapmak için başka bir kart kullanın."
+  },
+  "shopping_error_proxy_detected": {
+    "other": "niz {{.Ownership}} tamamlanmadı. Blok kaldırıcı ya da proxy hizmeti kullandığınızı tespit ettik. Lütfen bu hizmetlerin hepsini kapatıp tekrar deneyin."
+  },
+  "shopping_error_discount_worn_out": {
+    "other": "Bu promosyon kodu artık kullanılamaz."
+  },
+  "shopping_error_discount_blank": {
+    "other": "Lütfen promosyon kodu girin."
+  },
+  "shopping_error_discount_not_applied": {
+    "other": "Lütfen geçerli bir promosyon kodu girin."
+  },
+  "shopping_error_discount_invalid": {
+    "other": "Lütfen geçerli bir promosyon kodu girin."
+  },
+  "shopping_error_discount_disabled": {
+    "other": "Lütfen geçerli bir promosyon kodu girin."
+  },
+  "shopping_error_discount_already_applied": {
+    "other": "Bu seans için zaten bir promosyon kodu kullanıldı."
+  },
+  "shopping_error_discount_already_redeemed": {
+    "other": "Promosyon kodu zaten kullanıldı."
+  },
+  "shopping_error_discount_used_previously": {
+    "other": "Promosyon kodu zaten kullanıldı."
+  },
+  "shopping_error_discount_max_limit": {
+    "other": "Promosyon kodu artık kullanılamaz."
+  },
+  "shopping_error_discount_expired": {
+    "other": "Promo kodunun kullanım süresi dolmuştur."
+  },
+  "shopping_error_discount_invalid_ownership_buy": {
+    "other": "Bu promosyon kodu satın alırken kullanılamaz."
+  },
+  "shopping_error_discount_invalid_ownership_rent": {
+    "other": "Bu promosyon kodu kiralarken kullanılamaz."
+  },
+  "shopping_error_discount_invalid_item": {
+    "other": "Bu promosyon kodu bu ürünle kullanılamaz."
+  },
+  "shopping_error_discount_invalid_pricing_region": {
+    "other": "Bu promosyon kodu ülkenizde kullanılamaz."
+  },
+  "shopping_error_discounts_not_allowed": {
+    "other": "Bu promosyon kodu kullanılamaz."
+  },
+  "shopping_error_discount_disallowed_on_bundles": {
+    "other": "That promo code can not be used on bundles."
+  },
+  "shopping_error_payment_intent_authentication_failure": {
+    "other": "Kredi Kartınız reddedildi. Lütfen tekrar deneyin."
+  },
+  "shopping_complete_rental": {
+    "other": "Başardınız!"
+  },
+  "shopping_complete_rental_period": {
+    "one": "Filmi önümüzdeki gün istediğiniz sıklıkta izleyebilirsiniz.",
+    "other": "Filmi önümüzdeki {{.Count}} gün istediğiniz sıklıkta izleyebilirsiniz."
+  },
+  "shopping_complete_purchase": {
+    "other": "{{.Title}} yi satın aldığınız için teşekkürler"
+  },
+  "shopping_complete_credit_purchase": {
+    "other": "yi satın aldığınız için teşekkürler {{.Title}}, {{.CreditTotal}} hesabınıza eklenmiştir."
+  },
+  "shopping_complete_purchase_coming_soon": {
+    "other": "tarihinden itibaren filmi izleyebileceksiniz {{.Date}}."
+  },
+  "shopping_complete_receipt": {
+    "other": "Faturanız adresinize e-posta ile gönderilmiştir."
+  },
+  "shopping_complete_library_link": {
+    "other": "Kütüphanenizi görüntüle"
+  },
+  "shopping_complete_plan": {
+    "other": "{{ .Title }} satın alma işleminiz başarılı oldu."
+  },
+  "shopping_complete_rental_watch_window_start": {
+    "one": "Artık önümüzdeki günde filmi izlemeye başlayabilirsiniz.",
+    "other": "Artık önümüzdeki {{.Count}} günde filmi izlemeye başlayabilirsiniz."
+  },
+  "shopping_complete_rental_watch_window_end": {
+    "one": "Geri oynatım başladığında, filmi istediğiniz kadar izlemek için saatiniz olacak. ",
+    "other": "Geri oynatım başladığında, filmi istediğiniz kadar izlemek için {{.Count}} saatiniz olacak."
+  },
+  "shopping_complete_rental_coming_soon": {
+    "one": "dan itibaren filmi izleyebileceksiniz ve kiraladığınız film {{.Date}} gün boyunca aktif kalacak",
+    "other": "dan itibaren filmi izleyebileceksiniz ve kiraladığınız film {{.Date}} gün boyunca aktif kalacak {{.Count}}.."
+  },
+  "shopping_complete_rental_coming_soon_watch_window_start": {
+    "one": "dan itibaren filmi izleyebileceksiniz ve kiraladığınız film {{.Date}} gün boyunca aktif kalacak.",
+    "other": "dan itibaren filmi izleyebileceksiniz ve kiraladığınız film {{.Date}} gün boyunca aktif kalacak {{.Count}}."
+  },
+  "shopping_action_rent": {
+    "other": "Kirala"
+  },
+  "shopping_action_buy": {
+    "other": "Satın Al"
+  },
+  "meta_detail_cast_title": {
+    "other": "Oyuncular"
+  },
+  "meta_detail_crew_title": {
+    "other": "Ekip"
+  },
+  "meta_detail_languages": {
+    "one": "Dil",
+    "other": "Diller"
+  },
+  "meta_detail_studios": {
+    "one": "Stüdyo",
+    "other": "Stüdyolar"
+  },
+  "meta_detail_countries": {
+    "one": "Ülke",
+    "other": "Ülkeler"
+  },
+  "meta_detail_subtitles": {
+    "other": "Altyazılar"
+  },
+  "meta_detail_captions": {
+    "other": "Altyazılar [CC]"
+  },
+  "meta_detail_episodes_title": {
+    "other": "Bölümler"
+  },
+  "meta_detail_bonus_title": {
+    "other": "Bonus İçerik"
+  },
+  "meta_detail_recommendations_title": {
+    "other": "Bunu da beğenebilirsiniz"
+  },
+  "meta_detail_bundle_items_title": {
+    "other": "Content included in this bundle"
+  },
+  "bundle_items_all_films": {
+    "other": "{{.Count}} film"
+  },
+  "bundle_items_all_seasons": {
+    "other": "{{.Count}} sezon"
+  },
+  "bundle_items_mixed": {
+    "other": "{{.Count}} film ve sezon"
+  },
+  "userwishlist_page_header": {
+    "other": "Benim Listem"
+  },
+  "userwishlist_slider_header": {
+    "other": "Benim Listem"
+  },
+  "userwishlist_empty_header": {
+    "other": "Listeniz boş."
+  },
+  "userwishlist_empty_content": {
+    "other": "Geniş seçkimizi <a href=\"{{.HomeURL}}\">tarayarak</a> listenizi doldurun."
+  },
+  "userwishlist_button_add": {
+    "other": "Listeme Ekle"
+  },
+  "userwishlist_button_remove": {
+    "other": "Benim Listem"
+  },
+  "userwishlist_button_add_compact": {
+    "other": "Benim Listem"
+  },
+  "userwishlist_button_remove_compact": {
+    "other": "Benim Listem"
+  },
+  "activatedevice_page_header": {
+    "other": "Cihazı Etkinleştir"
+  },
+  "activatedevice_page_content": {
+    "other": "PIN kodu almak için cihazınızdaki talimatları izleyin.Bilgisayarınız ve cihazınızın etkinleştirmek için İnternet'e bağlanması gerekir."
+  },
+  "activatedevice_form_pin": {
+    "other": "PIN kodu"
+  },
+  "activatedevice_form_submit": {
+    "other": "Aktif hale getirmek"
+  },
+  "activatedevice_form_error_invalid_code": {
+    "other": "PIN kodu bulunamadı, lütfen tekrar deneyin."
+  },
+  "activatedevice_form_error_pin_not_found": {
+    "other": "PIN kodu bulunamadı, lütfen tekrar deneyin."
+  },
+  "activatedevice_signin_prompt": {
+    "other": "Cihazınızı etkinleştirmeden önce lütfen giriş yapın."
+  },
+  "activatedevice_page_activated": {
+    "other": "Etkinleştirdiğiniz için teşekkür ederiz{{.DeviceName}}. Artık kütüphanenize televizyonunuzda veya cihazınıza gözden geçirmeniz gerekir."
+  },
+  "userdevices_page_header": {
+    "other": "Cihazlar"
+  },
+  "userdevices_page_content": {
+    "one": "Kullandığınızda cihazlar otomatik olarak buraya eklenecektir. Tek bir cihaz kullanabilirsiniz.",
+    "other": "Cihazları kullandığınızda otomatik olarak buraya eklenecektir. {{.Count}} cihazla sınırlısınız."
+  },
+  "userdevices_empty_content": {
+    "other": "Şu an 0 kayıtlı cihazınız var."
+  },
+  "userdevices_header_type": {
+    "other": "Cihaz Türü"
+  },
+  "userdevices_header_description": {
+    "other": "Tanım"
+  },
+  "userdevices_device_added": {
+    "other": "Eklendi {{.Date}}."
+  },
+  "userdevices_device_actions_delete": {
+    "other": "Çıkar"
+  },
+  "userdevices_device_actions_cancel": {
+    "other": "İptal Et"
+  },
+  "userdevices_device_actions_confirm": {
+    "other": "Evet, cihazı çıkar"
+  },
+  "userdevices_device_deleted": {
+    "other": "(Çıkarıldı)"
+  },
+  "playlist_page_header": {
+    "other": "Çalma listesi"
+  },
+  "playlist_sign_in_warning": {
+    "other": "Canlı TV izlemek için lütfen oturum açın."
+  },
+  "playlist_share_title": {
+    "other": "Çalma listesi"
+  },
+  "playlist_up_next_title": {
+    "other": "Bir sonraki"
+  },
+  "pricing_ownership_buy": {
+    "other": "Satın Al"
+  },
+  "pricing_ownership_rent": {
+    "other": "Kirala"
+  },
+  "classification_intro": {
+    "other": "Sınıflandırma: "
+  },
+  "classification_divider": {
+    "other": " - "
+  },
+  "classification_outro": {
+    "other": ""
+  },
+  "cookie_banner_message": {
+    "other": "Bu site kullanıcı deneyimini artırmak için çerezler kullanmaktadır. Bu siteyi kullanırken, < çerez ve gizlilik ayarlarını kabul edin <a href=\"{{.CookiePolicyURL}}\">cookie usage</a>."
+  },
+  "cookie_banner_accept": {
+    "other": "Kabul"
+  },
+  "all_rights_reserved": {
+    "other": "Her hakkı saklıdır. Bu sitenin hiçbir bölümü yazılı iznimiz olmadan çoğaltılamaz."
+  },
+  "users_gender_none": {
+    "other": "Belirtilmemiş"
+  },
+  "users_gender_female": {
+    "other": "Kadın"
+  },
+  "users_gender_male": {
+    "other": "Erkek"
+  },
+  "users_gender_diverse": {
+    "other": "Farklı"
+  },
+  "users_gender_other": {
+    "other": "Diğer"
+  },
+  "pricing_quality_hd": {
+    "other": "HD"
+  },
+  "pricing_quality_sd": {
+    "other": "SD"
+  },
+  "pricing_quality_hd_only": {
+    "other": "HD Sadece"
+  },
+  "pricing_quality_sd_only": {
+    "other": "SD Sadece"
+  },
+  "shopping_card_save_card": {
+    "other": "Gelecekteki kullanım için bu kartı kaydet "
+  },
+  "shopping_card_button_change": {
+    "other": "Tüm kayıtlı kartları göster"
+  },
+  "shopping_card_existing_description": {
+    "other": "{{.Card.Brand}} bitirmek {{.Card.Number}}"
+  },
+  "shopping_card_existing_expiry": {
+    "other": "(sona ermek {{.Card.Expiry}})"
+  },
+  "shopping_card_existing_expired": {
+    "other": "(günü geçmiş)"
+  },
+  "shopping_card_use_other": {
+    "other": "Yeni bir kart kullanın"
+  },
+  "shopping_card_use_new_card": {
+    "other": "Kartı değiştir "
+  },
+  "shopping_info_ownership_plan": {
+    "other": "Abonelik"
+  },
+  "shopping_action_credit": {
+    "other": "Doldurmak"
+  },
+  "shopping_info_rental_period_coming_soon": {
+    "other": "...şu tarih ve yayınlanma vaktinden başlayarak."
+  },
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Kredi kartını değiştir"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Kredi kartı bilgilerini güncelle"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Güncelleme"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Sona ermek {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Deneme süresi"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Aboneliğimi iptal et"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "İptal"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Evet, aboneliğimi iptal et "
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Aboneliği iptal et?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Bu, aboneliği iptal edecektir.{{.Name}} plan.Yine de plandaki içeriği sona erene kadar izleyebileceksiniz. {{.Expiry}}."
+  },
+  "shopping_card_update_reason_none": {
+    "other": "Kredi kartınızı güncelleyin.Desteklenen kartlar Visa, MasterCard ve American Express'dir."
+  },
+  "availability_coming_soon": {
+    "other": "Yakında"
+  },
+  "availability_renting": {
+    "other": "Kiralama"
+  },
+  "availability_not_available": {
+    "other": "Mevcut Değil"
+  },
+  "availability_in_watch_window": {
+    "other": "Mevcut"
+  },
+  "availability_sold_out": {
+    "other": "Tükendi"
+  },
+  "availability_available_till": {
+    "other": "(bitiş tarihi)'ne dek erişilebilir."
+  },
+  "availability_not_available_in_country": {
+    "other": "Mevcut Değil"
+  },
+  "availability_available": {
+    "other": "(yayın tarihi)'nde erişilebilir."
+  },
+  "modal_cancel": {
+    "other": "İptal"
+  },
+  "play": {
+    "other": "Oynat"
+  },
+  "availability_expires": {
+    "other": "Son gösterim: {{.Expiry}}"
+  },
+  "availability_expired": {
+    "other": "Süresi doldu"
+  },
+  "combined_auth_signin_prompt": {
+    "other": "Oturum Aç"
+  },
+  "combined_auth_signup_prompt": {
+    "other": "Kaydol"
+  },
+  "combined_auth_terms": {
+    "other": "Tüm <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terimler &amp; koşullar</a> kabul ediyorum."
+  },
+  "signup_terms": {
+    "other": "Tüm <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">terimler &amp; koşullar</a> kabul ediyorum."
+  },
+  "validation_terms_required": {
+    "other": "Hüküm ve şartları kabul etmelisiniz."
+  },
+  "shopping_error_item_limit_exceeded": {
+    "other": " Ne yazık ki{{.Title}} tükendi. ."
+  },
+  "shopping_card_change": {
+    "other": "Kredi kartı doğru değil? <a href=\"{{.SubscriptionsURL}}\">Kartınızı güncellemek için buraya tıklayın.</a>"
+  },
+  "user_error_too_many_pin_errors": {
+    "other": "<p>Sorun yaşıyor gibi görünüyor.</p><p>PIN'inizi sıfırlayın veya bizimle iletişime geçin. <a href=\"{{.HelpURL}}\" target=\"_blank\">Yardım Edin</a>"
+  },
+  "app_badge_title": {
+    "other": "Satın alınan içeriğinizi görüntülemek için uygulamayı indirin!"
+  },
+  "app_badge_ios": {
+    "other": "App Store'da indirin"
+  },
+  "app_badge_android": {
+    "other": "Google Play'den indirin"
+  },
+  "shopping_price_title_plan": {
+    "other": "Fiyat"
+  },
+  "shopping_price_plan_note": {
+    "zero": "Her {{ .Interval }} .",
+    "one": "24 saatlik ücretsiz deneme süreniz sona erdikten sonra her {{ .Interval }}",
+    "other": "Her Ücretli {{ .Interval }} sizin sonra {{ .Count }} günlük ücretsiz deneme sürümü bitmeden."
+  },
+  "shopping_price_plan_note_interval": {
+    "one": "{{ .Interval }}",
+    "other": "{{ .Count }} {{ .Interval }}"
+  },
+  "shopping_enter_card_prompt_plan": {
+    "other": "Aboneliğinizi başlatmak için aşağıya kredi kartı bilgilerinizi girin."
+  },
+  "shopping_action_plan": {
+    "other": "Tamamlayınız"
+  },
+  "shopping_complete_subscription": {
+    "other": "Abonelik satın alma işleminiz başarılı oldu. Artık {{ .Title }} ."
+  },
+  "shopping_complete_subscription_browse": {
+    "other": "Sitede <a href=\"/\">gezinmekten</a> veya belirli bir şey <a href=\"/search.html\">aramaktan</a> çekinmeyin."
+  },
+  "shopping_info_plan_offer": {
+    "one": "{{ .Interval }} otomatik olarak yeniler",
+    "other": "Otomatik olarak her yeniler {{ .Count }} {{ .Interval }}"
+  },
+  "shopping_info_trial_period_offer": {
+    "one": "24 saatlik ücretsiz denemenizi şimdi deneyin!",
+    "other": "Ücretsiz {{ .Count }} günlük denemenizi deneyin!"
+  },
+  "plans_page_header": {
+    "other": "Mevcut Planlar"
+  },
+  "plan_label_owned": {
+    "other": "Bu plana sahipsin"
+  },
+  "plan_expiry_date": {
+    "other": "Satış kapanışı:"
+  },
+  "plan_read_more": {
+    "other": "Daha fazlasını bul"
+  },
+  "plan_page_read_more": {
+    "other": "Devamını oku"
+  },
+  "plan_page_header_text": {
+    "other": "Keyfini çıkarın {{ .Name }}"
+  },
+  "page_plan_explore_intro": {
+    "other": "VEYA"
+  },
+  "page_plan_explore_link": {
+    "other": "Diğer geçişleri keşfedin"
+  },
+  "plan_showcase_page_ownership_button_buy": {
+    "other": "Şimdi al"
+  },
+  "plan_free_link_text": {
+    "other": "Ücretsiz kaydol"
+  },
+  "awards_in_competition": {
+    "other": "Rekabette"
+  },
+  "awards_winner": {
+    "other": "kazanan"
+  },
+  "donate_button_text": {
+    "other": "Bağış yapmak"
+  },
+  "wcag_skip_links_header": {
+    "other": "Erişilebilirlik Bağlantıları "
+  },
+  "wcag_skip_links_content": {
+    "other": "İçeriğe atla"
+  },
+  "wcag_homepage_h1": {
+    "other": "Ana sayfa"
+  },
+  "wcag_carousel_h2": {
+    "other": "Atlıkarınca"
+  },
+  "wcag_collections_h2": {
+    "other": "Koleksiyonlar"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Altbilgi"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Ana"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Alt"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Gezinme geçişi"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Paket eşyaları"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Atlıkarınca"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Sayfa Koleksiyonu"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Koleksiyon Listesi"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Toplama kaydırıcısı"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "İstek listesi"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Facebook'ta Paylaş"
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Twitter'da paylaş"
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "LinkedIn'de Paylaş"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "MektupBoxd'da Görüntüle"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Zaten bu planın var."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Bu plan artık mevcut değil."
+  },
+  "shopping_payment_method_header": {
+    "other": "Ödeme metodları"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Kredi kartı"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "GIROPAY"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Bu ödeme ile bir şeyler ters gitti.Lütfen daha sonra tekrar deneyiniz."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Ödeme reddedildi.Bu pencereyi kapatın ve tekrar deneyin."
+  },
+  "header_banner": {
+    "other": "Başlık afişi"
+  },
+  "account_form_pin_code": {
+    "other": "TOPLU İĞNE"
+  },
+  "account_form_pin_code_not_set": {
+    "other": "Bazı başlıkları satın almak, kiralamak ve izlemek için gerekli olan bir PIN setiniz yoktur."
+  },
+  "account_form_set_pin": {
+    "other": "Pim koymak"
+  },
+  "account_form_pin_changed": {
+    "other": "Güncellenmiş"
+  },
+  "account_form_change_pin": {
+    "other": "Pin'i değiştir"
+  },
+  "user_set_pin_header": {
+    "other": "PIN'inizi ayarlayın"
+  },
+  "user_set_pin_button": {
+    "other": "Pim koymak"
+  },
+  "user_submit_pin_heading": {
+    "other": "Bu sınırlı içerik için PIN'inizi {{.Action}} öğesine girin."
+  },
+  "user_error_wrong_pin_retry": {
+    "other": "Hata, yanlış bir pim girdiniz"
+  },
+  "user_submit_pin_button": {
+    "other": "Giriş"
+  },
+  "user_reset_pin_button": {
+    "other": "Sıfırlama pimi"
+  },
+  "validation_pincode1_required": {
+    "other": "Lütfen geçerli bir PIN kodu girin."
+  },
+  "validation_pincode2_required": {
+    "other": "Lütfen geçerli bir PIN kodu girin."
+  },
+  "validation_pincode1_pattern": {
+    "other": "Lütfen geçerli bir PIN kodu girin."
+  },
+  "validation_pincode2_pattern": {
+    "other": "Lütfen geçerli bir PIN kodu girin."
+  },
+  "validation_pincode2_match": {
+    "other": "PIN kodu eşleşmiyor."
+  },
+  "userdevices_delete_limits": {
+    "other": "Kaldırabilirsin {{.Limit}} Bu listeden cihaz (lar) her {{.Period}} gün (ler)."
+  },
+  "userdevices_delete_limit_reached": {
+    "other": "Bu sınıra ulaştınız ve şu anda cihazları kaldıramazsınız.Bir cihazı silinebilirsiniz {{.Days}} gün (ler)."
+  },
+  "shopping_card_new_subscription": {
+    "other": "Bu kart düzenli olarak kaydedilir ve tahsil edilecektir."
+  },
+  "changepincode_modal_header": {
+    "other": "PIN'inizi değiştirin"
+  },
+  "changepincode_modal_currentpassword": {
+    "other": "mevcut şifreniz"
+  },
+  "changepincode_modal_pincode1": {
+    "other": "Yeni 4 basamaklı piminiz"
+  },
+  "changepincode_modal_pincode2": {
+    "other": "Yeni 4 basamaklı piminizi onaylayın "
+  },
+  "changepincode_modal_submit": {
+    "other": "Pim koymak"
+  },
+  "changepincode_modal_error_wrong_password": {
+    "other": "Bu şifre yanlış."
+  },
+  "user_set_pin_intro": {
+    "other": "Bir pim gerekir {{.Action}} Sınırlı içerik"
+  },
+  "user_error_wrong_pin_reset": {
+    "other": "PIN'inizi sıfırlamak için buraya tıklayın"
+  },
+  "user_error_too_many_pin_errors_help_page_link": {
+    "other": ""
+  },
+  "shopping_error_age_restricted": {
+    "other": "Bu içerik yaşı sınırlıdır."
+  },
+  "shopping_error_close_button": {
+    "other": "Tamam"
   }
-  
+}

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1,743 +1,775 @@
 {
   "site_owner": {
-   "other": "ABC Cinemas"
+    "other": "ABC Cinemas"
   },
   "settings_title": {
-   "other": "Settings"
+    "other": "Settings"
   },
-  "powered_by": { "other": "Powered by" },
-  "powered_by_name": { "other": "Shift72" },
-  "powered_by_url": { "other": "https://www.screenplus.com" },
-  "in_partnership_with": { "other": "у партнерстві з" },
-  "festival_scope": { "other": "Festival Scope" },
-  "festival_scope_url": { "other": "https://www.festivalscope.com/page/create-your-online-film-festival/" },
+  "powered_by": {
+    "other": "Powered by"
+  },
+  "powered_by_name": {
+    "other": "Shift72"
+  },
+  "powered_by_url": {
+    "other": "https://www.screenplus.com"
+  },
+  "in_partnership_with": {
+    "other": "у партнерстві з"
+  },
+  "festival_scope": {
+    "other": "Festival Scope"
+  },
+  "festival_scope_url": {
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+  },
   "en": {
-   "other": "Англійська мова"
+    "other": "Англійська мова"
   },
   "fr": {
-   "other": "Французький"
+    "other": "Французький"
   },
   "episode_name": {
-   "other": "Епізод"
+    "other": "Епізод"
   },
   "season_name": {
-   "other": "Сезон"
+    "other": "Сезон"
   },
   "seasons": {
-   "one": "один сезон",
-   "few": "{{.Count}} сезони",
-   "many": "{{.Count}} сезони"
+    "one": "один сезон",
+    "few": "{{.Count}} сезони",
+    "many": "{{.Count}} сезони"
   },
   "tvseason": {
     "other": "{{.ShowInfo.Title}} Серія {{.Season.SeasonNumber}}"
   },
-   "tvseason_html": {
+  "tvseason_html": {
     "other": "{{.ShowInfo.Title}} <span>Серія {{.Season.SeasonNumber}}</span>"
   },
   "tvepisode": {
-   "other": "{{.Episode.Title}}"
+    "other": "{{.Episode.Title}}"
   },
   "tvseason_number": {
-   "other": "{{.Season.SeasonNumber}}"
+    "other": "{{.Season.SeasonNumber}}"
   },
   "episode_count": {
-   "one": "1 Серій",
-   "few": "{{.Count}} Серій",
-   "many": "{{.Count}} Серій"
+    "one": "1 Серій",
+    "few": "{{.Count}} Серій",
+    "many": "{{.Count}} Серій"
   },
   "date_day": {
-   "other": "День"
+    "other": "День"
   },
   "date_month": {
-   "other": "Місяць"
+    "other": "Місяць"
   },
   "date_year": {
-   "other": "Рік"
+    "other": "Рік"
   },
   "404_page_header": {
-   "other": "Ця сторінка не існує..."
+    "other": "Ця сторінка не існує..."
   },
   "404_page_content": {
-   "other": "<p>На жаль, сторінка, яку ви шукаєте, не існує.</p><p>Вона могла бути переміщена або видалена, чи, можливо, ви щось неправильно написали.</p><p>Спробуйте повернутися на головну сторінку, щоб знайти те, що ви шукаєте.</p><p><a href=\"/\">Назад на головну сторінку</a></p>"
+    "other": "<p>На жаль, сторінка, яку ви шукаєте, не існує.</p><p>Вона могла бути переміщена або видалена, чи, можливо, ви щось неправильно написали.</p><p>Спробуйте повернутися на головну сторінку, щоб знайти те, що ви шукаєте.</p><p><a href=\"/\">Назад на головну сторінку</a></p>"
   },
   "nav_homepage": {
-   "other": "ABC Cinemas"
+    "other": "ABC Cinemas"
   },
   "nav_signin": {
-   "other": "Увійти"
+    "other": "Увійти"
   },
   "nav_signup": {
-   "other": "Створити обліковий запис"
+    "other": "Створити обліковий запис"
   },
   "nav_signed_in_as": {
-   "other": "Увійти через"
+    "other": "Увійти через"
   },
   "nav_library": {
-   "other": "Моя бібліотека"
+    "other": "Моя бібліотека"
   },
   "nav_devices": {
-   "other": "Мої пристрої"
+    "other": "Мої пристрої"
   },
   "nav_wishlist": {
-   "other": "Мій список"
+    "other": "Мій список"
   },
   "nav_account": {
-   "other": "Мій обліковий запис"
+    "other": "Мій обліковий запис"
   },
   "nav_signout": {
-   "other": "Вийти"
+    "other": "Вийти"
   },
   "play_trailer": {
-   "other": "Трейлер"
+    "other": "Трейлер"
   },
   "runtime_hours": {
-   "other": "г"
+    "other": "г"
   },
   "runtime_minutes": {
-   "other": "хв"
+    "other": "хв"
   },
   "datetime_today": {
-   "other": "сьогодні {{.Date}}"
+    "other": "сьогодні {{.Date}}"
   },
   "datetime_tomorrow": {
-   "other": "завтра {{.Date}}"
+    "other": "завтра {{.Date}}"
   },
   "datetime_yesterday": {
-   "other": "вчора {{.Date}}"
+    "other": "вчора {{.Date}}"
   },
   "datetime_next": {
-   "other": "наступна {{.Date}}"
+    "other": "наступна {{.Date}}"
   },
   "datetime_last": {
-   "other": "остання {{.Date}}"
+    "other": "остання {{.Date}}"
   },
   "search_control_placeholder": {
-   "other": "Пошук"
+    "other": "Пошук"
   },
   "search_control_submit": {
-   "other": "Шукати"
+    "other": "Шукати"
   },
   "play_button_watch": {
-   "other": "Дивитися"
+    "other": "Дивитися"
   },
   "play_button_resume": {
-   "other": "Продовжити"
+    "other": "Продовжити"
   },
   "social_media_buttons_title": {
-   "other": "Поділитися"
+    "other": "Поділитися"
   },
-  "social_media_buttons_facebook": { "other": "Поділіться на Facebook" },
-  "social_media_buttons_twitter": { "other": "Поділіться у Twitter" },
-  "social_media_buttons_linkedin": { "other": "Поділіться на Linkedin" },
-  "social_media_buttons_email": { "other": "Поділіться електронною поштою" },
-  "social_media_buttons_email_subject": { "other": "Поділитися посиланням" },
-  "social_media_buttons_copied_link": { "other": "Посилання скопійовано в буфер обміну!" },
-  "social_media_buttons_copy_link": { "other": "Копіювати в буфер обміну" },
+  "social_media_buttons_facebook": {
+    "other": "Поділіться на Facebook"
+  },
+  "social_media_buttons_twitter": {
+    "other": "Поділіться у Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "Поділіться на Linkedin"
+  },
+  "social_media_buttons_email": {
+    "other": "Поділіться електронною поштою"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "Поділитися посиланням"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "Посилання скопійовано в буфер обміну!"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "Копіювати в буфер обміну"
+  },
   "accept_invite_page_header": {
-   "other": "Ласкаво просимо "
+    "other": "Ласкаво просимо "
   },
   "acceptinvite_form_invalid_reset_password_token": {
-   "other": "Здається, ви вже використали це запрошення. Спробуйте <a href=\"signin.html\">увійти</a>. Якщо ви забули свій пароль, ви можете <a href=\"forgotpassword.html\">скинути свій пароль</a>."
+    "other": "Здається, ви вже використали це запрошення. Спробуйте <a href=\"signin.html\">увійти</a>. Якщо ви забули свій пароль, ви можете <a href=\"forgotpassword.html\">скинути свій пароль</a>."
   },
   "acceptinvite_complete": {
-   "other": "Дякуємо. Ваш обліковий запис створено."
+    "other": "Дякуємо. Ваш обліковий запис створено."
   },
   "acceptinvite_form_submit": {
-   "other": "Прийняти запрошення"
+    "other": "Прийняти запрошення"
   },
   "acceptinvite_agreement": {
-   "other": "Натискаючи кнопку \"Прийняти запрошення\", ви погоджуєтесь, що прочитали та зрозуміли наші <a href=\"/page/terms-and-conditions/\" target=\"_blank\">правила &amp; умови</a> та <a href=\"/page/privacy/\" target=\"_blank\">правила захисту персональних даних</a>."
+    "other": "Натискаючи кнопку \"Прийняти запрошення\", ви погоджуєтесь, що прочитали та зрозуміли наші <a href=\"/page/terms-and-conditions/\" target=\"_blank\">правила &amp; умови</a> та <a href=\"/page/privacy/\" target=\"_blank\">правила захисту персональних даних</a>."
   },
   "signup_page_header": {
-   "other": "Створити новий обліковий запис"
+    "other": "Створити новий обліковий запис"
   },
   "signup_form_name": {
-   "other": "Ім'я"
+    "other": "Ім'я"
   },
   "signup_form_email": {
-   "other": "Електронна адреса"
+    "other": "Електронна адреса"
   },
   "signup_form_password": {
-   "other": "Пароль"
+    "other": "Пароль"
   },
   "signup_form_password_confirmation": {
-   "other": "Підтвердити пароль"
+    "other": "Підтвердити пароль"
   },
   "signup_form_gender": {
-   "other": "Стать"
+    "other": "Стать"
   },
   "signup_form_dob": {
-   "other": "Дата народження"
+    "other": "Дата народження"
   },
   "signup_form_submit": {
-   "other": "Зберегти"
+    "other": "Зберегти"
   },
   "signin_page_header": {
-   "other": "Увійти"
+    "other": "Увійти"
   },
   "signin_form_email": {
-   "other": "Електронна адреса"
+    "other": "Електронна адреса"
   },
   "signin_form_password": {
-   "other": "Пароль"
+    "other": "Пароль"
   },
   "signin_form_remember": {
-   "other": "Запам'ятати мене"
+    "other": "Запам'ятати мене"
   },
   "signin_form_submit": {
-   "other": "Зберегти"
+    "other": "Зберегти"
   },
   "signin_page_forgotpassword": {
-   "other": "Забули пароль?"
+    "other": "Забули пароль?"
   },
   "signin_page_createnewaccount": {
-   "other": "Немає облікового запису? Створити новий обліковий запис"
+    "other": "Немає облікового запису? Створити новий обліковий запис"
   },
   "signup_page_alreadyhaveanaccount": {
-   "other": "Уже маєте обліковий запис? Увійти"
+    "other": "Уже маєте обліковий запис? Увійти"
   },
   "signup_form_error_email_already_in_use": {
-   "other": "Ця електронна адреса вже використовується."
+    "other": "Ця електронна адреса вже використовується."
   },
   "signin_form_error_incorrect_credentials": {
-   "other": "Неправильне ім'я користувача або пароль."
+    "other": "Неправильне ім'я користувача або пароль."
   },
   "signin_form_error_ip_throttled": {
-   "other": "Ви не змогли підписати занадто багато разів.Будь-ласка спробуйте пізніше."
+    "other": "Ви не змогли підписати занадто багато разів.Будь-ласка спробуйте пізніше."
   },
   "signin_form_error_account_suspended": {
-   "other": "Ваш обліковий запис тимчасово призупинено.Будь ласка, зв'яжіться з адміністратором, якщо ви вважаєте, що це помилка."
+    "other": "Ваш обліковий запис тимчасово призупинено.Будь ласка, зв'яжіться з адміністратором, якщо ви вважаєте, що це помилка."
   },
   "signup_form_error_forbidden": {
-   "other": "Сталася помилка."
+    "other": "Сталася помилка."
   },
   "combined_auth_continue": {
-   "other": "Продовжити"
+    "other": "Продовжити"
   },
   "combined_auth_change": {
-   "other": "змінити"
+    "other": "змінити"
   },
   "combined_auth_signin": {
-   "other": "Увійти"
+    "other": "Увійти"
   },
   "combined_auth_signup": {
-   "other": "Створити обліковий запис"
+    "other": "Створити обліковий запис"
   },
   "combined_auth_signin_password": {
-   "other": "Будь ласка, введіть свій пароль, щоб увійти у свій обліковий запис."
+    "other": "Будь ласка, введіть свій пароль, щоб увійти у свій обліковий запис."
   },
   "combined_auth_signin_error_incorrect_credentials": {
-   "other": "Неправильний пароль."
+    "other": "Неправильний пароль."
   },
   "combined_auth_error_forbidden": {
-   "other": "Сталася помилка."
+    "other": "Сталася помилка."
   },
   "combined_auth_error_too_many_requests": {
     "other": "Забагато запитів, спробуйте пізніше."
   },
   "forgotpassword_page_header": {
-   "other": "Скинути пароль"
+    "other": "Скинути пароль"
   },
   "forgotpassword_form_email": {
-   "other": "Електронна адреса"
+    "other": "Електронна адреса"
   },
   "forgotpassword_form_submit": {
-   "other": "Скинути"
+    "other": "Скинути"
   },
   "forgotpassword_form_error_email_doesnt_exist": {
-   "other": "За цією електронною адресою не здайдено жодного облікового запису."
+    "other": "За цією електронною адресою не здайдено жодного облікового запису."
   },
   "forgotpassword_form_error_account_suspended": {
-   "other": "Роботу облікового запису призупинено."
+    "other": "Роботу облікового запису призупинено."
   },
   "forgotpassword_complete": {
-   "other": "Дякуємо. Електронний лист про скидання пароля незабаром прийде на вашу електронну адресу."
+    "other": "Дякуємо. Електронний лист про скидання пароля незабаром прийде на вашу електронну адресу."
   },
   "forgotpassword_form_error_forbidden": {
-   "other": "Сталася помилка."
+    "other": "Сталася помилка."
   },
   "forgotpassword_form_error_too_many_requests": {
     "other": "Забагато запитів, спробуйте пізніше."
   },
   "resetpassword_page_header": {
-   "other": "Змінити пароль"
+    "other": "Змінити пароль"
   },
   "resetpassword_form_invalid_reset_password_token": {
-   "other": "Схоже, цей запит на скидання пароля недійсний, заповніть форму <a href=\"{{.URL}}\">Змінити пароль</a> ще раз."
+    "other": "Схоже, цей запит на скидання пароля недійсний, заповніть форму <a href=\"{{.URL}}\">Змінити пароль</a> ще раз."
   },
   "resetpassword_form_password": {
-   "other": "Новий пароль"
+    "other": "Новий пароль"
   },
   "resetpassword_form_password2": {
-   "other": "Підтвердити новий пароль"
+    "other": "Підтвердити новий пароль"
   },
   "resetpassword_form_submit": {
-   "other": "Змінити"
+    "other": "Змінити"
   },
   "resetpassword_complete": {
-   "other": "Дякуємо. Ваш пароль було змінено, і ви увійшли до свого облікового запису."
+    "other": "Дякуємо. Ваш пароль було змінено, і ви увійшли до свого облікового запису."
   },
   "resetpassword_form_error_invalid_reset_password_token": {
-   "other": "Запит на скидання пароля недійсний. Будь ласка, спробуйте пізніше."
+    "other": "Запит на скидання пароля недійсний. Будь ласка, спробуйте пізніше."
   },
   "resetpassword_form_error_reset_password_token_expired": {
-   "other": "Термін дії маркера скидання пароля закінчився. Будь ласка, запитайте новий."
+    "other": "Термін дії маркера скидання пароля закінчився. Будь ласка, запитайте новий."
   },
   "resetpassword_form_error_too_many_requests": {
     "other": "Забагато запитів, спробуйте пізніше."
   },
   "account_page_header": {
-   "other": "Мій обліковий запис"
+    "other": "Мій обліковий запис"
   },
   "account_form_name": {
-   "other": "Ім'я"
+    "other": "Ім'я"
   },
   "account_form_email": {
-   "other": "Електронна адреса"
+    "other": "Електронна адреса"
   },
   "account_form_password": {
-   "other": "Пароль"
+    "other": "Пароль"
   },
   "account_form_change_password": {
-   "other": "Змінити"
+    "other": "Змінити"
   },
   "account_form_gender": {
-   "other": "Стать"
+    "other": "Стать"
   },
   "account_form_dob": {
-   "other": "Дата народження"
+    "other": "Дата народження"
   },
   "account_form_submit": {
-   "other": "Оновити"
+    "other": "Оновити"
   },
   "account_form_submitted": {
-   "other": "Оновлено"
+    "other": "Оновлено"
   },
   "account_form_password_changed": {
-   "other": "Оновлено"
+    "other": "Оновлено"
   },
   "account_form_error_incorrect_password": {
-   "other": "Неправильний пароль"
+    "other": "Неправильний пароль"
   },
   "account_form_pin_code": {
-   "other": "PIN"
+    "other": "PIN"
   },
   "account_form_pin_code_not_set": {
-   "other": "У вас немає PIN-коду, який необхідний для придбання, оренду та перегляду деяких назв."
+    "other": "У вас немає PIN-коду, який необхідний для придбання, оренду та перегляду деяких назв."
   },
   "account_form_set_pin": {
-   "other": "Затемнювати"
+    "other": "Затемнювати"
   },
   "account_form_pin_changed": {
-   "other": "Оновлений"
+    "other": "Оновлений"
   },
   "account_form_change_pin": {
-   "other": "Змінити pin"
+    "other": "Змінити pin"
   },
   "user_set_pin_header": {
-   "other": "Встановіть свій PIN-код"
+    "other": "Встановіть свій PIN-код"
   },
   "user_set_pin_button": {
-   "other": "Затемнювати"
+    "other": "Затемнювати"
   },
   "user_submit_pin_heading": {
-   "other": "Введіть свій PIN-код {{.Action}} Цей обмежений вміст"
+    "other": "Введіть свій PIN-код {{.Action}} Цей обмежений вміст"
   },
   "user_error_wrong_pin_retry": {
-   "other": "На жаль, ви ввели неправильний PIN-код"
+    "other": "На жаль, ви ввели неправильний PIN-код"
   },
   "user_error_too_many_pin_errors": {
-   "other": "<p>Схоже, у вас є проблеми.</p><p>Скинути PIN-код або зв'яжіться з нами <a href=\"{{.HelpURL}}\" target=\"_blank\">довідка</a>"
+    "other": "<p>Схоже, у вас є проблеми.</p><p>Скинути PIN-код або зв'яжіться з нами <a href=\"{{.HelpURL}}\" target=\"_blank\">довідка</a>"
   },
   "user_submit_pin_button": {
-   "other": "Вводити"
+    "other": "Вводити"
   },
   "user_reset_pin_button": {
-   "other": "Скинути штифт "
+    "other": "Скинути штифт "
   },
   "signup_form_optin": {
-   "other": "Підписатися на нашу безкоштовну розсилку"
+    "other": "Підписатися на нашу безкоштовну розсилку"
   },
   "passwordconfirmation_modal_header": {
-   "other": "Підтвердити пароль"
+    "other": "Підтвердити пароль"
   },
   "passwordconfirmation_modal_label": {
-   "other": "Будь ласка, введіть свій пароль, щоб оновити зміни"
+    "other": "Будь ласка, введіть свій пароль, щоб оновити зміни"
   },
   "passwordconfirmation_modal_confirm": {
-   "other": "Підтвердити"
+    "other": "Підтвердити"
   },
   "changepassword_modal_header": {
-   "other": "Змінити пароль"
+    "other": "Змінити пароль"
   },
   "changepassword_modal_currentpassword": {
-   "other": "Поточний пароль"
+    "other": "Поточний пароль"
   },
   "changepassword_modal_password": {
-   "other": "Новий пароль"
+    "other": "Новий пароль"
   },
   "changepassword_modal_password2": {
-   "other": "Підтвердити новий пароль"
+    "other": "Підтвердити новий пароль"
   },
   "changepassword_modal_submit": {
-   "other": "Оновити"
+    "other": "Оновити"
   },
   "changepassword_modal_error_incorrect_password": {
-   "other": "Невірний пароль"
+    "other": "Невірний пароль"
   },
   "userlibrary_page_header": {
-   "other": "Моя бібліотека"
+    "other": "Моя бібліотека"
   },
   "userlibrary_empty_header": {
-   "other": "Ваша бібліотека порожня."
+    "other": "Ваша бібліотека порожня."
   },
   "userlibrary_empty_content": {
-   "other": "Заповніть її, <a href=\"/\">переглянувши</a> нашу колекцію."
+    "other": "Заповніть її, <a href=\"/\">переглянувши</a> нашу колекцію."
   },
   "searchresults_page_header": {
-   "other": "Результати пошуку"
+    "other": "Результати пошуку"
   },
   "searchresults_load_more": {
-   "few": "Завантажити ще {{.Count}}",
-   "many": "Завантажити ще {{.Count}}"
+    "few": "Завантажити ще {{.Count}}",
+    "many": "Завантажити ще {{.Count}}"
   },
   "searchresults_total": {
-   "one": "Знайдено 1 результат за запитом \"{{.Query}}\".",
+    "one": "Знайдено 1 результат за запитом \"{{.Query}}\".",
     "few": "Знайдено {{.Count}} результатів за запитом \"{{.Query}}\".",
     "many": "Знайдено {{.Count}} результатів за запитом \"{{.Query}}\"."
   },
   "searchresults_empty_header": {
-   "other": "Результати пошуку за запитом \"{{.Query}}\" відсутні"
+    "other": "Результати пошуку за запитом \"{{.Query}}\" відсутні"
   },
   "searchresults_empty_content": {
-   "other": "Спробуйте інший запит пошуку або <a href=\"/\">перегляньте наш контент</a>, щоб знайти те, що ви шукаєте."
+    "other": "Спробуйте інший запит пошуку або <a href=\"/\">перегляньте наш контент</a>, щоб знайти те, що ви шукаєте."
   },
   "validation_name_required": {
-   "other": "Будь ласка, введіть своє ім'я."
+    "other": "Будь ласка, введіть своє ім'я."
   },
   "validation_email_required": {
-   "other": "Будь ласка, введіть свою електронну адресу."
+    "other": "Будь ласка, введіть свою електронну адресу."
   },
   "validation_email_email": {
-   "other": "Будь ласка, введіть дійсну електронну адресу."
+    "other": "Будь ласка, введіть дійсну електронну адресу."
   },
   "validation_currentpassword_required": {
-   "other": "Будь ласка, введіть ваш дійсний пароль."
+    "other": "Будь ласка, введіть ваш дійсний пароль."
   },
   "validation_password_required": {
-   "other": "Будь ласка, введіть пароль."
+    "other": "Будь ласка, введіть пароль."
   },
   "validation_password2_required": {
-   "other": "Будь ласка, продублюйте свій пароль."
+    "other": "Будь ласка, продублюйте свій пароль."
   },
   "validation_password2_match": {
-   "other": "Паролі не співпадають."
+    "other": "Паролі не співпадають."
   },
   "validation_password_minlength": {
-   "few": "Будь ласка, введіть щонайменше {{.Count}} символів.",
-   "many": "Будь ласка, введіть щонайменше {{.Count}} символів."
+    "few": "Будь ласка, введіть щонайменше {{.Count}} символів.",
+    "many": "Будь ласка, введіть щонайменше {{.Count}} символів."
   },
   "validation_promocode_required": {
-   "other": "Будь ласка, введіть промокод."
+    "other": "Будь ласка, введіть промокод."
   },
   "validation_pincode_required": {
-   "other": "Введіть PIN-код."
+    "other": "Введіть PIN-код."
   },
   "validation_pincode1_required": {
-   "other": "Введіть дійсний PIN-код."
+    "other": "Введіть дійсний PIN-код."
   },
   "validation_pincode2_required": {
-   "other": "Введіть дійсний PIN-код."
+    "other": "Введіть дійсний PIN-код."
   },
   "validation_pincode1_pattern": {
-   "other": "Введіть дійсний PIN-код."
+    "other": "Введіть дійсний PIN-код."
   },
   "validation_pincode2_pattern": {
-   "other": "Введіть дійсний PIN-код."
+    "other": "Введіть дійсний PIN-код."
   },
   "validation_pincode2_match": {
-   "other": "PIN-код не збігається."
+    "other": "PIN-код не збігається."
   },
   "validation_gender_required": {
-   "other": "Будь ласка, оберіть вашу стать."
+    "other": "Будь ласка, оберіть вашу стать."
   },
   "validation_dob_required": {
-   "other": "Будь ласка, введіть вашу дату народження."
+    "other": "Будь ласка, введіть вашу дату народження."
   },
   "validation_dob_date": {
-   "other": "Будь ласка, введіть дійсну дату народження."
+    "other": "Будь ласка, введіть дійсну дату народження."
   },
   "shopping_info_subtitle_hd": {
-   "other": "HD відео за запитом."
+    "other": "HD відео за запитом."
   },
   "shopping_info_subtitle_sd": {
-   "other": "SD відео за запитом."
+    "other": "SD відео за запитом."
   },
   "shopping_info_subtitle_wallet": {
-   "other": "Кошти у вашому гаманці можуть бути використані для покупки або оренди будь-якого вмісту на ScreenPlus."
+    "other": "Кошти у вашому гаманці можуть бути використані для покупки або оренди будь-якого вмісту на ScreenPlus."
   },
   "shopping_info_subtitle_help": {
-   "other": "Дивитися системні вимоги."
+    "other": "Дивитися системні вимоги."
   },
   "shopping_info_ownership_buy": {
-   "other": "купити"
+    "other": "купити"
   },
   "shopping_info_ownership_rent": {
-   "other": "взяти напрокат"
+    "other": "взяти напрокат"
   },
   "shopping_info_sd_only": {
-   "other": "Обмежена лише відтворення SD."
+    "other": "Обмежена лише відтворення SD."
   },
   "shopping_info_release_date_title": {
-   "other": "Дата релізу {{.Date}}. "
+    "other": "Дата релізу {{.Date}}. "
   },
   "shopping_info_release_date_explanation_rent": {
-   "other": "Ви можете взяти фільм напрокат вже зараз, але ви не зможете переглянути його до дати релізу."
+    "other": "Ви можете взяти фільм напрокат вже зараз, але ви не зможете переглянути його до дати релізу."
   },
   "shopping_info_release_date_explanation_buy": {
-   "other": "Ви можете взяти фільм напрокат вже зараз, але ви не зможете переглянути його до дати релізу."
+    "other": "Ви можете взяти фільм напрокат вже зараз, але ви не зможете переглянути його до дати релізу."
   },
   "shopping_info_available_until_date_title": {
-   "other": "Доступний до {{.Date}}. "
+    "other": "Доступний до {{.Date}}. "
   },
   "shopping_info_available_until_date_explanation_rent": {
-   "other": "Ви не зможете переглянути контент після цього."
+    "other": "Ви не зможете переглянути контент після цього."
   },
   "shopping_info_available_until_date_explanation_buy": {
-   "other": "Ви не зможете переглянути контент після цього."
-  },  
-  "duration_hour": { "one": "1 година", "other": "{{.Count}} години" },
-  "duration_day": { "one": "1 день", "other": "{{.Count}} дні" },
+    "other": "Ви не зможете переглянути контент після цього."
+  },
+  "duration_hour": {
+    "one": "1 година",
+    "other": "{{.Count}} години"
+  },
+  "duration_day": {
+    "one": "1 день",
+    "other": "{{.Count}} дні"
+  },
   "shopping_info_rental_period_duration": {
-   "few": "{{.ValueUnit}} прокату ",
-   "many": "{{.ValueUnit}} прокату "
+    "few": "{{.ValueUnit}} прокату ",
+    "many": "{{.ValueUnit}} прокату "
   },
   "shopping_info_watch_window_duration": {
-   "few": "{{.Count}}-годинне вікно відтворення. ",
-   "many": "{{.Count}}-годинне вікно відтворення. "
+    "few": "{{.Count}}-годинне вікно відтворення. ",
+    "many": "{{.Count}}-годинне вікно відтворення. "
   },
   "shopping_info_watch_window_explanation_film": {
-   "one": "Після оформлення прокату, фільм буде доступний у вашому обліковому записі протягом {{.ValueUnit}}. ",
-   "few": "Після оформлення прокату, фільм буде доступний у вашому обліковому записі протягом {{.ValueUnit}}. ",
-   "many": "Після оформлення прокату, фільм буде доступний у вашому обліковому записі протягом {{.ValueUnit}}. "
+    "one": "Після оформлення прокату, фільм буде доступний у вашому обліковому записі протягом {{.ValueUnit}}. ",
+    "few": "Після оформлення прокату, фільм буде доступний у вашому обліковому записі протягом {{.ValueUnit}}. ",
+    "many": "Після оформлення прокату, фільм буде доступний у вашому обліковому записі протягом {{.ValueUnit}}. "
   },
   "shopping_info_watch_window_explanation2_film": {
-   "one": "Після натискання кнопки \"Дивитися\" відкривається вікно перегляду. У вас є 1 година, щоб переглянути фільм скільки завгодно разів.",
-   "few": "Після натискання кнопки \"Дивитися\" відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути фільм скільки завгодно разів.",
-   "many": "Після натискання кнопки \"Дивитися\" відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути фільм скільки завгодно разів."
+    "one": "Після натискання кнопки \"Дивитися\" відкривається вікно перегляду. У вас є 1 година, щоб переглянути фільм скільки завгодно разів.",
+    "few": "Після натискання кнопки \"Дивитися\" відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути фільм скільки завгодно разів.",
+    "many": "Після натискання кнопки \"Дивитися\" відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути фільм скільки завгодно разів."
   },
   "shopping_info_watch_window_explanation_bundle": {
-   "one": "Після оформлення прокату, об'єкти в вашому комплекті будуть доступні у вашому обліковому записі протягом 1 дня.",
-   "few": "Після оформлення прокату, об'єкти в вашому комплекті будуть доступні у вашому обліковому записі протягом {{.Count}} днів.",
-   "many": "Після оформлення прокату, об'єкти в вашому комплекті будуть доступні у вашому обліковому записі протягом {{.Count}} днів."
+    "one": "Після оформлення прокату, об'єкти в вашому комплекті будуть доступні у вашому обліковому записі протягом 1 дня.",
+    "few": "Після оформлення прокату, об'єкти в вашому комплекті будуть доступні у вашому обліковому записі протягом {{.Count}} днів.",
+    "many": "Після оформлення прокату, об'єкти в вашому комплекті будуть доступні у вашому обліковому записі протягом {{.Count}} днів."
   },
   "shopping_info_watch_window_explanation2_bundle": {
-   "one": "Після натискання кнопки \"Дивитися\" на сторінці фільму відкривається вікно перегляду. У вас є 1 година, щоб переглянути цей фільм скільки завгодно разів.",
-   "few": "Після натискання кнопки \"Дивитися\" на сторінці фільму відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути цей фільм скільки завгодно разів.",
-   "many": "Після натискання кнопки \"Дивитися\" на сторінці фільму відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути цей фільм скільки завгодно разів."
+    "one": "Після натискання кнопки \"Дивитися\" на сторінці фільму відкривається вікно перегляду. У вас є 1 година, щоб переглянути цей фільм скільки завгодно разів.",
+    "few": "Після натискання кнопки \"Дивитися\" на сторінці фільму відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути цей фільм скільки завгодно разів.",
+    "many": "Після натискання кнопки \"Дивитися\" на сторінці фільму відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути цей фільм скільки завгодно разів."
   },
   "shopping_info_watch_window_explanation_season": {
-   "one": "Після оформлення прокату, сезон буде доступний на вашому обліковому записі протягом 1 дня.",
-   "few": "Після оформлення прокату, сезон буде доступний на вашому обліковому записі протягом {{.Count}} днів. ",
-   "many": "Після оформлення прокату, сезон буде доступний на вашому обліковому записі протягом {{.Count}} днів. "
+    "one": "Після оформлення прокату, сезон буде доступний на вашому обліковому записі протягом 1 дня.",
+    "few": "Після оформлення прокату, сезон буде доступний на вашому обліковому записі протягом {{.Count}} днів. ",
+    "many": "Після оформлення прокату, сезон буде доступний на вашому обліковому записі протягом {{.Count}} днів. "
   },
   "shopping_info_watch_window_explanation2_season": {
-   "one": "Після натискання кнопки \"Дивитися\" у серії відкривається вікно перегляду. У вас є 1 година, щоб переглянути цю серію скільки завгодно разів.",
-   "few": "Після натискання кнопки \"Дивитися\" у серії відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути цю серію скільки завгодно разів.",
-   "many": "Після натискання кнопки \"Дивитися\" у серії відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути цю серію скільки завгодно разів."
+    "one": "Після натискання кнопки \"Дивитися\" у серії відкривається вікно перегляду. У вас є 1 година, щоб переглянути цю серію скільки завгодно разів.",
+    "few": "Після натискання кнопки \"Дивитися\" у серії відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути цю серію скільки завгодно разів.",
+    "many": "Після натискання кнопки \"Дивитися\" у серії відкривається вікно перегляду. У вас є {{.Count}} годин(и), щоб переглянути цю серію скільки завгодно разів."
   },
   "shopping_info_credit_bonus_title": {
-   "other": "{{.BonusPercentage}}% Бонус"
+    "other": "{{.BonusPercentage}}% Бонус"
   },
   "shopping_enter_card_prompt": {
-   "other": "Введіть дані вашої банківської карти, щоб завершити {{.Verb}}."
+    "other": "Введіть дані вашої банківської карти, щоб завершити {{.Verb}}."
   },
   "shopping_terms": {
-   "other": "Завершуючи цю транзакцію, я погоджуюся з <a href=\"/page/terms-and-conditions/\" target=\"_blank\" tabindex=\"-1\">умовами використання</a>."
+    "other": "Завершуючи цю транзакцію, я погоджуюся з <a href=\"/page/terms-and-conditions/\" target=\"_blank\" tabindex=\"-1\">умовами використання</a>."
   },
   "shopping_discount_applied": {
-   "other": "Застосована сума знижки {{.DiscountAmount}}."
+    "other": "Застосована сума знижки {{.DiscountAmount}}."
   },
   "shopping_discount_apply": {
-   "other": "Застосувати"
+    "other": "Застосувати"
   },
   "shopping_discount_code": {
-   "other": "Введіть промокод."
+    "other": "Введіть промокод."
   },
   "shopping_discount_have_code": {
-   "other": "У мене є промокод."
+    "other": "У мене є промокод."
   },
   "shopping_price_you_pay": {
-   "other": "Ви сплачуєте"
+    "other": "Ви сплачуєте"
   },
   "shopping_price_nothing": {
-   "other": "Нічого"
+    "other": "Нічого"
   },
   "shopping_price_free": {
-   "other": "Безкоштовно"
+    "other": "Безкоштовно"
   },
   "shopping_auth_directions": {
-   "other": "Потрібно увійти до облікового запису. Будь ласка, введіть свою електронну адресу."
+    "other": "Потрібно увійти до облікового запису. Будь ласка, введіть свою електронну адресу."
   },
   "shopping_error_in_library": {
-   "other": "{{.Title}} уже додано до бібліотеки."
+    "other": "{{.Title}} уже додано до бібліотеки."
   },
   "shopping_error_missing_card": {
-   "other": "Будь ласка, введіть дані вашої банківської картки."
+    "other": "Будь ласка, введіть дані вашої банківської картки."
   },
   "shopping_error_title": {
-   "other": "Сталася помилка."
+    "other": "Сталася помилка."
   },
   "shopping_error_incorrect_cvc": {
-   "other": "Будь ласка, введіть дійсний CVV."
+    "other": "Будь ласка, введіть дійсний CVV."
   },
   "shopping_error_invalid_cvc": {
-   "other": "Будь ласка, введіть дійсний CVV."
+    "other": "Будь ласка, введіть дійсний CVV."
   },
   "shopping_error_incorrect_number": {
-   "other": "Будь ласка, введіть дійсний номер банківської картки."
+    "other": "Будь ласка, введіть дійсний номер банківської картки."
   },
   "shopping_error_invalid_number": {
-   "other": "Будь ласка, введіть дійсний номер банківської картки."
+    "other": "Будь ласка, введіть дійсний номер банківської картки."
   },
   "shopping_error_card_declined": {
-   "other": "Банківська карта відхилена."
+    "other": "Банківська карта відхилена."
   },
   "shopping_error_invalid_expiry_month": {
-   "other": "Будь ласка, введіть дійсний термін дії картки."
+    "other": "Будь ласка, введіть дійсний термін дії картки."
   },
   "shopping_error_invalid_expiry_year": {
-   "other": "Будь ласка, введіть дійсний термін дії картки."
+    "other": "Будь ласка, введіть дійсний термін дії картки."
   },
   "shopping_error_expired_card": {
-   "other": "Термін дії банківської картки закінчився."
+    "other": "Термін дії банківської картки закінчився."
   },
   "shopping_error_creditcard_country_mismatch": {
-   "other": "Ваше {{.Ownership}} не встановлено. Ви маєте знаходитися в країні, де була випущена банківська картка. Будь ласка, використайте іншу картку для здійснення платежу."
+    "other": "Ваше {{.Ownership}} не встановлено. Ви маєте знаходитися в країні, де була випущена банківська картка. Будь ласка, використайте іншу картку для здійснення платежу."
   },
   "shopping_error_proxy_detected": {
-   "other": "Ваше {{.Ownership}} не встановлено. Здається ви використовуєте розблокувальник або проксі. Будь ласка, вимкніть ці сервіси та спробуйте ще раз."
+    "other": "Ваше {{.Ownership}} не встановлено. Здається ви використовуєте розблокувальник або проксі. Будь ласка, вимкніть ці сервіси та спробуйте ще раз."
   },
   "shopping_error_discount_worn_out": {
-   "other": "Цей промо-код більше не може бути використаний."
+    "other": "Цей промо-код більше не може бути використаний."
   },
   "shopping_error_discount_blank": {
-   "other": "Будь ласка, введіть промокод."
+    "other": "Будь ласка, введіть промокод."
   },
   "shopping_error_discount_not_applied": {
-   "other": "Будь ласка, введіть дійсний промокод."
+    "other": "Будь ласка, введіть дійсний промокод."
   },
   "shopping_error_discount_invalid": {
-   "other": "Будь ласка, введіть дійсний промокод."
+    "other": "Будь ласка, введіть дійсний промокод."
   },
   "shopping_error_discount_disabled": {
-   "other": "Будь ласка, введіть дійсний промокод."
+    "other": "Будь ласка, введіть дійсний промокод."
   },
   "shopping_error_discount_already_applied": {
-   "other": "Промокод уже був використаний для цього сеансу."
+    "other": "Промокод уже був використаний для цього сеансу."
   },
   "shopping_error_discount_already_redeemed": {
-   "other": "Цей промокод уже був використаний."
+    "other": "Цей промокод уже був використаний."
   },
   "shopping_error_discount_used_previously": {
-   "other": "Цей промокод уже був використаний."
+    "other": "Цей промокод уже був використаний."
   },
   "shopping_error_discount_max_limit": {
-   "other": "Цей промокод більше не можна використовувати."
+    "other": "Цей промокод більше не можна використовувати."
   },
   "shopping_error_discount_expired": {
-   "other": "Термін дії цього промокоду закінчився."
+    "other": "Термін дії цього промокоду закінчився."
   },
   "shopping_error_discount_invalid_ownership_buy": {
-   "other": "Цей промокод не можна використовувати для придбання."
+    "other": "Цей промокод не можна використовувати для придбання."
   },
   "shopping_error_discount_invalid_ownership_rent": {
-   "other": "Цей промокод не можна використовувати для прокату."
+    "other": "Цей промокод не можна використовувати для прокату."
   },
   "shopping_error_discount_invalid_item": {
-   "other": "Цей промокод не може бути використаний з цим товаром."
+    "other": "Цей промокод не може бути використаний з цим товаром."
   },
   "shopping_error_discount_invalid_pricing_region": {
-   "other": "Цей промокод не може бути використаний у вашій країні."
+    "other": "Цей промокод не може бути використаний у вашій країні."
   },
   "shopping_error_discounts_not_allowed": {
-   "other": "Цей промокод не може бути використаний."
+    "other": "Цей промокод не може бути використаний."
   },
   "shopping_error_discount_disallowed_on_bundles": {
-   "other": "Цей промокод не може бути використаний для комплектів."
+    "other": "Цей промокод не може бути використаний для комплектів."
   },
   "shopping_error_payment_intent_authentication_failure": {
-   "other": "Банківську картку відхилено. Спробуйте ще раз."
+    "other": "Банківську картку відхилено. Спробуйте ще раз."
   },
   "shopping_complete_rental": {
-   "other": "Успішно!"
+    "other": "Успішно!"
   },
   "shopping_complete_rental_period": {
-   "one": "Тепер ви можете переглядати фільм стільки раз, скільки забажаєте, протягом наступного дня.",
-   "few": "Тепер ви можете переглядати фільм стільки раз, скільки забажаєте, протягом наступних {{.Count}} днів.",
-   "many": "Тепер ви можете переглядати фільм стільки раз, скільки забажаєте, протягом наступних {{.Count}} днів."
+    "one": "Тепер ви можете переглядати фільм стільки раз, скільки забажаєте, протягом наступного дня.",
+    "few": "Тепер ви можете переглядати фільм стільки раз, скільки забажаєте, протягом наступних {{.Count}} днів.",
+    "many": "Тепер ви можете переглядати фільм стільки раз, скільки забажаєте, протягом наступних {{.Count}} днів."
   },
   "shopping_complete_purchase": {
-   "other": "Дякуємо за придбання фільму {{.Title}}."
+    "other": "Дякуємо за придбання фільму {{.Title}}."
   },
   "shopping_complete_credit_purchase": {
-   "other": "Дякуємо за придбання фільму {{.Title}}, сума {{.CreditTotal}} зарахована на ваш обліковий запис."
+    "other": "Дякуємо за придбання фільму {{.Title}}, сума {{.CreditTotal}} зарахована на ваш обліковий запис."
   },
   "shopping_complete_purchase_coming_soon": {
-   "other": "Ви зможете подивитися цей фільм з {{.Date}}."
+    "other": "Ви зможете подивитися цей фільм з {{.Date}}."
   },
   "shopping_complete_receipt": {
-   "other": "Квиток відправлений на вашу електрону адресу."
+    "other": "Квиток відправлений на вашу електрону адресу."
   },
   "shopping_complete_library_link": {
-   "other": "Подивитися вашу бібліотеку"
+    "other": "Подивитися вашу бібліотеку"
   },
   "shopping_complete_plan": {
     "other": "Ваша покупка {{ .Title }} була успішною."
-  },  
+  },
   "shopping_complete_rental_watch_window_start": {
-   "one": "Тепер ви можете почати дивитися фільм протягом наступного дня.",
-   "few": "Тепер ви можете почати дивитися фільм протягом наступних {{.Count}} днів.",
-   "many": "Тепер ви можете почати дивитися фільм протягом наступних {{.Count}} днів."
+    "one": "Тепер ви можете почати дивитися фільм протягом наступного дня.",
+    "few": "Тепер ви можете почати дивитися фільм протягом наступних {{.Count}} днів.",
+    "many": "Тепер ви можете почати дивитися фільм протягом наступних {{.Count}} днів."
   },
   "shopping_complete_rental_watch_window_end": {
-   "one": "Коли розпочнеться показ, у вас буде одна година, щоб переглянути фільм скільки завгодно разів.",
-   "few": "Коли розпочнеться показ, у вас буде {{.Count}} годин(и), щоб переглянути фільм скільки завгодно разів.",
-   "many": "Коли розпочнеться показ, у вас буде {{.Count}} годин(и), щоб переглянути фільм скільки завгодно разів."
+    "one": "Коли розпочнеться показ, у вас буде одна година, щоб переглянути фільм скільки завгодно разів.",
+    "few": "Коли розпочнеться показ, у вас буде {{.Count}} годин(и), щоб переглянути фільм скільки завгодно разів.",
+    "many": "Коли розпочнеться показ, у вас буде {{.Count}} годин(и), щоб переглянути фільм скільки завгодно разів."
   },
   "shopping_complete_rental_coming_soon": {
-   "one": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом одного дня.",
-   "few": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом {{.Count}} днів.",
-   "many": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом {{.Count}} днів."
+    "one": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом одного дня.",
+    "few": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом {{.Count}} днів.",
+    "many": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом {{.Count}} днів."
   },
   "shopping_complete_rental_coming_soon_watch_window_start": {
-   "one": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом одного дня.",
-   "few": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом {{.Count}} днів.",
-   "many": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом {{.Count}} днів."
+    "one": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом одного дня.",
+    "few": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом {{.Count}} днів.",
+    "many": "Ви зможете переглянути фільм з {{.Date}}, а період прокату триватиме протягом {{.Count}} днів."
   },
   "shopping_action_rent": {
-   "other": "Взяти напрокат"
+    "other": "Взяти напрокат"
   },
   "shopping_action_buy": {
-   "other": "Купити"
+    "other": "Купити"
   },
   "meta_detail_cast_title": {
-   "other": "Акторський склад"
+    "other": "Акторський склад"
   },
   "meta_detail_crew_title": {
-   "other": "Знімальна група"
+    "other": "Знімальна група"
   },
   "meta_detail_languages": {
-   "one": "Мова",
-   "few": "Мови",
-   "many": "Мови",
-   "other": "Мови"
+    "one": "Мова",
+    "few": "Мови",
+    "many": "Мови",
+    "other": "Мови"
   },
   "meta_detail_studios": {
-   "one": "Студія",
-   "few": "Студія",
-   "many": "Студія",
-   "other": "Студії"
+    "one": "Студія",
+    "few": "Студія",
+    "many": "Студія",
+    "other": "Студії"
   },
   "meta_detail_countries": {
     "one": "Країна",
@@ -746,328 +778,349 @@
     "other": "Країни"
   },
   "meta_detail_subtitles": {
-   "other": "Субтитри"
+    "other": "Субтитри"
   },
-  "meta_detail_captions": { "other": "Субтитри [CC]" },
+  "meta_detail_captions": {
+    "other": "Субтитри [CC]"
+  },
   "meta_detail_episodes_title": {
-   "other": "Епізоди"
+    "other": "Епізоди"
   },
   "meta_detail_bonus_title": {
-   "other": "Бонусний контент"
+    "other": "Бонусний контент"
   },
   "meta_detail_recommendations_title": {
-   "other": "Вам також може сподобатися"
+    "other": "Вам також може сподобатися"
   },
   "meta_detail_bundle_items_title": {
-   "other": "Контент, що входить до цього комплекту."
+    "other": "Контент, що входить до цього комплекту."
   },
   "bundle_items_all_films": {
-   "few": "{{.Count}} фільмів",
-   "many": "{{.Count}} фільмів"
+    "few": "{{.Count}} фільмів",
+    "many": "{{.Count}} фільмів"
   },
   "bundle_items_all_seasons": {
-   "few": "{{.Count}} сезонів",
-   "many": "{{.Count}} сезонів"
+    "few": "{{.Count}} сезонів",
+    "many": "{{.Count}} сезонів"
   },
   "bundle_items_mixed": {
-   "few": "{{.Count}} фільмів і сезонів",
-   "many": "{{.Count}} фільмів і сезонів"
+    "few": "{{.Count}} фільмів і сезонів",
+    "many": "{{.Count}} фільмів і сезонів"
   },
   "userwishlist_page_header": {
-   "other": "Мій список"
+    "other": "Мій список"
   },
   "userwishlist_slider_header": {
-   "other": "Мій список"
+    "other": "Мій список"
   },
   "userwishlist_empty_header": {
-   "other": "Ваш список порожній."
+    "other": "Ваш список порожній."
   },
   "userwishlist_empty_content": {
-   "other": "Заповніть його, <a href=\"/\">переглянувши</a> нашу колекцію."
+    "other": "Заповніть його, <a href=\"/\">переглянувши</a> нашу колекцію."
   },
   "userwishlist_button_add": {
-   "other": "Додати до мого списку"
+    "other": "Додати до мого списку"
   },
   "userwishlist_button_remove": {
-   "other": "Мій список"
+    "other": "Мій список"
   },
   "userwishlist_button_add_compact": {
-   "other": "Мій список"
+    "other": "Мій список"
   },
   "userwishlist_button_remove_compact": {
-   "other": "Мій список"
+    "other": "Мій список"
   },
   "activatedevice_page_header": {
-   "other": "Активувати пристрій"
+    "other": "Активувати пристрій"
   },
   "activatedevice_page_content": {
-   "other": "Дотримуйтесь інструкцій на своєму пристрої, щоб отримати PIN-код.Ваш комп'ютер та пристрій повинні бути підключені до Інтернету для активації. "
+    "other": "Дотримуйтесь інструкцій на своєму пристрої, щоб отримати PIN-код.Ваш комп'ютер та пристрій повинні бути підключені до Інтернету для активації. "
   },
   "activatedevice_form_pin": {
-   "other": "PIN-код"
+    "other": "PIN-код"
   },
   "activatedevice_form_submit": {
-   "other": "Активувати"
+    "other": "Активувати"
   },
   "activatedevice_form_error_invalid_code": {
-   "other": "PIN-код не знайдено, повторіть спробу."
+    "other": "PIN-код не знайдено, повторіть спробу."
   },
   "activatedevice_form_error_pin_not_found": {
-   "other": "PIN-код не знайдено, повторіть спробу."
+    "other": "PIN-код не знайдено, повторіть спробу."
   },
   "activatedevice_signin_prompt": {
-   "other": "Увійдіть, перш ніж активувати свій пристрій."
+    "other": "Увійдіть, перш ніж активувати свій пристрій."
   },
   "activatedevice_page_activated": {
-   "other": "Дякуємо за активацію{{.DeviceName}}. Тепер ви повинні переглядати свою бібліотеку на телебаченні або пристрої."
+    "other": "Дякуємо за активацію{{.DeviceName}}. Тепер ви повинні переглядати свою бібліотеку на телебаченні або пристрої."
   },
   "userdevices_page_header": {
-   "other": "Пристрої"
+    "other": "Пристрої"
   },
   "userdevices_page_content": {
-   "one": "Пристрої будуть автоматично додаватися під час їхнього використання. Ваш ліміт пристроїв – 1.",
-   "few": "Пристрої будуть автоматично додаватися під час їхнього використання. Ваш ліміт пристроїв – {{.Count}}.",
-   "many": "Пристрої будуть автоматично додаватися під час їхнього використання. Ваш ліміт пристроїв – {{.Count}}."
+    "one": "Пристрої будуть автоматично додаватися під час їхнього використання. Ваш ліміт пристроїв – 1.",
+    "few": "Пристрої будуть автоматично додаватися під час їхнього використання. Ваш ліміт пристроїв – {{.Count}}.",
+    "many": "Пристрої будуть автоматично додаватися під час їхнього використання. Ваш ліміт пристроїв – {{.Count}}."
   },
   "userdevices_empty_content": {
-   "other": "Зараз у вас 0 зареєстрованих пристроїв."
+    "other": "Зараз у вас 0 зареєстрованих пристроїв."
   },
   "userdevices_header_type": {
-   "other": "Тип пристрою"
+    "other": "Тип пристрою"
   },
   "userdevices_header_description": {
-   "other": "Опис"
+    "other": "Опис"
   },
   "userdevices_device_added": {
-   "other": "Доданий {{.Date}}"
+    "other": "Доданий {{.Date}}"
   },
   "userdevices_device_actions_delete": {
-   "other": "Видалити"
+    "other": "Видалити"
   },
   "userdevices_device_actions_cancel": {
-   "other": "Відмінити"
+    "other": "Відмінити"
   },
   "userdevices_device_actions_confirm": {
-   "other": "Так, видалити пристрій"
+    "other": "Так, видалити пристрій"
   },
   "userdevices_device_deleted": {
-   "other": "(Видалений)"
+    "other": "(Видалений)"
   },
   "userdevices_delete_limits": {
-   "other": "Ви можете видалити {{.Limit}} Пристрій (и) з цього списку кожен {{.Period}} День (и)."
+    "other": "Ви можете видалити {{.Limit}} Пристрій (и) з цього списку кожен {{.Period}} День (и)."
   },
   "userdevices_delete_limit_reached": {
-   "other": "Ви досягли цього межу і не можете видалити будь-які пристрої прямо зараз.Ви можете видалити пристрій {{.Days}} День (и)."
+    "other": "Ви досягли цього межу і не можете видалити будь-які пристрої прямо зараз.Ви можете видалити пристрій {{.Days}} День (и)."
   },
   "playlist_page_header": {
-   "other": "Список відтворення"
+    "other": "Список відтворення"
   },
   "playlist_sign_in_warning": {
-   "other": "Увійдіть, щоб переглянути Live TV."
+    "other": "Увійдіть, щоб переглянути Live TV."
   },
   "playlist_share_title": {
-   "other": "Список відтворення"
+    "other": "Список відтворення"
   },
   "playlist_up_next_title": {
-   "other": "Наступний"
+    "other": "Наступний"
   },
   "pricing_ownership_buy": {
-   "other": "Купити"
+    "other": "Купити"
   },
   "pricing_ownership_rent": {
-   "other": "Взяти напрокат"
+    "other": "Взяти напрокат"
   },
   "classification_intro": {
-   "other": "Класифікація: "
+    "other": "Класифікація: "
   },
   "classification_divider": {
-   "other": " - "
+    "other": " - "
   },
   "classification_outro": {
-   "other": ""
+    "other": ""
   },
   "cookie_banner_message": {
-   "other": "Цей вебсайт використовує файли cookies, щоб забезпечити вам найкращий досвід користування. Продовжуючи відвідування сайту, ви погоджуєтесь з нашою <a href=\"/page/cookie-policy/\">політикою використання файлів cookies</a>."
+    "other": "Цей вебсайт використовує файли cookies, щоб забезпечити вам найкращий досвід користування. Продовжуючи відвідування сайту, ви погоджуєтесь з нашою <a href=\"/page/cookie-policy/\">політикою використання файлів cookies</a>."
   },
   "cookie_banner_accept": {
-   "other": "Погодьтесь"
+    "other": "Погодьтесь"
   },
   "all_rights_reserved": {
-   "other": "Усі права захищені. Жодну частину цього вебсайту не можна відтворювати без нашої попередньої письмової згоди."
+    "other": "Усі права захищені. Жодну частину цього вебсайту не можна відтворювати без нашої попередньої письмової згоди."
   },
   "users_gender_none": {
-   "other": "Не вказано"
+    "other": "Не вказано"
   },
   "users_gender_female": {
-   "other": "Жіноча"
+    "other": "Жіноча"
   },
   "users_gender_male": {
-   "other": "Чоловіча"
+    "other": "Чоловіча"
   },
   "users_gender_diverse": {
-   "other": "Різноманітна"
+    "other": "Різноманітна"
   },
   "users_gender_other": {
-   "other": "Інша"
+    "other": "Інша"
   },
   "pricing_quality_hd": {
-   "other": "HD"
+    "other": "HD"
   },
   "pricing_quality_sd": {
-   "other": "SD"
+    "other": "SD"
   },
   "pricing_quality_hd_only": {
-   "other": "HD тільки"
+    "other": "HD тільки"
   },
   "pricing_quality_sd_only": {
-   "other": "SD тільки"
+    "other": "SD тільки"
   },
   "shopping_card_save_card": {
-   "other": "Зберегти цю картку для майбутнього використання "
+    "other": "Зберегти цю картку для майбутнього використання "
   },
   "shopping_card_button_change": {
-   "other": "Показати всі збережені карти "
+    "other": "Показати всі збережені карти "
   },
   "shopping_card_existing_description": {
-   "other": "{{.Card.Brand}} закінчується {{.Card.Number}}"
+    "other": "{{.Card.Brand}} закінчується {{.Card.Number}}"
   },
   "shopping_card_existing_expiry": {
-   "other": "(закінчується {{.Card.Expiry}})"
+    "other": "(закінчується {{.Card.Expiry}})"
   },
   "shopping_card_existing_expired": {
-   "other": "(закінчився)"
+    "other": "(закінчився)"
   },
   "shopping_card_use_other": {
-   "other": "Використовуйте нову картку"
+    "other": "Використовуйте нову картку"
   },
   "shopping_card_use_new_card": {
-   "other": "Змінити картку"
+    "other": "Змінити картку"
   },
   "shopping_card_update_reason_none": {
-   "other": "Оновіть кредитну картку.Підтримувані картки - Visa, MasterCard та American Express."
+    "other": "Оновіть кредитну картку.Підтримувані картки - Visa, MasterCard та American Express."
   },
   "shopping_card_new_subscription": {
-   "other": "Ця карта збережена і регулярно стягується"
+    "other": "Ця карта збережена і регулярно стягується"
   },
   "shopping_card_change": {
-   "other": "Кредитна картка не правильна? <a href=\"{{.SubscriptionsURL}}\">Натисніть тут, щоб оновити свою картку.</a>"
+    "other": "Кредитна картка не правильна? <a href=\"{{.SubscriptionsURL}}\">Натисніть тут, щоб оновити свою картку.</a>"
   },
   "shopping_info_ownership_plan": {
-   "other": "Підписка"
+    "other": "Підписка"
   },
-
   "shopping_action_credit": {
-   "other": "Поповнити"
+    "other": "Поповнити"
   },
-
   "shopping_info_rental_period_coming_soon": {
-   "other": "з дати та часу релізу."
+    "other": "з дати та часу релізу."
   },
-
-  "usersubscriptions_change_payment_method_change": { "other": "Змінити кредитну картку" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "Оновлення деталей кредитної картки" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "Оновлення" },
-
-  "usersubscriptions_subscription_expiry": { "other": "Закінчується {{.Expiry}}" },
-  "usersubscriptions_subscription_status_trialing": { "other": "Пробний період" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "Скасувати мою підписку" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "Скасувати" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "Так, скасувати мою підписку" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "Скасувати підписку?" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "Це скасує підписку на {{.Name}} план.Ви все одно зможете подивитися вміст у плані, поки не закінчується {{.Expiry}}." },
-
+  "usersubscriptions_change_payment_method_change": {
+    "other": "Змінити кредитну картку"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "Оновлення деталей кредитної картки"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "Оновлення"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "Закінчується {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "Пробний період"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "Скасувати мою підписку"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "Скасувати"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "Так, скасувати мою підписку"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "Скасувати підписку?"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "Це скасує підписку на {{.Name}} план.Ви все одно зможете подивитися вміст у плані, поки не закінчується {{.Expiry}}."
+  },
   "availability_coming_soon": {
-   "other": "Скоро у доступі"
+    "other": "Скоро у доступі"
   },
   "availability_renting": {
-   "other": "Прокат"
+    "other": "Прокат"
   },
   "availability_not_available": {
-   "other": "Не доступний для перегляду"
+    "other": "Не доступний для перегляду"
   },
   "availability_in_watch_window": {
-   "other": "Доступний для перегляду"
+    "other": "Доступний для перегляду"
   },
   "availability_sold_out": {
-   "other": "Перегляд завершено"
+    "other": "Перегляд завершено"
   },
   "availability_available_till": {
-   "other": "Доступний для перегляду до {{.ExpiryDate}}"
+    "other": "Доступний для перегляду до {{.ExpiryDate}}"
   },
   "availability_not_available_in_country": {
-   "other": "Не доступний для перегляду"
+    "other": "Не доступний для перегляду"
   },
   "availability_available": {
-   "other": "Доступний з {{.ReleaseDate}}"
+    "other": "Доступний з {{.ReleaseDate}}"
   },
   "availability_expires": {
-   "other": "Доступ буде закрито {{.Expiry}}"
+    "other": "Доступ буде закрито {{.Expiry}}"
   },
   "availability_expired": {
-   "other": "Доступ закритий"
+    "other": "Доступ закритий"
   },
   "modal_cancel": {
-   "other": "Відмінити"
+    "other": "Відмінити"
   },
   "play": {
-   "other": "Дивитися"
+    "other": "Дивитися"
   },
   "combined_auth_signin_prompt": {
-   "other": "Увійти"
+    "other": "Увійти"
   },
   "combined_auth_signup_prompt": {
-   "other": "Підписатися"
+    "other": "Підписатися"
   },
   "combined_auth_terms": {
-   "other": "Я погоджуюся з усіма <a href=\"/page/terms-and-conditions/\" target=\"_blank\">правилами &amp; умовами</a>."
+    "other": "Я погоджуюся з усіма <a href=\"/page/terms-and-conditions/\" target=\"_blank\">правилами &amp; умовами</a>."
   },
   "signup_terms": {
-   "other": "Я погоджуюся з усіма <a href=\"/page/terms-and-conditions/\" target=\"_blank\">правилами &amp; умовами</a>."
+    "other": "Я погоджуюся з усіма <a href=\"/page/terms-and-conditions/\" target=\"_blank\">правилами &amp; умовами</a>."
   },
   "validation_terms_required": {
-   "other": "Ви маєте погодитися з правилами та умовами."
+    "other": "Ви маєте погодитися з правилами та умовами."
   },
   "shopping_error_item_limit_exceeded": {
-   "other": "На жаль, перегляд фільму {{.Title}} завершено."
+    "other": "На жаль, перегляд фільму {{.Title}} завершено."
   },
   "changepincode_modal_header": {
-   "other": "Змініть свій PIN-код"
+    "other": "Змініть свій PIN-код"
   },
   "changepincode_modal_currentpassword": {
-   "other": "Ваш поточний пароль "
+    "other": "Ваш поточний пароль "
   },
   "changepincode_modal_pincode1": {
-   "other": "Ваш новий 4-значний PIN-код "
+    "other": "Ваш новий 4-значний PIN-код "
   },
   "changepincode_modal_pincode2": {
-   "other": "Підтвердьте свій новий 4-значний PIN-код "
+    "other": "Підтвердьте свій новий 4-значний PIN-код "
   },
   "changepincode_modal_submit": {
-   "other": "Встановіть PIN-код "
+    "other": "Встановіть PIN-код "
   },
   "changepincode_modal_error_wrong_password": {
-   "other": "Цей пароль неправильний."
+    "other": "Цей пароль неправильний."
   },
   "user_set_pin_intro": {
-   "other": "Вам потрібен штифт {{.Action}} обмежений вміст"
+    "other": "Вам потрібен штифт {{.Action}} обмежений вміст"
   },
   "user_error_wrong_pin_reset": {
-   "other": "Натисніть тут, щоб скинути PIN-код "
+    "other": "Натисніть тут, щоб скинути PIN-код "
   },
   "user_error_too_many_pin_errors_help_page_link": {
-   "other": ""
+    "other": ""
   },
   "shopping_error_age_restricted": {
-   "other": "Цей вміст є обмеженим віком."
+    "other": "Цей вміст є обмеженим віком."
   },
   "shopping_error_close_button": {
-   "other": "гаразд"
+    "other": "гаразд"
   },
-
-  "app_badge_title": { "other": "Завантажте додаток, щоб переглянути придбаний вміст!" },
-  "app_badge_ios": { "other": "Завантажте в App Store" },
-  "app_badge_android": { "other": "Отримати його в Google Play" },
-
+  "app_badge_title": {
+    "other": "Завантажте додаток, щоб переглянути придбаний вміст!"
+  },
+  "app_badge_ios": {
+    "other": "Завантажте в App Store"
+  },
+  "app_badge_android": {
+    "other": "Отримати його в Google Play"
+  },
   "shopping_price_title_plan": {
     "other": "Ціна"
   },
@@ -1139,36 +1192,85 @@
   "donate_button_text": {
     "other": "Пожертвуйте"
   },
-
-  "wcag_skip_links_header": { "other": "Посилання на доступність" },
-  "wcag_skip_links_content": { "other": "Перейти до вмісту " },
-
-  "wcag_homepage_h1": { "other": "Домашня сторінка" },
-  "wcag_carousel_h2": { "other": "Карусель" },
-  "wcag_collections_h2": { "other": "Колекції" },
-
-  "wcag_aria_label_footer": { "other": "Колонтитул" },
-  "wcag_aria_label_nav_main": { "other": "Основний" },
-  "wcag_aria_label_nav_sub": { "other": "Суп" },
-  "wcag_aria_label_toggle_nav": { "other": "Перемикання навігації" },
-  "wcag_aria_label_bundle_items": { "other": "Пункти пучки" },
-  "wcag_aria_label_carousel": { "other": "Карусель" },
-  "wcag_aria_label_page_collection": { "other": "Колекція сторінок" },
-  "wcag_aria_label_collection_list": { "other": "Список зборів"},
-  "wcag_aria_label_collection_slider": { "other": "Колекція слайдер" },
-  "wcag_aria_label_wishlist": { "other": "Список побажань" },
-  "wcag_aria_label_facebook": { "other": "Поділитися на Facebook " },
-  "wcag_aria_label_twitter": { "other": "Поділитися на Twitter " },
-  "wcag_aria_label_linkedin": { "other": "Поділитися на Linkedin" },
-  "wcag_aria_label_letterboxd": { "other": "Перегляд на LetterBoxd" },
-  "shopping_error_plan_already_owned": { "other": "Ви вже маєте цей план." },
-  "shopping_error_plan_expired": { "other": "Цей план більше не доступний." },
-  "shopping_payment_method_header": { "other": "Методи оплати" },
-  "shopping_payment_method_credit_card": { "other": "Кредитна карта" },
-  "shopping_payment_method_giropay": { "other": "Герома" },
-  "shopping_error_stripe_unknown_error": { "other": "Щось пішло не так з цим платежем.Будь-ласка спробуйте пізніше." },
-  "shopping_error_payment_complete_failed": { "other": "Оплата відхилено.Закрийте це вікно і повторіть спробу." },
-
-
-  "header_banner": { "other": "Головний банер" }
+  "wcag_skip_links_header": {
+    "other": "Посилання на доступність"
+  },
+  "wcag_skip_links_content": {
+    "other": "Перейти до вмісту "
+  },
+  "wcag_homepage_h1": {
+    "other": "Домашня сторінка"
+  },
+  "wcag_carousel_h2": {
+    "other": "Карусель"
+  },
+  "wcag_collections_h2": {
+    "other": "Колекції"
+  },
+  "wcag_aria_label_footer": {
+    "other": "Колонтитул"
+  },
+  "wcag_aria_label_nav_main": {
+    "other": "Основний"
+  },
+  "wcag_aria_label_nav_sub": {
+    "other": "Суп"
+  },
+  "wcag_aria_label_toggle_nav": {
+    "other": "Перемикання навігації"
+  },
+  "wcag_aria_label_bundle_items": {
+    "other": "Пункти пучки"
+  },
+  "wcag_aria_label_carousel": {
+    "other": "Карусель"
+  },
+  "wcag_aria_label_page_collection": {
+    "other": "Колекція сторінок"
+  },
+  "wcag_aria_label_collection_list": {
+    "other": "Список зборів"
+  },
+  "wcag_aria_label_collection_slider": {
+    "other": "Колекція слайдер"
+  },
+  "wcag_aria_label_wishlist": {
+    "other": "Список побажань"
+  },
+  "wcag_aria_label_facebook": {
+    "other": "Поділитися на Facebook "
+  },
+  "wcag_aria_label_twitter": {
+    "other": "Поділитися на Twitter "
+  },
+  "wcag_aria_label_linkedin": {
+    "other": "Поділитися на Linkedin"
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "Перегляд на LetterBoxd"
+  },
+  "shopping_error_plan_already_owned": {
+    "other": "Ви вже маєте цей план."
+  },
+  "shopping_error_plan_expired": {
+    "other": "Цей план більше не доступний."
+  },
+  "shopping_payment_method_header": {
+    "other": "Методи оплати"
+  },
+  "shopping_payment_method_credit_card": {
+    "other": "Кредитна карта"
+  },
+  "shopping_payment_method_giropay": {
+    "other": "Герома"
+  },
+  "shopping_error_stripe_unknown_error": {
+    "other": "Щось пішло не так з цим платежем.Будь-ласка спробуйте пізніше."
+  },
+  "shopping_error_payment_complete_failed": {
+    "other": "Оплата відхилено.Закрийте це вікно і повторіть спробу."
+  },
+  "header_banner": {
+    "other": "Головний банер"
+  }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1,1129 +1,1169 @@
 {
   "site_owner": {
-   "other": "ABC Cinemas"
+    "other": "ABC Cinemas"
   },
   "settings_title": {
-   "other": "設置"
+    "other": "設置"
   },
   "powered_by": {
-   "other": "指定網站服務商"
+    "other": "指定網站服務商"
   },
   "powered_by_name": {
-   "other": "Shift72"
+    "other": "Shift72"
   },
   "powered_by_url": {
-   "other": "https://www.shift72.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
-   "other": "合作單位"
+    "other": "合作單位"
   },
   "festival_scope": {
-   "other": "Festival Scope"
+    "other": "Festival Scope"
   },
   "festival_scope_url": {
-   "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
+    "other": "https://www.festivalscope.com/page/create-your-online-film-festival/"
   },
   "en": {
-   "other": "英語"
+    "other": "英語"
   },
   "fr": {
-   "other": "法語"
+    "other": "法語"
   },
   "episode_name": {
-   "other": "集"
+    "other": "集"
   },
   "season_name": {
-   "other": "季"
+    "other": "季"
   },
   "seasons": {
-   "one": "共 1 季",
-   "other": "共 {{.Count}} 季"
+    "one": "共 1 季",
+    "other": "共 {{.Count}} 季"
   },
   "tvseason": {
-   "other": "{{.ShowInfo.Title}} 第 {{.Season.SeasonNumber}} 集"
+    "other": "{{.ShowInfo.Title}} 第 {{.Season.SeasonNumber}} 集"
   },
   "tvseason_html": {
-   "other": "{{.ShowInfo.Title}} <span>第 {{.Season.SeasonNumber}} 季</span>"
+    "other": "{{.ShowInfo.Title}} <span>第 {{.Season.SeasonNumber}} 季</span>"
   },
   "tvepisode": {
-   "other": "{{.Episode.Title}}"
+    "other": "{{.Episode.Title}}"
   },
   "tvseason_number": {
-   "other": "影集 {{.Season.SeasonNumber}}"
+    "other": "影集 {{.Season.SeasonNumber}}"
   },
   "episode_count": {
-   "one": "共 1 集",
-   "other": "共 {{.Count}} 集"
+    "one": "共 1 集",
+    "other": "共 {{.Count}} 集"
   },
   "date_day": {
-   "other": "日"
+    "other": "日"
   },
   "date_month": {
-   "other": "月"
+    "other": "月"
   },
   "date_year": {
-   "other": "年"
+    "other": "年"
   },
   "404_page_header": {
-   "other": "此頁面不存在"
+    "other": "此頁面不存在"
   },
   "404_page_content": {
-   "other": "<p>很抱歉，此頁面不存在。</p><p>頁面可能已被移除，或輸入的資訊有誤。</p><p>請回到首頁重新搜尋。</p><p><a href=\"{{.URL}}\">回到首頁</a></p>"
+    "other": "<p>很抱歉，此頁面不存在。</p><p>頁面可能已被移除，或輸入的資訊有誤。</p><p>請回到首頁重新搜尋。</p><p><a href=\"{{.URL}}\">回到首頁</a></p>"
   },
   "nav_homepage": {
-   "other": "ABC Cinemas"
+    "other": "ABC Cinemas"
   },
   "nav_signin": {
-   "other": "登入"
+    "other": "登入"
   },
   "nav_signup": {
-   "other": "建立帳號"
+    "other": "建立帳號"
   },
   "nav_signed_in_as": {
-   "other": "使用者"
+    "other": "使用者"
   },
   "nav_library": {
-   "other": "已付費影片"
+    "other": "已付費影片"
   },
   "nav_devices": {
-   "other": "我的播放裝置"
+    "other": "我的播放裝置"
   },
   "nav_wishlist": {
-   "other": "我的追蹤片單"
+    "other": "我的追蹤片單"
   },
   "nav_account": {
-   "other": "我的帳號"
+    "other": "我的帳號"
   },
   "nav_signout": {
-   "other": "登出"
+    "other": "登出"
   },
   "header_banner": {
-   "other": "標題橫幅"
+    "other": "標題橫幅"
   },
   "play_trailer": {
-   "other": "預告"
+    "other": "預告"
   },
   "runtime_hours": {
-   "other": "時"
+    "other": "時"
   },
   "runtime_minutes": {
-   "other": "分"
+    "other": "分"
   },
   "datetime_today": {
-   "other": "今天 {{.Date}}"
+    "other": "今天 {{.Date}}"
   },
   "datetime_tomorrow": {
-   "other": "明天 {{.Date}}"
+    "other": "明天 {{.Date}}"
   },
   "datetime_yesterday": {
-   "other": "昨天 {{.Date}}"
+    "other": "昨天 {{.Date}}"
   },
   "datetime_next": {
-   "other": "{{.Date}}"
+    "other": "{{.Date}}"
   },
   "datetime_last": {
-   "other": "最近一次觀看 {{.Date}}"
+    "other": "最近一次觀看 {{.Date}}"
   },
   "search_control_placeholder": {
-   "other": "關鍵字搜尋"
+    "other": "關鍵字搜尋"
   },
   "search_control_submit": {
-   "other": "送出"
+    "other": "送出"
   },
   "play_button_watch": {
-   "other": "播放"
+    "other": "播放"
   },
   "play_button_resume": {
-   "other": "繼續播放"
+    "other": "繼續播放"
   },
   "social_media_buttons_title": {
-   "other": "分享"
+    "other": "分享"
   },
-  "social_media_buttons_facebook": { "other": "在脸书上分享" },
-  "social_media_buttons_twitter": { "other": "分享到Twitter" },
-  "social_media_buttons_linkedin": { "other": "在领英上分享" },
-  "social_media_buttons_email": { "other": "通过电子邮件分享" },
-  "social_media_buttons_email_subject": { "other": "链接分享" },
-  "social_media_buttons_copied_link": { "other": "链接已复制到剪贴板！" },
-  "social_media_buttons_copy_link": { "other": "复制到剪贴板" },
+  "social_media_buttons_facebook": {
+    "other": "在脸书上分享"
+  },
+  "social_media_buttons_twitter": {
+    "other": "分享到Twitter"
+  },
+  "social_media_buttons_linkedin": {
+    "other": "在领英上分享"
+  },
+  "social_media_buttons_email": {
+    "other": "通过电子邮件分享"
+  },
+  "social_media_buttons_email_subject": {
+    "other": "链接分享"
+  },
+  "social_media_buttons_copied_link": {
+    "other": "链接已复制到剪贴板！"
+  },
+  "social_media_buttons_copy_link": {
+    "other": "复制到剪贴板"
+  },
   "accept_invite_page_header": {
-   "other": "歡迎 "
+    "other": "歡迎 "
   },
   "acceptinvite_form_invalid_reset_password_token": {
-   "other": "您已接受過此邀請，請從 <a href=\"{{.SigninURL}}\">登入</a> 。若忘記密碼，請至 <a href=\"{{.ForgotPasswordURL}}\">重設密碼</a>。"
+    "other": "您已接受過此邀請，請從 <a href=\"{{.SigninURL}}\">登入</a> 。若忘記密碼，請至 <a href=\"{{.ForgotPasswordURL}}\">重設密碼</a>。"
   },
   "acceptinvite_complete": {
-   "other": "帳號已建立"
+    "other": "帳號已建立"
   },
   "acceptinvite_form_submit": {
-   "other": "接受邀請"
+    "other": "接受邀請"
   },
   "acceptinvite_agreement": {
-   "other": "按下「接受邀請」前，請先確認已閱讀並詳細了解我們的服務條款<a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">條款 &amp; 狀況</a> 和 <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">隱私政策</a>。"
+    "other": "按下「接受邀請」前，請先確認已閱讀並詳細了解我們的服務條款<a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">條款 &amp; 狀況</a> 和 <a href=\"{{.PrivacyPolicyURL}}\" target=\"_blank\">隱私政策</a>。"
   },
   "signup_page_header": {
-   "other": "建立新帳號"
+    "other": "建立新帳號"
   },
   "signup_form_name": {
-   "other": "姓名"
+    "other": "姓名"
   },
   "signup_form_email": {
-   "other": "電子郵件"
+    "other": "電子郵件"
   },
   "signup_form_password": {
-   "other": "密碼"
+    "other": "密碼"
   },
   "signup_form_password_confirmation": {
-   "other": "確認密碼"
+    "other": "確認密碼"
   },
   "signup_form_gender": {
-   "other": "性別"
+    "other": "性別"
   },
   "signup_form_dob": {
-   "other": "生日"
+    "other": "生日"
   },
   "signup_form_submit": {
-   "other": "送出"
+    "other": "送出"
   },
   "signin_page_header": {
-   "other": "登入"
+    "other": "登入"
   },
   "signin_form_email": {
-   "other": "電子郵件"
+    "other": "電子郵件"
   },
   "signin_form_password": {
-   "other": "密碼"
+    "other": "密碼"
   },
   "signin_form_remember": {
-   "other": "記住我"
+    "other": "記住我"
   },
   "signin_form_submit": {
-   "other": "送出"
+    "other": "送出"
   },
   "signin_page_forgotpassword": {
-   "other": "忘記密碼？"
+    "other": "忘記密碼？"
   },
   "signin_page_createnewaccount": {
-   "other": "還沒有帳號？立即加入"
+    "other": "還沒有帳號？立即加入"
   },
   "signup_page_alreadyhaveanaccount": {
-   "other": "已有帳號？立即登入"
+    "other": "已有帳號？立即登入"
   },
   "signup_form_error_email_already_in_use": {
-   "other": "此電子郵件已被使用。"
+    "other": "此電子郵件已被使用。"
   },
   "signin_form_error_incorrect_credentials": {
-   "other": "輸入的帳號或密碼錯誤。"
+    "other": "輸入的帳號或密碼錯誤。"
   },
   "signin_form_error_ip_throttled": {
-   "other": "登入錯誤超過次數，請稍候再試。"
+    "other": "登入錯誤超過次數，請稍候再試。"
   },
   "signin_form_error_account_suspended": {
-   "other": "此帳號目前暫停使用。若有任何疑問，請與我們聯繫。"
+    "other": "此帳號目前暫停使用。若有任何疑問，請與我們聯繫。"
   },
   "signup_form_error_forbidden": {
-   "other": "發生錯誤"
+    "other": "發生錯誤"
   },
   "combined_auth_continue": {
-   "other": "繼續"
+    "other": "繼續"
   },
   "combined_auth_change": {
-   "other": "變更"
+    "other": "變更"
   },
   "combined_auth_signin": {
-   "other": "登入"
+    "other": "登入"
   },
   "combined_auth_signup": {
-   "other": "建立帳號"
+    "other": "建立帳號"
   },
   "combined_auth_signin_password": {
-   "other": "請輸入您的密碼登入帳號"
+    "other": "請輸入您的密碼登入帳號"
   },
   "combined_auth_signin_error_incorrect_credentials": {
-   "other": "密碼輸入錯誤"
+    "other": "密碼輸入錯誤"
   },
   "combined_auth_error_forbidden": {
-   "other": "發生錯誤"
+    "other": "發生錯誤"
   },
   "combined_auth_error_too_many_requests": {
     "other": "請求過多，請稍後重試。"
   },
   "forgotpassword_page_header": {
-   "other": "重設密碼"
+    "other": "重設密碼"
   },
   "forgotpassword_form_email": {
-   "other": "電子郵件"
+    "other": "電子郵件"
   },
   "forgotpassword_form_submit": {
-   "other": "重設"
+    "other": "重設"
   },
   "forgotpassword_form_error_email_doesnt_exist": {
-   "other": "此電子郵件無對應的帳號。"
+    "other": "此電子郵件無對應的帳號。"
   },
   "forgotpassword_form_error_account_suspended": {
-   "other": "此帳號已暫停使用。"
+    "other": "此帳號已暫停使用。"
   },
   "forgotpassword_complete": {
-   "other": "謝謝，請至您的個人信箱收取「重設密碼」通知。"
+    "other": "謝謝，請至您的個人信箱收取「重設密碼」通知。"
   },
   "forgotpassword_form_error_forbidden": {
-   "other": "發生錯誤"
+    "other": "發生錯誤"
   },
   "forgotpassword_form_error_too_many_requests": {
     "other": "請求過多，請稍後重試。"
   },
   "resetpassword_page_header": {
-   "other": "變更密碼"
+    "other": "變更密碼"
   },
   "resetpassword_form_invalid_reset_password_token": {
-   "other": "重設密碼失敗，請點選 <a href=\"{{.URL}}\">忘記密碼</a>重新申請"
+    "other": "重設密碼失敗，請點選 <a href=\"{{.URL}}\">忘記密碼</a>重新申請"
   },
   "resetpassword_form_password": {
-   "other": "新密碼"
+    "other": "新密碼"
   },
   "resetpassword_form_password2": {
-   "other": "再次確認新密碼"
+    "other": "再次確認新密碼"
   },
   "resetpassword_form_submit": {
-   "other": "變更"
+    "other": "變更"
   },
   "resetpassword_complete": {
-   "other": "謝謝，密碼已變更，系統已將您重新登入。"
+    "other": "謝謝，密碼已變更，系統已將您重新登入。"
   },
   "resetpassword_form_error_invalid_reset_password_token": {
-   "other": "重設密碼失敗，請稍後再試。"
+    "other": "重設密碼失敗，請稍後再試。"
   },
   "resetpassword_form_error_reset_password_token_expired": {
-   "other": "「重設密碼」申請已失效，請重新申請。"
+    "other": "「重設密碼」申請已失效，請重新申請。"
   },
   "resetpassword_form_error_too_many_requests": {
     "other": "請求過多，請稍後重試。"
   },
   "account_page_header": {
-   "other": "我的帳號"
+    "other": "我的帳號"
   },
   "account_form_name": {
-   "other": "姓名"
+    "other": "姓名"
   },
   "account_form_email": {
-   "other": "電子郵件"
+    "other": "電子郵件"
   },
   "account_form_password": {
-   "other": "密碼"
+    "other": "密碼"
   },
   "account_form_change_password": {
-   "other": "變更"
+    "other": "變更"
   },
   "account_form_gender": {
-   "other": "性別"
+    "other": "性別"
   },
   "account_form_dob": {
-   "other": "生日"
+    "other": "生日"
   },
   "account_form_submit": {
-   "other": "更新"
+    "other": "更新"
   },
   "account_form_submitted": {
-   "other": "已更新"
+    "other": "已更新"
   },
   "account_form_password_changed": {
-   "other": "密碼已更新"
+    "other": "密碼已更新"
   },
   "account_form_error_incorrect_password": {
-   "other": "密碼錯誤"
+    "other": "密碼錯誤"
   },
   "account_form_pin_code": {
-   "other": "PIN碼"
+    "other": "PIN碼"
   },
   "account_form_pin_code_not_set": {
-   "other": "未設定PIN碼。請設定PIN碼以購買、租借和觀看影片。"
+    "other": "未設定PIN碼。請設定PIN碼以購買、租借和觀看影片。"
   },
   "account_form_set_pin": {
-   "other": "設定PIN碼"
+    "other": "設定PIN碼"
   },
   "account_form_pin_changed": {
-   "other": "已更新"
+    "other": "已更新"
   },
   "account_form_change_pin": {
-   "other": "變更PIN碼"
+    "other": "變更PIN碼"
   },
   "user_set_pin_header": {
-   "other": "設定PIN碼"
+    "other": "設定PIN碼"
   },
   "user_set_pin_button": {
-   "other": "設定PIN碼"
+    "other": "設定PIN碼"
   },
   "user_submit_pin_heading": {
-   "other": "為此專屬內容 {{.Action}} 設定PIN碼"
+    "other": "為此專屬內容 {{.Action}} 設定PIN碼"
   },
   "user_error_wrong_pin_retry": {
-   "other": "輸入PIN碼錯誤"
+    "other": "輸入PIN碼錯誤"
   },
   "user_error_too_many_pin_errors": {
-   "other": "<p>PIN碼多次輸入錯誤。</p><p>請重設PIN碼或與我們聯繫 <a href=\"{{.HelpURL}}\" target=\"_blank\">幫助</a>"
+    "other": "<p>PIN碼多次輸入錯誤。</p><p>請重設PIN碼或與我們聯繫 <a href=\"{{.HelpURL}}\" target=\"_blank\">幫助</a>"
   },
   "user_submit_pin_button": {
-   "other": "輸入"
+    "other": "輸入"
   },
   "user_reset_pin_button": {
-   "other": "重設PIN碼"
+    "other": "重設PIN碼"
   },
   "signup_form_optin": {
-   "other": "訂閱電子報"
+    "other": "訂閱電子報"
   },
   "passwordconfirmation_modal_header": {
-   "other": "確認密碼"
+    "other": "確認密碼"
   },
   "passwordconfirmation_modal_label": {
-   "other": "請輸入密碼來更新資訊"
+    "other": "請輸入密碼來更新資訊"
   },
   "passwordconfirmation_modal_confirm": {
-   "other": "確認"
+    "other": "確認"
   },
   "changepassword_modal_header": {
-   "other": "變更密碼"
+    "other": "變更密碼"
   },
   "changepassword_modal_currentpassword": {
-   "other": "目前密碼"
+    "other": "目前密碼"
   },
   "changepassword_modal_password": {
-   "other": "新密碼"
+    "other": "新密碼"
   },
   "changepassword_modal_password2": {
-   "other": "再次確認新密碼"
+    "other": "再次確認新密碼"
   },
   "changepassword_modal_submit": {
-   "other": "更新"
+    "other": "更新"
   },
   "changepassword_modal_error_incorrect_password": {
-   "other": "密碼錯誤"
+    "other": "密碼錯誤"
   },
   "userlibrary_page_header": {
-   "other": "已付費影片"
+    "other": "已付費影片"
   },
   "userlibrary_empty_header": {
-   "other": "尚無任何影片。"
+    "other": "尚無任何影片。"
   },
   "userlibrary_empty_content": {
-   "other": "歡迎至 <a href=\"{{.HomeURL}}\">首頁</a> 瀏覽影展精選片單 。"
+    "other": "歡迎至 <a href=\"{{.HomeURL}}\">首頁</a> 瀏覽影展精選片單 。"
   },
   "searchresults_page_header": {
-   "other": "搜尋結果"
+    "other": "搜尋結果"
   },
   "searchresults_load_more": {
-   "other": "顯示 {{.Count}} 更多"
+    "other": "顯示 {{.Count}} 更多"
   },
   "searchresults_total": {
-   "one": "找到1個符合 \"{{.Query}}\"的結果。",
-   "other": "找到 {{.Count}} 個符合 \"{{.Query}}\"的結果。"
+    "one": "找到1個符合 \"{{.Query}}\"的結果。",
+    "other": "找到 {{.Count}} 個符合 \"{{.Query}}\"的結果。"
   },
   "searchresults_empty_header": {
-   "other": "沒有符合 \"{{.Query}}\"的結果"
+    "other": "沒有符合 \"{{.Query}}\"的結果"
   },
   "searchresults_empty_content": {
-   "other": "請嘗試其他搜尋，或回到<a href=\"{{.HomeURL}}\">首頁</a> 瀏覽影展精選片單 。"
+    "other": "請嘗試其他搜尋，或回到<a href=\"{{.HomeURL}}\">首頁</a> 瀏覽影展精選片單 。"
   },
   "validation_name_required": {
-   "other": "請輸入姓名"
+    "other": "請輸入姓名"
   },
   "validation_email_required": {
-   "other": "請輸入電子郵件"
+    "other": "請輸入電子郵件"
   },
   "validation_email_email": {
-   "other": "請輸入有效的電子郵件"
+    "other": "請輸入有效的電子郵件"
   },
   "validation_currentpassword_required": {
-   "other": "請輸入目前使用的密碼"
+    "other": "請輸入目前使用的密碼"
   },
   "validation_password_required": {
-   "other": "請輸入密碼"
+    "other": "請輸入密碼"
   },
   "validation_password2_required": {
-   "other": "請再次輸入密碼"
+    "other": "請再次輸入密碼"
   },
   "validation_password2_match": {
-   "other": "密碼不符，請重新輸入"
+    "other": "密碼不符，請重新輸入"
   },
   "validation_password_minlength": {
-   "other": "請至少輸入 {{.Count}} 碼"
+    "other": "請至少輸入 {{.Count}} 碼"
   },
   "validation_promocode_required": {
-   "other": "請輸入兌換碼"
+    "other": "請輸入兌換碼"
   },
   "validation_pincode_required": {
-   "other": "請輸入PIN碼"
+    "other": "請輸入PIN碼"
   },
   "validation_pincode1_required": {
-   "other": "請輸入有效PIN碼"
+    "other": "請輸入有效PIN碼"
   },
   "validation_pincode2_required": {
-   "other": "請輸入有效PIN碼"
+    "other": "請輸入有效PIN碼"
   },
   "validation_pincode1_pattern": {
-   "other": "請輸入有效PIN碼"
+    "other": "請輸入有效PIN碼"
   },
   "validation_pincode2_pattern": {
-   "other": "請輸入有效的PIN碼"
+    "other": "請輸入有效的PIN碼"
   },
   "validation_pincode2_match": {
-   "other": "輸入的PIN碼不符"
+    "other": "輸入的PIN碼不符"
   },
   "validation_gender_required": {
-   "other": "請選擇您的性別"
+    "other": "請選擇您的性別"
   },
   "validation_dob_required": {
-   "other": "請輸入您的生日"
+    "other": "請輸入您的生日"
   },
   "validation_dob_date": {
-   "other": "請輸入有效的生日日期"
+    "other": "請輸入有效的生日日期"
   },
   "shopping_info_subtitle_hd": {
-   "other": "提供HD畫質"
+    "other": "提供HD畫質"
   },
   "shopping_info_subtitle_sd": {
-   "other": "提供SD畫質"
+    "other": "提供SD畫質"
   },
   "shopping_info_subtitle_wallet": {
-   "other": "錢包中的金額可用來購買或租借SreenPlus的內容。"
+    "other": "錢包中的金額可用來購買或租借SreenPlus的內容。"
   },
   "shopping_info_subtitle_help": {
-   "other": "點此查看裝置及系統需求"
+    "other": "點此查看裝置及系統需求"
   },
   "shopping_info_ownership_buy": {
-   "other": "購買"
+    "other": "購買"
   },
   "shopping_info_ownership_rent": {
-   "other": "租借"
+    "other": "租借"
   },
   "shopping_info_sd_only": {
-   "other": "僅限以SD畫質播放"
+    "other": "僅限以SD畫質播放"
   },
   "shopping_info_release_date_title": {
-   "other": "上線日期 {{.Date}}. "
+    "other": "上線日期 {{.Date}}. "
   },
   "shopping_info_release_date_explanation_rent": {
-   "other": "可先租借，並於影片上線後開始觀看。"
+    "other": "可先租借，並於影片上線後開始觀看。"
   },
   "shopping_info_release_date_explanation_buy": {
-   "other": "可先購買，並於影片上線後開始觀看。"
+    "other": "可先購買，並於影片上線後開始觀看。"
   },
   "shopping_info_available_until_date_title": {
-   "other": "影片可觀看至 {{.Date}}. "
+    "other": "影片可觀看至 {{.Date}}. "
   },
   "shopping_info_available_until_date_explanation_rent": {
-   "other": "影片下線後將無法觀看。"
+    "other": "影片下線後將無法觀看。"
   },
   "shopping_info_available_until_date_explanation_buy": {
-   "other": "影片下線後將無法觀看。"
+    "other": "影片下線後將無法觀看。"
   },
-  "duration_hour": { "one": "1小時", "other": "{{.Count}}個小時" },
-  "duration_day": { "one": "1天", "other": "{{.Count}}天" },
+  "duration_hour": {
+    "one": "1小時",
+    "other": "{{.Count}}個小時"
+  },
+  "duration_day": {
+    "one": "1天",
+    "other": "{{.Count}}天"
+  },
   "shopping_info_rental_period_duration": {
-   "other": "租借天數 {{.ValueUnit}} "
+    "other": "租借天數 {{.ValueUnit}} "
   },
   "shopping_info_watch_window_duration": {
-   "other": "觀影期限 {{.Count}} 小時。  "
+    "other": "觀影期限 {{.Count}} 小時。  "
   },
   "shopping_info_watch_window_explanation_film": {
-   "one": "完成租借後，影片將在帳號中保留 {{.ValueUnit}}。",
-   "other": "完成租借後，影片將在帳號中保留 {{.ValueUnit}}。"
+    "one": "完成租借後，影片將在帳號中保留 {{.ValueUnit}}。",
+    "other": "完成租借後，影片將在帳號中保留 {{.ValueUnit}}。"
   },
   "shopping_info_watch_window_explanation2_film": {
-   "one": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 1 小時內無限次觀看。",
-   "other": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 {{.Count}} 小時內無限次觀看。"
+    "one": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 1 小時內無限次觀看。",
+    "other": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 {{.Count}} 小時內無限次觀看。"
   },
   "shopping_info_watch_window_explanation_bundle": {
-   "one": "完成租借後，影片合輯將於帳號中保留 1 天。",
-   "other": "完成租借後，影片合輯將於帳號中保留 {{.Count}} 天。"
+    "one": "完成租借後，影片合輯將於帳號中保留 1 天。",
+    "other": "完成租借後，影片合輯將於帳號中保留 {{.Count}} 天。"
   },
   "shopping_info_watch_window_explanation2_bundle": {
-   "one": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 1 小時內無限次觀看。",
-   "other": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 {{.Count}} 小時內無限次觀看。"
+    "one": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 1 小時內無限次觀看。",
+    "other": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 {{.Count}} 小時內無限次觀看。"
   },
   "shopping_info_watch_window_explanation_season": {
-   "one": "完成租借後，影集將於帳號中保留 1 天。",
-   "other": "完成租借後，影集將於帳號中保留 {{.Count}} 天。"
+    "one": "完成租借後，影集將於帳號中保留 1 天。",
+    "other": "完成租借後，影集將於帳號中保留 {{.Count}} 天。"
   },
   "shopping_info_watch_window_explanation2_season": {
-   "one": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 1 小時內無限次觀看。",
-   "other": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 {{.Count}} 小時內無限次觀看。"
+    "one": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 1 小時內無限次觀看。",
+    "other": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 {{.Count}} 小時內無限次觀看。"
   },
   "shopping_info_credit_bonus_title": {
-   "other": "折扣{{.BonusPercentage}}%"
+    "other": "折扣{{.BonusPercentage}}%"
   },
   "shopping_enter_card_prompt": {
-   "other": "請輸入信用卡資訊，以完成 {{.Verb}}。"
+    "other": "請輸入信用卡資訊，以完成 {{.Verb}}。"
   },
   "shopping_terms": {
-   "other": "完成付款時，即代表您已同意本站 <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">使用者服務條款</a>."
+    "other": "完成付款時，即代表您已同意本站 <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\" tabindex=\"-1\">使用者服務條款</a>."
   },
   "shopping_discount_applied": {
-   "other": "已折扣 {{.DiscountAmount}} "
+    "other": "已折扣 {{.DiscountAmount}} "
   },
   "shopping_discount_apply": {
-   "other": "兌換"
+    "other": "兌換"
   },
   "shopping_discount_code": {
-   "other": "輸入兌換碼"
+    "other": "輸入兌換碼"
   },
   "shopping_discount_have_code": {
-   "other": "我有兌換碼"
+    "other": "我有兌換碼"
   },
   "shopping_price_you_pay": {
-   "other": "您將支付"
+    "other": "您將支付"
   },
   "shopping_price_nothing": {
-   "other": "無項目"
+    "other": "無項目"
   },
   "shopping_price_free": {
-   "other": "免費"
+    "other": "免費"
   },
   "shopping_auth_directions": {
-   "other": "請先登入。於下方輸入電子郵件。"
+    "other": "請先登入。於下方輸入電子郵件。"
   },
   "shopping_error_in_library": {
-   "other": "{{.Title}} 已在您的已付費影片。"
+    "other": "{{.Title}} 已在您的已付費影片。"
   },
   "shopping_error_missing_card": {
-   "other": "請輸入信用卡資訊"
+    "other": "請輸入信用卡資訊"
   },
   "shopping_error_title": {
-   "other": "發生錯誤"
+    "other": "發生錯誤"
   },
   "shopping_error_incorrect_cvc": {
-   "other": "請輸入有效的CVV"
+    "other": "請輸入有效的CVV"
   },
   "shopping_error_invalid_cvc": {
-   "other": "請輸入有效的CVV"
+    "other": "請輸入有效的CVV"
   },
   "shopping_error_incorrect_number": {
-   "other": "請輸入有效的信用卡卡號"
+    "other": "請輸入有效的信用卡卡號"
   },
   "shopping_error_invalid_number": {
-   "other": "請輸入有效的信用卡卡號"
+    "other": "請輸入有效的信用卡卡號"
   },
   "shopping_error_card_declined": {
-   "other": "信用卡遭拒絕"
+    "other": "信用卡遭拒絕"
   },
   "shopping_error_invalid_expiry_month": {
-   "other": "請輸入正確的有效日期"
+    "other": "請輸入正確的有效日期"
   },
   "shopping_error_invalid_expiry_year": {
-   "other": "請輸入正確的有效日期"
+    "other": "請輸入正確的有效日期"
   },
   "shopping_error_expired_card": {
-   "other": "此信用卡已過效期"
+    "other": "此信用卡已過效期"
   },
   "shopping_error_creditcard_country_mismatch": {
-   "other": "{{.Ownership}} 未完成。請使用所在地區核發之有效信用卡進行支付，或使用其他卡片完成付款。"
+    "other": "{{.Ownership}} 未完成。請使用所在地區核發之有效信用卡進行支付，或使用其他卡片完成付款。"
   },
   "shopping_error_proxy_detected": {
-   "other": "{{.Ownership}} 未完成。已偵測到使用代理或遠端伺服器。請先將任何相關服務關閉。"
+    "other": "{{.Ownership}} 未完成。已偵測到使用代理或遠端伺服器。請先將任何相關服務關閉。"
   },
   "shopping_error_discount_worn_out": {
-   "other": "此兌換碼已失效"
+    "other": "此兌換碼已失效"
   },
   "shopping_error_discount_blank": {
-   "other": "請輸入兌換碼"
+    "other": "請輸入兌換碼"
   },
   "shopping_error_discount_not_applied": {
-   "other": "請輸入有效的兌換碼"
+    "other": "請輸入有效的兌換碼"
   },
   "shopping_error_discount_invalid": {
-   "other": "請輸入有效的兌換碼"
+    "other": "請輸入有效的兌換碼"
   },
   "shopping_error_discount_disabled": {
-   "other": "請輸入有效的兌換碼"
+    "other": "請輸入有效的兌換碼"
   },
   "shopping_error_discount_already_applied": {
-   "other": "此兌換碼已在此項目使用"
+    "other": "此兌換碼已在此項目使用"
   },
   "shopping_error_discount_already_redeemed": {
-   "other": "此兌換碼已被使用"
+    "other": "此兌換碼已被使用"
   },
   "shopping_error_discount_used_previously": {
-   "other": "此兌換碼已被使用"
+    "other": "此兌換碼已被使用"
   },
   "shopping_error_discount_max_limit": {
-   "other": "此兌換碼已失效"
+    "other": "此兌換碼已失效"
   },
   "shopping_error_discount_expired": {
-   "other": "此兌換碼已過期"
+    "other": "此兌換碼已過期"
   },
   "shopping_error_discount_invalid_ownership_buy": {
-   "other": "此兌換碼無法於購買時使用"
+    "other": "此兌換碼無法於購買時使用"
   },
   "shopping_error_discount_invalid_ownership_rent": {
-   "other": "此兌換碼無法於租借時使用"
+    "other": "此兌換碼無法於租借時使用"
   },
   "shopping_error_discount_invalid_item": {
-   "other": "此兌換碼無法於此項目使用"
+    "other": "此兌換碼無法於此項目使用"
   },
   "shopping_error_discount_invalid_pricing_region": {
-   "other": "所在地區無法使用此兌換碼"
+    "other": "所在地區無法使用此兌換碼"
   },
   "shopping_error_discounts_not_allowed": {
-   "other": "此兌換碼無法使用"
+    "other": "此兌換碼無法使用"
   },
   "shopping_error_discount_disallowed_on_bundles": {
-   "other": "此兌換碼無法用於影片合輯"
+    "other": "此兌換碼無法用於影片合輯"
   },
   "shopping_error_payment_intent_authentication_failure": {
-   "other": "輸入的信用卡遭拒絕。請再試一次。"
+    "other": "輸入的信用卡遭拒絕。請再試一次。"
   },
   "shopping_complete_rental": {
-   "other": "付費成功！"
+    "other": "付費成功！"
   },
   "shopping_complete_rental_period": {
-   "one": "可於 1 天內無限次觀看。",
-   "other": "可於 {{.Count}} 天內無限次觀看。"
+    "one": "可於 1 天內無限次觀看。",
+    "other": "可於 {{.Count}} 天內無限次觀看。"
   },
   "shopping_complete_purchase": {
-   "other": "感謝您付費觀賞 {{.Title}}。"
+    "other": "感謝您付費觀賞 {{.Title}}。"
   },
   "shopping_complete_credit_purchase": {
-   "other": "{{.Title}}已完成付費，{{.CreditTotal}} 已加入您的帳號。"
+    "other": "{{.Title}}已完成付費，{{.CreditTotal}} 已加入您的帳號。"
   },
   "shopping_complete_purchase_coming_soon": {
-   "other": "您可於 {{.Date}} 後開始觀看。"
+    "other": "您可於 {{.Date}} 後開始觀看。"
   },
   "shopping_complete_receipt": {
-   "other": "收據已透過電子郵件發送至您的信箱。"
+    "other": "收據已透過電子郵件發送至您的信箱。"
   },
   "shopping_complete_library_link": {
-   "other": "瀏覽已付費影片"
+    "other": "瀏覽已付費影片"
   },
   "shopping_complete_plan": {
     "other": "您已成功{{ .Title }}"
-  },  
+  },
   "shopping_complete_rental_watch_window_start": {
-   "one": "可於 1 天內開始觀看。",
-   "other": "您可於 {{.Count}} 天內開始觀看。"
+    "one": "可於 1 天內開始觀看。",
+    "other": "您可於 {{.Count}} 天內開始觀看。"
   },
   "shopping_complete_rental_watch_window_end": {
-   "one": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 1 小時內無限次觀看。",
-   "other": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 {{.Count}} 小時內無限次觀看。"
+    "one": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 1 小時內無限次觀看。",
+    "other": "觀影期限，將由進入播放視窗按下「播放」開始計算，可於 {{.Count}} 小時內無限次觀看。"
   },
   "shopping_complete_rental_coming_soon": {
-   "one": "可於 {{.Date}} 後開始觀看影片，租借天數還有1天。",
-   "other": "可於 {{.Date}} 後開始觀看影片，租借天數還有 {{.Count}} 天。"
+    "one": "可於 {{.Date}} 後開始觀看影片，租借天數還有1天。",
+    "other": "可於 {{.Date}} 後開始觀看影片，租借天數還有 {{.Count}} 天。"
   },
   "shopping_complete_rental_coming_soon_watch_window_start": {
-   "one": "可於 {{.Date}} 後開始觀看影片，租借天數還有1天。",
-   "other": "可於 {{.Date}} 後開始觀看影片，租借天數還有 {{.Count}} 天。"
+    "one": "可於 {{.Date}} 後開始觀看影片，租借天數還有1天。",
+    "other": "可於 {{.Date}} 後開始觀看影片，租借天數還有 {{.Count}} 天。"
   },
   "shopping_action_rent": {
-   "other": "租借"
+    "other": "租借"
   },
   "shopping_action_buy": {
-   "other": "購買"
+    "other": "購買"
   },
   "shopping_payment_method_header": {
-   "other": "付款方式"
+    "other": "付款方式"
   },
   "shopping_payment_method_credit_card": {
-   "other": "信用卡"
+    "other": "信用卡"
   },
   "shopping_payment_method_giropay": {
-   "other": "Giropay"
+    "other": "Giropay"
   },
   "shopping_error_stripe_unknown_error": {
-   "other": "付款時發生問題，請稍後再試。"
+    "other": "付款時發生問題，請稍後再試。"
   },
   "shopping_error_payment_complete_failed": {
-   "other": "付款被拒絕，請關掉視窗後再重試。"
+    "other": "付款被拒絕，請關掉視窗後再重試。"
   },
   "meta_detail_cast_title": {
-   "other": "演員"
+    "other": "演員"
   },
   "meta_detail_crew_title": {
-   "other": "工作人員"
+    "other": "工作人員"
   },
   "meta_detail_languages": {
-   "one": "語言",
-   "other": "語言"
+    "one": "語言",
+    "other": "語言"
   },
   "meta_detail_studios": {
-   "one": "片商",
-   "other": "片商"
+    "one": "片商",
+    "other": "片商"
   },
   "meta_detail_countries": {
-   "one": "地區",
-   "other": "地區"
+    "one": "地區",
+    "other": "地區"
   },
   "meta_detail_subtitles": {
-   "other": "字幕"
+    "other": "字幕"
   },
-  "meta_detail_captions": { "other": "字幕 [CC]" },
+  "meta_detail_captions": {
+    "other": "字幕 [CC]"
+  },
   "meta_detail_episodes_title": {
-   "other": "集數"
+    "other": "集數"
   },
   "meta_detail_bonus_title": {
-   "other": "相關花絮"
+    "other": "相關花絮"
   },
   "meta_detail_recommendations_title": {
-   "other": "您也許也會喜歡"
+    "other": "您也許也會喜歡"
   },
   "meta_detail_bundle_items_title": {
-   "other": "此影片合輯包括以下內容"
+    "other": "此影片合輯包括以下內容"
   },
   "bundle_items_all_films": {
-   "other": "共 {{.Count}} 部影片"
+    "other": "共 {{.Count}} 部影片"
   },
   "bundle_items_all_seasons": {
-   "other": "共 {{.Count}} 部影集"
+    "other": "共 {{.Count}} 部影集"
   },
   "bundle_items_mixed": {
-   "other": "共 {{.Count}} 部影片與影集"
+    "other": "共 {{.Count}} 部影片與影集"
   },
   "userwishlist_page_header": {
-   "other": "我的追蹤片單"
+    "other": "我的追蹤片單"
   },
   "userwishlist_slider_header": {
-   "other": "我的追蹤片單"
+    "other": "我的追蹤片單"
   },
   "userwishlist_empty_header": {
-   "other": "尚無任何影片。"
+    "other": "尚無任何影片。"
   },
   "userwishlist_empty_content": {
-   "other": "歡迎至 <a href=\"{{.HomeURL}}\">首頁</a> 瀏覽影展精選片單 。"
+    "other": "歡迎至 <a href=\"{{.HomeURL}}\">首頁</a> 瀏覽影展精選片單 。"
   },
   "userwishlist_button_add": {
-   "other": "加入我的追蹤片單"
+    "other": "加入我的追蹤片單"
   },
   "userwishlist_button_remove": {
-   "other": "我的追蹤片單"
+    "other": "我的追蹤片單"
   },
   "userwishlist_button_add_compact": {
-   "other": "我的追蹤片單"
+    "other": "我的追蹤片單"
   },
   "userwishlist_button_remove_compact": {
-   "other": "我的追蹤片單"
+    "other": "我的追蹤片單"
   },
   "activatedevice_page_header": {
-   "other": "可使用裝置"
+    "other": "可使用裝置"
   },
   "activatedevice_page_content": {
-   "other": "請依照指示取得PIN碼，並確認電腦與裝置皆已連上可用網路。"
+    "other": "請依照指示取得PIN碼，並確認電腦與裝置皆已連上可用網路。"
   },
   "activatedevice_form_pin": {
-   "other": "PIN碼"
+    "other": "PIN碼"
   },
   "activatedevice_form_submit": {
-   "other": "啟用"
+    "other": "啟用"
   },
   "activatedevice_form_error_invalid_code": {
-   "other": "PIN碼錯誤，請重新輸入"
+    "other": "PIN碼錯誤，請重新輸入"
   },
   "activatedevice_form_error_pin_not_found": {
-   "other": "PIN碼錯誤，請重新輸入"
+    "other": "PIN碼錯誤，請重新輸入"
   },
   "activatedevice_signin_prompt": {
-   "other": "請先登入再啟動播放裝置"
+    "other": "請先登入再啟動播放裝置"
   },
   "activatedevice_page_activated": {
-   "other": "{{.DeviceName}}已啟用。請使用此裝置開始觀賞影片。"
+    "other": "{{.DeviceName}}已啟用。請使用此裝置開始觀賞影片。"
   },
   "userdevices_page_header": {
-   "other": "我的播放裝置"
+    "other": "我的播放裝置"
   },
   "userdevices_page_content": {
-   "one": "播放裝置將於使用時自動加入，您最多可使用 1 個裝置。",
-   "other": "播放裝置將於使用時自動加入，您最多可使用 {{.Count}} 個裝置。"
+    "one": "播放裝置將於使用時自動加入，您最多可使用 1 個裝置。",
+    "other": "播放裝置將於使用時自動加入，您最多可使用 {{.Count}} 個裝置。"
   },
   "userdevices_empty_content": {
-   "other": "目前尚未加入任何裝置"
+    "other": "目前尚未加入任何裝置"
   },
   "userdevices_header_type": {
-   "other": "裝置類型"
+    "other": "裝置類型"
   },
   "userdevices_header_description": {
-   "other": "裝置內容"
+    "other": "裝置內容"
   },
   "userdevices_device_added": {
-   "other": "於 {{.Date}} 加入"
+    "other": "於 {{.Date}} 加入"
   },
   "userdevices_device_actions_delete": {
-   "other": "移除"
+    "other": "移除"
   },
   "userdevices_device_actions_cancel": {
-   "other": "取消"
+    "other": "取消"
   },
   "userdevices_device_actions_confirm": {
-   "other": "是，移除裝置"
+    "other": "是，移除裝置"
   },
   "userdevices_device_deleted": {
-   "other": "（裝置已移除）"
+    "other": "（裝置已移除）"
   },
   "userdevices_delete_limits": {
-   "other": "您可於每 {{.Period}} 日，移除 {{.Limit}} 項裝置。"
+    "other": "您可於每 {{.Period}} 日，移除 {{.Limit}} 項裝置。"
   },
   "userdevices_delete_limit_reached": {
-   "other": "加入的裝置數已達上限，目前無法移除裝置，請於 {{.Days}} 日後移除裝置。"
+    "other": "加入的裝置數已達上限，目前無法移除裝置，請於 {{.Days}} 日後移除裝置。"
   },
   "playlist_page_header": {
-   "other": "播放清單"
+    "other": "播放清單"
   },
   "playlist_sign_in_warning": {
-   "other": "請先登入以觀賞直播。"
+    "other": "請先登入以觀賞直播。"
   },
   "playlist_share_title": {
-   "other": "播放清單"
+    "other": "播放清單"
   },
   "playlist_up_next_title": {
-   "other": "下一部"
+    "other": "下一部"
   },
   "pricing_ownership_buy": {
-   "other": "購買"
+    "other": "購買"
   },
   "pricing_ownership_rent": {
-   "other": "租借"
+    "other": "租借"
   },
   "classification_intro": {
-   "other": "評分：  "
+    "other": "評分：  "
   },
   "classification_divider": {
-   "other": " - "
+    "other": " - "
   },
   "classification_outro": {
-   "other": ""
+    "other": ""
   },
   "cookie_banner_message": {
-   "other": "本網站採用Cookies以提供您更流暢的用戶/上網體驗，繼續使用本網站，即表示您同意我們的<a href=\"{{.CookiePolicyURL}}\">Cookie相關使用條例</a>。"
+    "other": "本網站採用Cookies以提供您更流暢的用戶/上網體驗，繼續使用本網站，即表示您同意我們的<a href=\"{{.CookiePolicyURL}}\">Cookie相關使用條例</a>。"
   },
   "cookie_banner_accept": {
-   "other": "接受"
+    "other": "接受"
   },
   "all_rights_reserved": {
-   "other": "版權所有，本網站未經書面同意禁止重製。"
+    "other": "版權所有，本網站未經書面同意禁止重製。"
   },
   "users_gender_none": {
-   "other": "未定"
+    "other": "未定"
   },
   "users_gender_female": {
-   "other": "女"
+    "other": "女"
   },
   "users_gender_male": {
-   "other": "男"
+    "other": "男"
   },
   "users_gender_diverse": {
-   "other": "多元"
+    "other": "多元"
   },
   "users_gender_other": {
-   "other": "其他"
+    "other": "其他"
   },
   "pricing_quality_hd": {
-   "other": "HD"
+    "other": "HD"
   },
   "pricing_quality_sd": {
-   "other": "SD"
+    "other": "SD"
   },
   "pricing_quality_hd_only": {
-   "other": "HD 只要"
+    "other": "HD 只要"
   },
   "pricing_quality_sd_only": {
-   "other": "SD 只要"
+    "other": "SD 只要"
   },
   "shopping_card_save_card": {
-   "other": "儲存此信用卡資訊，供日後使用"
+    "other": "儲存此信用卡資訊，供日後使用"
   },
   "shopping_card_button_change": {
-   "other": "顯示所有已儲存的信用卡"
+    "other": "顯示所有已儲存的信用卡"
   },
   "shopping_card_existing_description": {
-   "other": "{{.Card.Brand}} 末碼為 {{.Card.Number}}"
+    "other": "{{.Card.Brand}} 末碼為 {{.Card.Number}}"
   },
   "shopping_card_existing_expiry": {
-   "other": "（於 {{.Card.Expiry}} 失效）"
+    "other": "（於 {{.Card.Expiry}} 失效）"
   },
   "shopping_card_existing_expired": {
-   "other": "（已過期）"
+    "other": "（已過期）"
   },
   "shopping_card_use_other": {
-   "other": "使用新的信用卡"
+    "other": "使用新的信用卡"
   },
   "shopping_card_use_new_card": {
-   "other": "換一張信用卡"
+    "other": "換一張信用卡"
   },
   "shopping_card_update_reason_none": {
-   "other": "此信用卡無法更新"
+    "other": "此信用卡無法更新"
   },
   "shopping_card_new_subscription": {
-   "other": "此信用卡已儲存，將依照您的使用進行付款"
+    "other": "此信用卡已儲存，將依照您的使用進行付款"
   },
   "shopping_card_change": {
-   "other": "信用卡錯誤 <a href=\"{{.SubscriptionsURL}}\">請按此更新。</a>"
+    "other": "信用卡錯誤 <a href=\"{{.SubscriptionsURL}}\">請按此更新。</a>"
   },
   "shopping_info_ownership_plan": {
-   "other": "訂閱"
+    "other": "訂閱"
   },
   "shopping_action_credit": {
-   "other": "頂尖"
+    "other": "頂尖"
   },
   "shopping_info_rental_period_coming_soon": {
-   "other": "自上架時間起"
+    "other": "自上架時間起"
   },
-  "usersubscriptions_change_payment_method_change": { "other": "改變信用卡" },
-  "usersubscriptions_change_payment_method_modal_title": { "other": "更新信用卡詳細信息" },
-  "usersubscriptions_change_payment_method_modal_submit": { "other": "更新" },
-
-  "usersubscriptions_subscription_expiry": { "other": "到期 {{.Expiry}}" },
-  "usersubscriptions_subscription_status_trialing": { "other": "試用期" },
-  "usersubscriptions_subscription_unsubscribe": { "other": "取消我的訂閱" },
-  "usersubscriptions_unsubscribe_modal_cancel": { "other": "取消" },
-  "usersubscriptions_unsubscribe_modal_confirm": { "other": "是的，取消我的訂閱" },
-  "usersubscriptions_unsubscribe_modal_title": { "other": "取消訂閱？" },
-  "usersubscriptions_unsubscribe_modal_body": { "other": "這將取消訂閱 {{.Name}} 計劃. 您仍然能夠在計劃到期之前觀看計劃中的內容 {{.Expiry}}." },
-
+  "usersubscriptions_change_payment_method_change": {
+    "other": "改變信用卡"
+  },
+  "usersubscriptions_change_payment_method_modal_title": {
+    "other": "更新信用卡詳細信息"
+  },
+  "usersubscriptions_change_payment_method_modal_submit": {
+    "other": "更新"
+  },
+  "usersubscriptions_subscription_expiry": {
+    "other": "到期 {{.Expiry}}"
+  },
+  "usersubscriptions_subscription_status_trialing": {
+    "other": "試用期"
+  },
+  "usersubscriptions_subscription_unsubscribe": {
+    "other": "取消我的訂閱"
+  },
+  "usersubscriptions_unsubscribe_modal_cancel": {
+    "other": "取消"
+  },
+  "usersubscriptions_unsubscribe_modal_confirm": {
+    "other": "是的，取消我的訂閱"
+  },
+  "usersubscriptions_unsubscribe_modal_title": {
+    "other": "取消訂閱？"
+  },
+  "usersubscriptions_unsubscribe_modal_body": {
+    "other": "這將取消訂閱 {{.Name}} 計劃. 您仍然能夠在計劃到期之前觀看計劃中的內容 {{.Expiry}}."
+  },
   "availability_coming_soon": {
-   "other": "即將播映"
+    "other": "即將播映"
   },
   "availability_renting": {
-   "other": "租借中"
+    "other": "租借中"
   },
   "availability_not_available": {
-   "other": "無法觀看"
+    "other": "無法觀看"
   },
   "availability_in_watch_window": {
-   "other": "可觀看"
+    "other": "可觀看"
   },
   "availability_sold_out": {
-   "other": "售完"
+    "other": "售完"
   },
   "availability_available_till": {
-   "other": "可觀看至 {{.ExpiryDate}}"
+    "other": "可觀看至 {{.ExpiryDate}}"
   },
   "availability_not_available_in_country": {
-   "other": "您的所在地區無法觀看"
+    "other": "您的所在地區無法觀看"
   },
   "availability_available": {
-   "other": "將於 {{.ReleaseDate}} 上線"
+    "other": "將於 {{.ReleaseDate}} 上線"
   },
   "availability_expires": {
-   "other": "將於 {{.Expiry}} 到期"
+    "other": "將於 {{.Expiry}} 到期"
   },
   "availability_expired": {
-   "other": "已到期"
+    "other": "已到期"
   },
   "modal_cancel": {
-   "other": "取消"
+    "other": "取消"
   },
   "play": {
-   "other": "播放"
+    "other": "播放"
   },
   "combined_auth_signin_prompt": {
-   "other": "登入"
+    "other": "登入"
   },
   "combined_auth_signup_prompt": {
-   "other": "登出"
+    "other": "登出"
   },
   "combined_auth_terms": {
-   "other": "我同意本站 <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">使用者服務條款</a>"
+    "other": "我同意本站 <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">使用者服務條款</a>"
   },
   "signup_terms": {
-   "other": "我同意本站 <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">使用者服務條款</a>"
+    "other": "我同意本站 <a href=\"{{.TermsAndConditionsURL}}\" target=\"_blank\">使用者服務條款</a>"
   },
   "validation_terms_required": {
-   "other": "您必須同意本站使用者服務條款"
+    "other": "您必須同意本站使用者服務條款"
   },
   "shopping_error_item_limit_exceeded": {
-   "other": "很抱歉，{{.Title}} 已售完"
+    "other": "很抱歉，{{.Title}} 已售完"
   },
   "changepincode_modal_header": {
-   "other": "變更PIN碼"
+    "other": "變更PIN碼"
   },
   "changepincode_modal_currentpassword": {
-   "other": "目前密碼"
+    "other": "目前密碼"
   },
   "changepincode_modal_pincode1": {
-   "other": "新PIN碼"
+    "other": "新PIN碼"
   },
   "changepincode_modal_pincode2": {
-   "other": "再次確認新PIN碼"
+    "other": "再次確認新PIN碼"
   },
   "changepincode_modal_submit": {
-   "other": "設定PIN碼"
+    "other": "設定PIN碼"
   },
   "changepincode_modal_error_wrong_password": {
-   "other": "密碼錯誤"
+    "other": "密碼錯誤"
   },
   "user_set_pin_intro": {
-   "other": "需輸入PIN碼以 {{.Action}} 此內容"
+    "other": "需輸入PIN碼以 {{.Action}} 此內容"
   },
   "user_error_wrong_pin_reset": {
-   "other": "按此重置PIN碼"
+    "other": "按此重置PIN碼"
   },
   "user_error_too_many_pin_errors_help_page_link": {
-   "other": ""
+    "other": ""
   },
   "shopping_error_age_restricted": {
-   "other": "此內容有年齡限制。"
+    "other": "此內容有年齡限制。"
   },
   "shopping_error_close_button": {
-   "other": "好"
+    "other": "好"
   },
   "wcag_skip_links_header": {
-   "other": "輔助連結"
+    "other": "輔助連結"
   },
   "wcag_skip_links_content": {
-   "other": "跳至內文"
+    "other": "跳至內文"
   },
   "wcag_homepage_h1": {
-   "other": "首頁"
+    "other": "首頁"
   },
   "wcag_carousel_h2": {
-   "other": "輪播"
+    "other": "輪播"
   },
   "wcag_collections_h2": {
-   "other": "收藏"
+    "other": "收藏"
   },
   "wcag_aria_label_footer": {
-   "other": "頁尾"
+    "other": "頁尾"
   },
   "wcag_aria_label_nav_main": {
-   "other": "首頁內容"
+    "other": "首頁內容"
   },
   "wcag_aria_label_nav_sub": {
-   "other": "子頁"
+    "other": "子頁"
   },
   "wcag_aria_label_toggle_nav": {
-   "other": "浮動導覽選單"
+    "other": "浮動導覽選單"
   },
   "wcag_aria_label_bundle_items": {
-   "other": "影片合輯"
+    "other": "影片合輯"
   },
   "wcag_aria_label_carousel": {
-   "other": "輪播"
+    "other": "輪播"
   },
   "wcag_aria_label_page_collection": {
-   "other": "收藏頁面"
+    "other": "收藏頁面"
   },
   "wcag_aria_label_collection_list": {
-   "other": "收藏清單"
+    "other": "收藏清單"
   },
   "wcag_aria_label_collection_slider": {
-   "other": "收藏內容輪播"
+    "other": "收藏內容輪播"
   },
   "wcag_aria_label_wishlist": {
-   "other": "我的追蹤片單"
+    "other": "我的追蹤片單"
   },
   "wcag_aria_label_facebook": {
-   "other": "分享至Facebook"
+    "other": "分享至Facebook"
   },
   "wcag_aria_label_twitter": {
-   "other": "分享至Twitter"
+    "other": "分享至Twitter"
   },
   "wcag_aria_label_linkedin": {
-   "other": "分享至LinkedIn"
+    "other": "分享至LinkedIn"
   },
   "app_badge_title": {
-   "other": "下載應用程序以查看購買的內容！"
+    "other": "下載應用程序以查看購買的內容！"
   },
   "app_badge_ios": {
-   "other": "在App Store上下載"
+    "other": "在App Store上下載"
   },
   "app_badge_android": {
-   "other": "在Google Play上獲取它"
+    "other": "在Google Play上獲取它"
   },
   "shopping_price_title_plan": {
     "other": "價錢"
@@ -1196,7 +1236,13 @@
   "donate_button_text": {
     "other": "捐"
   },
-  "shopping_error_plan_already_owned": { "other": "你已經擁有這個計劃." },
-  "shopping_error_plan_expired": { "other": "該計劃不再可用." },
-  "wcag_aria_label_letterboxd": { "other": "在letterboxd上查看" }
+  "shopping_error_plan_already_owned": {
+    "other": "你已經擁有這個計劃."
+  },
+  "shopping_error_plan_expired": {
+    "other": "該計劃不再可用."
+  },
+  "wcag_aria_label_letterboxd": {
+    "other": "在letterboxd上查看"
+  }
 }


### PR DESCRIPTION
TLDR: this PR just re-indents all the language json files

- We have now [merged a script into core-template](https://github.com/shift72/core-template/pull/294) that automatically translates a key for each translation file
- A side effect of this was all translations had to be auto formatted as it [rewrites the JSON with two indents](https://github.com/shift72/core-template/blob/develop/scripts/translate.mjs#L39)
- So @stajs [requested a PR](https://github.com/shift72/core-template/pull/295#issuecomment-1076942648) that does the formatting in one fell swoop
- Should theoretically be no different apart from intents/newlines, but cast your eyes over it just in case