### PR TITLE
Ab#6719   load ga4 script dynamically

### DIFF
--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -65,8 +65,6 @@
     </script>
 
     <script type="text/javascript" src="/scripts/swiper.min.js"></script>
-
-    {{yield googleGa4Script()}}
   </head>
   <body>
 

--- a/site/templates/application/google.jet
+++ b/site/templates/application/google.jet
@@ -1,24 +1,32 @@
-{{block googleGa4Script(analyticsId=config("google_analytics_id"))}}
-  {{if hasPrefix(analyticsId,"G")}}
-  <!-- GA4 script if G tracking code is provided -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{analyticsId}}"></script>
-  {{end}}
-{{end}}
-
 {{block googleScripts(tagManagerId=config("google_tag_manager_id"), analyticsId=config("google_analytics_id"))}}
   <!-- Google integration scripts -->
   <script>
     function loadGoogleTagManager() {
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','{{ tagManagerId }}')
+      (
+        function(w,d,s,l,i){
+          w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+          var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),
+          dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          }
+      )
+      (window,document,'script','dataLayer','{{ tagManagerId }}')
     }
 
     <!-- GA4 code snippet if G tracking code is provided, else use legacy UA code snippet -->
     {{if hasPrefix(analyticsId,"G")}}
       function loadGoogleAnalytics() {
+        (
+          function(d, googleId){
+          var f = d.getElementsByTagName('script')[0];
+          var s = d.createElement('script');
+          s.src = 'https://www.googletagmanager.com/gtag/js?id=' + googleId;
+          s.async = true;
+          f.parentNode.insertBefore(s,f);
+          }
+          (document,'{{analyticsId}}')
+        );
+
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());

--- a/site/templates/application/google.jet
+++ b/site/templates/application/google.jet
@@ -2,30 +2,17 @@
   <!-- Google integration scripts -->
   <script>
     function loadGoogleTagManager() {
-      (
-        function(w,d,s,l,i){
-          w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-          var f=d.getElementsByTagName(s)[0],
-          j=d.createElement(s),
-          dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-          }
-      )
-      (window,document,'script','dataLayer','{{ tagManagerId }}')
-    }
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+      var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+      j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','{{ tagManagerId }}')}
 
     <!-- GA4 code snippet if G tracking code is provided, else use legacy UA code snippet -->
     {{if hasPrefix(analyticsId,"G")}}
       function loadGoogleAnalytics() {
-        (
-          function(d, googleId){
-          var f = d.getElementsByTagName('script')[0];
-          var s = d.createElement('script');
-          s.src = 'https://www.googletagmanager.com/gtag/js?id=' + googleId;
-          s.async = true;
-          f.parentNode.insertBefore(s,f);
-          }
-          (document,'{{analyticsId}}')
-        );
+        (function(d, googleId){var f = d.getElementsByTagName('script')[0];var s = d.createElement('script');
+        s.src = 'https://www.googletagmanager.com/gtag/js?id=' + googleId;s.async = true;f.parentNode.insertBefore(s,f);
+        }(document,'{{analyticsId}}'));
 
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Ok, so ive removed the block / yield to load the GA4 async script and wrote it as an anonymous function instead, so its only loaded once the cookie consent has been checked. Ive tested it locally thoroughly, switching between Legacy GA and GA4 to make sure data is collected and only if cookie consent has been given. I've also tested that the GA4 code works alongside google tag manager.