### PR TITLE
Sponsor image support film detail page

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "اشتراكاتي"
+  },
+  "sponsor_image_alt": {
+    "other": "شعار الراعي"
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "اشتراكاتي"
+  },
+  "sponsor_logo_prefix": {
+    "other": "جلب لك بواسطة:"
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1295,8 +1295,5 @@
   },
   "nav_subscriptions": {
     "other": "اشتراكاتي"
-  },
-  "sponsor_logo_prefix": {
-    "other": "جلب لك بواسطة:"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "Les meves subscripcions"
+  },
+  "sponsor_image_alt": {
+    "other": "logotip del patrocinador"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1295,8 +1295,5 @@
   },
   "nav_subscriptions": {
     "other": "Les meves subscripcions"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Portat a vostè per:"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "Les meves subscripcions"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Portat a vostè per:"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "Mine abonnementer"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Bragt til dig af:"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1295,8 +1295,5 @@
   },
   "nav_subscriptions": {
     "other": "Mine abonnementer"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Bragt til dig af:"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "Mine abonnementer"
+  },
+  "sponsor_image_alt": {
+    "other": "sponsor logo"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "Meine Abonnements"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Zur Verfügung gestellt von:"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "Meine Abonnements"
+  },
+  "sponsor_image_alt": {
+    "other": "Sponsorenlogo"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1295,8 +1295,5 @@
   },
   "nav_subscriptions": {
     "other": "Meine Abonnements"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Zur Verfügung gestellt von:"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "οι εγγραφές μου"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Σας προσφέρθηκε από:"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "οι εγγραφές μου"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Σας προσφέρθηκε από:"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "οι εγγραφές μου"
+  },
+  "sponsor_image_alt": {
+    "other": "λογότυπο χορηγού"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1286,5 +1286,8 @@
   },
   "meta_description_collapse": {
     "other": "See less"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Brought to you by:"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1286,5 +1286,8 @@
   },
   "meta_description_collapse": {
     "other": "See less"
+  },
+  "sponsor_image_alt": {
+    "other": "sponsor logo"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1286,8 +1286,5 @@
   },
   "meta_description_collapse": {
     "other": "See less"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Brought to you by:"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "mis Suscripciónes"
+  },
+  "sponsor_image_alt": {
+    "other": "logotipo del patrocinador"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "mis Suscripciónes"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Traído a usted por:"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "mis Suscripciónes"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Traído a usted por:"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "mis Suscripciónes"
+  },
+  "sponsor_image_alt": {
+    "other": "logotipo del patrocinador"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "mis Suscripciónes"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Traído a usted por:"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "mis Suscripciónes"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Traído a usted por:"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "Minu tellimused"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Teieni toonud:"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "Minu tellimused"
+  },
+  "sponsor_image_alt": {
+    "other": "sponsori logo"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1295,8 +1295,5 @@
   },
   "nav_subscriptions": {
     "other": "Minu tellimused"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Teieni toonud:"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Omat tilaukset"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Tuotu sinulle:"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Omat tilaukset"
+  },
+  "sponsor_image_alt": {
+    "other": "sponsorin logo"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "Omat tilaukset"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Tuotu sinulle:"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "Mes abonnements"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Présenté par:"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Mes abonnements"
+  },
+  "sponsor_image_alt": {
+    "other": "logo du sponsor"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Mes abonnements"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Présenté par:"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1278,5 +1278,8 @@
   },
   "nav_subscriptions": {
     "other": "Moje pretplate"
+  },
+  "sponsor_image_alt": {
+    "other": "logotip sponzora"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1278,8 +1278,5 @@
   },
   "nav_subscriptions": {
     "other": "Moje pretplate"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Donio vam:"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1278,5 +1278,8 @@
   },
   "nav_subscriptions": {
     "other": "Moje pretplate"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Donio vam:"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "a Feliratkozásaim"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Elhozta neked:"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1295,8 +1295,5 @@
   },
   "nav_subscriptions": {
     "other": "a Feliratkozásaim"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Elhozta neked:"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1295,5 +1295,8 @@
   },
   "nav_subscriptions": {
     "other": "a Feliratkozásaim"
+  },
+  "sponsor_image_alt": {
+    "other": "szponzor logó"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "le mie sottoscrizioni"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Portato a voi da:"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "le mie sottoscrizioni"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Portato a voi da:"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "le mie sottoscrizioni"
+  },
+  "sponsor_image_alt": {
+    "other": "logo dello sponsor"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "私のサブスクリプション"
+  },
+  "sponsor_image_alt": {
+    "other": "スポンサーロゴ"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "私のサブスクリプション"
-  },
-  "sponsor_logo_prefix": {
-    "other": "の提供で："
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "私のサブスクリプション"
+  },
+  "sponsor_logo_prefix": {
+    "other": "の提供で："
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Mano prenumeratos"
+  },
+  "sponsor_image_alt": {
+    "other": "rėmėjo logotipas"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Mano prenumeratos"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Jums atnešė:"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "Mano prenumeratos"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Jums atnešė:"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "mijn abonnementen"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Wordt gesponsord door:"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "mijn abonnementen"
+  },
+  "sponsor_image_alt": {
+    "other": "sponsorlogo"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "mijn abonnementen"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Wordt gesponsord door:"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Mine abonnementer"
+  },
+  "sponsor_image_alt": {
+    "other": "sponsorlogo"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "Mine abonnementer"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Brakt til deg av:"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Mine abonnementer"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Brakt til deg av:"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1331,8 +1331,5 @@
   },
   "nav_subscriptions": {
     "other": "moje subskrypcje"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Dostarczone przez:"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1331,5 +1331,8 @@
   },
   "nav_subscriptions": {
     "other": "moje subskrypcje"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Dostarczone przez:"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1331,5 +1331,8 @@
   },
   "nav_subscriptions": {
     "other": "moje subskrypcje"
+  },
+  "sponsor_image_alt": {
+    "other": "logo sponsora"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "Minhas assinaturas"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Patrocinado por:"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Minhas assinaturas"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Patrocinado por:"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Minhas assinaturas"
+  },
+  "sponsor_image_alt": {
+    "other": "logotipo do patrocinador"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "Minhas assinaturas"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Patrocinado por:"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Minhas assinaturas"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Patrocinado por:"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Minhas assinaturas"
+  },
+  "sponsor_image_alt": {
+    "other": "logotipo do patrocinador"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1308,5 +1308,8 @@
   },
   "nav_subscriptions": {
     "other": "Мои подписки"
+  },
+  "sponsor_image_alt": {
+    "other": "логотип спонсора"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1308,8 +1308,5 @@
   },
   "nav_subscriptions": {
     "other": "Мои подписки"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Привлечены к вам:"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1308,5 +1308,8 @@
   },
   "nav_subscriptions": {
     "other": "Мои подписки"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Привлечены к вам:"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Моје претплате"
+  },
+  "sponsor_image_alt": {
+    "other": "логотип спонзора"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "Моје претплате"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Довео до вас:"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "Моје претплате"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Довео до вас:"
   }
 }

--- a/site/styles/_buttons.scss
+++ b/site/styles/_buttons.scss
@@ -205,7 +205,9 @@
   @extend .btn-secondary;
 }
 
-.s72-btn.s72-btn-explore-subs { @extend .btn-primary; }
+.s72-btn.s72-btn-explore-subs {
+  @extend .btn-primary;
+}
 
 .btn-wishlist {
   p {

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -592,6 +592,7 @@ s72-element-switcher,
   width: 100%;
   display: flex;
   justify-content: space-between;
+  gap: 50px;
 
   .sponsor {
     display: none;
@@ -599,7 +600,6 @@ s72-element-switcher,
       display: flex;
     }
     padding-top: 10px;
-    margin-left: 50px;
   }
 }
 

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -146,7 +146,7 @@
     }
   }
 
-  > .sponsor-poster {
+  > .poster-wrapper {
     margin-right: 20px;
   }
 }
@@ -623,7 +623,7 @@ s72-element-switcher {
   }
 }
 
-.sponsor-poster .sponsor {
+.poster-wrapper .sponsor {
   @media (min-width: 1200px) {
     display: none;
   }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -595,7 +595,7 @@ s72-element-switcher,
 
   .sponsor {
     display: none;
-    @media (min-width: 1200px) {
+    @include media-breakpoint-up(xl) {
       display: flex;
     }
     padding-top: 10px;

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -597,15 +597,13 @@ s72-element-switcher,
   .sponsor {
     display: none;
     @include media-breakpoint-up(xl) {
-      display: flex;
+      display: block;
     }
     padding-top: 10px;
   }
 }
 
 .sponsor {
-  display: flex;
-  flex-direction: column;
   margin-bottom: 25px;
   max-width: 250px;
 }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -151,7 +151,9 @@
   }
 }
 
-.meta-detail-info-width {
+.element-switcher-wrapper,
+.meta-detail-bonus-content,
+.meta-detail-episodes-content {
   flex: 1 1 100%;
 
   @include media-breakpoint-up(md) {

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -149,7 +149,7 @@
   }
 
   .poster-wrapper .sponsor {
-    @media (min-width: 1200px) {
+    @include media-breakpoint-up(xl) {
       display: none;
     }
   }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -120,8 +120,8 @@
 .meta-detail-main {
   @extend .d-flex;
   flex-direction: column;
-  padding: var(--page-detail-padding-top) 20px 0 20px;
   gap: 0 20px;
+  padding: var(--page-detail-padding-top) 20px 0 20px;
 
   @include media-breakpoint-up(md) {
     flex-direction: row;
@@ -288,7 +288,6 @@ s72-element-switcher,
   .meta-detail-studio,
   .meta-detail-country,
   .meta-detail-subtitle {
-
     h2,
     h3,
     h4 {
@@ -589,17 +588,17 @@ s72-element-switcher,
 }
 
 .element-switcher-wrapper {
-  width: 100%;
   display: flex;
-  justify-content: space-between;
   gap: 50px;
+  justify-content: space-between;
+  width: 100%;
 
   .sponsor {
     display: none;
+    padding-top: 10px;
     @include media-breakpoint-up(xl) {
       display: block;
     }
-    padding-top: 10px;
   }
 }
 
@@ -619,8 +618,8 @@ s72-element-switcher {
 
 .meta-detail-info {
   display: grid;
-  grid-template-columns: repeat(1, 1fr);
   gap: 20px;
+  grid-template-columns: repeat(1, 1fr);
 
   @include media-breakpoint-up(lg) {
     grid-template-columns: repeat(2, 1fr);

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -121,6 +121,8 @@
   @extend .d-flex;
   flex-direction: column;
   padding: var(--page-detail-padding-top) 20px 0 20px;
+  gap: 0 20px;
+
   @include media-breakpoint-up(md) {
     flex-direction: row;
     padding-bottom: 0;
@@ -144,10 +146,6 @@
     @include media-breakpoint-up(md) {
       width: 208px;
     }
-  }
-
-  > .poster-wrapper {
-    margin-right: 20px;
   }
 }
 

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -151,7 +151,7 @@
   }
 }
 
-.element-switcher-wrapper,
+s72-element-switcher,
 .meta-detail-bonus-content,
 .meta-detail-episodes-content {
   flex: 1 1 100%;

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -151,8 +151,8 @@
   }
 }
 
-s72-element-switcher {
-  flex-grow: 1;
+.meta-detail-info-width {
+  flex: 1 1 100%;
 
   @include media-breakpoint-up(md) {
     max-width: 563px;
@@ -612,4 +612,10 @@ s72-element-switcher {
   display: flex;
   flex-direction: column;
   margin-bottom: 25px;
+}
+
+.meta-detail-content .sponsor {
+  flex: 0 0 auto;
+  max-width: 250px;
+  text-align: right;
 }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -588,6 +588,10 @@
   justify-content: space-between;
 
   .sponsor {
+    display: none;
+    @media (min-width: 1200px) {
+      display: flex;
+    }
     padding-top: 10px;
     margin-left: 50px;
   }
@@ -616,5 +620,11 @@ s72-element-switcher {
 
   @include media-breakpoint-up(lg) {
     grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.sponsor-poster .sponsor {
+  @media (min-width: 1200px) {
+    display: none;
   }
 }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -147,6 +147,12 @@
       width: 208px;
     }
   }
+
+  .poster-wrapper .sponsor {
+    @media (min-width: 1200px) {
+      display: none;
+    }
+  }
 }
 
 s72-element-switcher,
@@ -620,11 +626,5 @@ s72-element-switcher {
 
   @include media-breakpoint-up(lg) {
     grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-.poster-wrapper .sponsor {
-  @media (min-width: 1200px) {
-    display: none;
   }
 }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -146,18 +146,24 @@
     }
   }
 
-  > .poster {
+  > .sponsor-poster {
     margin-right: 20px;
   }
 }
 
-.meta-detail-content {
+s72-element-switcher {
+  flex-grow: 1;
+
   @include media-breakpoint-up(md) {
-    width: 563px;
+    max-width: 563px;
   }
   @include media-breakpoint-up(xl) {
-    width: 1100px;
+    max-width: 1100px;
   }
+}
+
+.meta-detail-content {
+  width: 100%;
 
   h1 {
     animation: fadein 2s;
@@ -589,4 +595,21 @@
   @include media-breakpoint-up(lg) {
     font-size: 12px;
   }
+}
+
+.element-switcher-sponsor {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+
+  .sponsor {
+    padding-top: 10px;
+    margin-left: 50px;
+  }
+}
+
+.sponsor {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 25px;
 }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -582,7 +582,7 @@
   }
 }
 
-.element-switcher-sponsor {
+.element-switcher-wrapper {
   width: 100%;
   display: flex;
   justify-content: space-between;

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -612,10 +612,10 @@
   display: flex;
   flex-direction: column;
   margin-bottom: 25px;
+  max-width: 250px;
 }
 
 .meta-detail-content .sponsor {
   flex: 0 0 auto;
-  max-width: 250px;
   text-align: right;
 }

--- a/site/templates/common/sponsor-image.jet
+++ b/site/templates/common/sponsor-image.jet
@@ -1,10 +1,18 @@
-{{block sponsor(text, link, external, img)}}
-  <div class="sponsor">
-    {{if text}}
-      <span>{{text}}</span>
-    {{end}}
-    {{if link}}<a href="{{link}}" {{if external}} target="_blank" {{end}}>{{end}}
-      <s72-image src="{{img}}" alt="{{ i18n("sponsor_image_alt") }}" ></s72-image>
-    {{if link}}</a>{{end}}
-  </div>
+{{block sponsor()}}
+  {{sponsorImage := .ImageMap["Sponsor"]}}
+
+  {{if isset(sponsorImage)}}
+    {{sponsorText := .CustomFields.GetString("sponsor_image_text_film", "")}}
+    {{sponsorLink := .CustomFields.GetString("sponsor_image_link_film", "")}}
+    {{sponsorLinkIsExternal := .CustomFields.GetBool("sponsor_image_link_external_film", false)}}
+
+    <div class="sponsor">
+      {{if sponsorText}}
+        <span>{{sponsorText}}</span>
+      {{end}}
+      {{if sponsorLink}}<a href="{{sponsorLink}}" {{if sponsorLinkIsExternal}} target="_blank" {{end}}>{{end}}
+        <s72-image src="{{sponsorImage}}" alt="{{ i18n("sponsor_image_alt") }}" ></s72-image>
+      {{if sponsorLink}}</a>{{end}}
+    </div>
+  {{end}}
 {{end}}

--- a/site/templates/common/sponsor-image.jet
+++ b/site/templates/common/sponsor-image.jet
@@ -3,8 +3,8 @@
     {{if text}}
       <span>{{text}}</span>
     {{end}}
-    <a {{if link}} href="{{link}}" {{if external}} target="_blank" {{end}} {{end}}>
+    {{if link}}<a href="{{link}}" {{if external}} target="_blank" {{end}}>{{end}}
       <s72-image src="{{img}}"></s72-image>
-    </a>
+    {{if link}}</a>{{end}}
   </div>
 {{end}}

--- a/site/templates/common/sponsor-image.jet
+++ b/site/templates/common/sponsor-image.jet
@@ -8,7 +8,7 @@
 
     <div class="sponsor">
       {{if sponsorText}}
-        <span>{{sponsorText}}</span>
+        <div>{{sponsorText}}</div>
       {{end}}
       {{if sponsorLink}}<a href="{{sponsorLink}}" {{if sponsorLinkIsExternal}} target="_blank" {{end}}>{{end}}
         <s72-image src="{{sponsorImage}}" alt="{{ i18n("sponsor_image_alt") }}" ></s72-image>

--- a/site/templates/common/sponsor-image.jet
+++ b/site/templates/common/sponsor-image.jet
@@ -1,0 +1,10 @@
+{{ block sponsor(text, link, external, img) }}
+  <div class="sponsor">
+    {{ if text }}
+      <span>{{text}}</span>
+    {{ end }}
+    <a {{ if link }} href="{{ link }}" {{ if external }} target="_blank" {{ end }} {{ end }}>
+      <s72-image src="{{img}}"></s72-image>
+    </a>
+  </div>
+{{ end }}

--- a/site/templates/common/sponsor-image.jet
+++ b/site/templates/common/sponsor-image.jet
@@ -1,10 +1,10 @@
-{{ block sponsor(text, link, external, img) }}
+{{block sponsor(text, link, external, img)}}
   <div class="sponsor">
-    {{ if text }}
+    {{if text}}
       <span>{{text}}</span>
-    {{ end }}
-    <a {{ if link }} href="{{ link }}" {{ if external }} target="_blank" {{ end }} {{ end }}>
+    {{end}}
+    <a {{if link}} href="{{link}}" {{if external}} target="_blank" {{end}} {{end}}>
       <s72-image src="{{img}}"></s72-image>
     </a>
   </div>
-{{ end }}
+{{end}}

--- a/site/templates/common/sponsor-image.jet
+++ b/site/templates/common/sponsor-image.jet
@@ -4,7 +4,7 @@
       <span>{{text}}</span>
     {{end}}
     {{if link}}<a href="{{link}}" {{if external}} target="_blank" {{end}}>{{end}}
-      <s72-image src="{{img}}"></s72-image>
+      <s72-image src="{{img}}" alt="{{ i18n("sponsor_image_alt") }}" ></s72-image>
     {{if link}}</a>{{end}}
   </div>
 {{end}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -18,6 +18,12 @@
 {{end}}
 
 {{block body()}}
+
+{{ sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "") }}
+{{ sponsorlink := film.CustomFields.GetString("sponsor_image_link_film", "") }}
+{{ sponsorImage := film.ImageMap["Sponsor"] }}
+
+
   <main id="main" class="page page-film meta-detail meta-detail-film">
     <div class="meta-detail-bg">
       <div class="right-gradient"></div>
@@ -26,10 +32,12 @@
     <div class="container">
       <div class="meta-detail-main">
         <div class="sponsor-poster">
-          {{if isset(film.ImageMap["Sponsor"])}}
+          {{if sponsorText && isset(sponsorImage)}}
             <div class="sponsor d-xl-none">
-              {{ i18n("sponsor_logo_prefix") }}
-              <s72-image src="{{film.ImageMap["Sponsor"]}}"></s72-image>
+              <span>{{ sponsorText }}</span>
+              <a {{ if sponsorlink }} href="{{ sponsorlink }}" target="_blank" {{ end }}>
+                <s72-image src="{{sponsorImage}}"></s72-image>
+              </a>
             </div>
           {{end}}
           {{if config("default_image_type") == "portrait"}}
@@ -71,7 +79,7 @@
 
           {{yield awardNominations() film}}
           <div class="element-switcher-sponsor">
-            <s72-element-switcher>
+            <s72-element-switcher class="meta-detail-info-width">
               {{if isEnabled("element_switcher_enabled")}}
                 <div class="meta-detail-switcher-tagline">
                   <p>{{film.Tagline}}</p>
@@ -157,15 +165,17 @@
                 {{end}}
               </div>
             </s72-element-switcher>
-            {{if isset(film.ImageMap["Sponsor"])}}
+            {{if sponsorText && isset(sponsorImage)}}
               <div class="sponsor d-none d-xl-flex">
-                {{ i18n("sponsor_logo_prefix") }}
-                <s72-image src="{{film.ImageMap["Sponsor"]}}"></s72-image>
+                <span>{{sponsorText}}</span>
+                <a {{ if sponsorlink }} href="{{ sponsorlink }}" target="_blank" {{ end }}>
+                  <s72-image src="{{sponsorImage}}"></s72-image>
+                </a>
               </div>
             {{end}}
           </div>
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}
-            <section class="meta-detail-bonus-content" aria-label="{{i18n("meta_detail_bonus_title")}}">
+            <section class="meta-detail-bonus-content meta-detail-info-width" aria-label="{{i18n("meta_detail_bonus_title")}}">
               <h2>{{i18n("meta_detail_bonus_title")}}</h2>
               {{yield list(itemsPerRow=4, itemLayout="landscape") content}}
                 {{range bonus := film.Bonuses}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -20,10 +20,10 @@
 
 {{block body()}}
 
-{{sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "")}}
-{{sponsorLink := film.CustomFields.GetString("sponsor_image_link_film", "")}}
-{{sponsorLinkIsExternal := film.CustomFields.GetBool("sponsor_image_link_external_film", false)}}
-{{sponsorImage := film.ImageMap["Sponsor"]}}
+  {{sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "")}}
+  {{sponsorLink := film.CustomFields.GetString("sponsor_image_link_film", "")}}
+  {{sponsorLinkIsExternal := film.CustomFields.GetBool("sponsor_image_link_external_film", false)}}
+  {{sponsorImage := film.ImageMap["Sponsor"]}}
 
   <main id="main" class="page page-film meta-detail meta-detail-film">
     <div class="meta-detail-bg">

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -74,7 +74,7 @@
           {{end}}
 
           {{yield awardNominations() film}}
-          <div class="element-switcher-sponsor">
+          <div class="element-switcher-wrapper">
             <s72-element-switcher class="meta-detail-info-width">
               {{if isEnabled("element_switcher_enabled")}}
                 <div class="meta-detail-switcher-tagline">

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -94,64 +94,64 @@
                       <a href="{{ routeToPath(path) }}">{{member.Name}}</a>
                     </div>
                   {{end}}
-                {{if len(film.Languages) > 0 }}
-                  <div class="meta-detail-language">
-                    <h2>{{i18n("meta_detail_languages", len(film.Languages))}}</h2>
-                    <p>{{ film.Languages }}</p>
-                  </div>
-                {{end}}
-                {{allSubtitles := film.GetSubtitles()}}
-                {{if len(allSubtitles) > 0 }}
-                  {{subtitles := ""}}
-                  {{captions := ""}}
-                  {{if len(film.SubtitleTracks) == 0}}
-                    {{subtitles = allSubtitles}}
-                  {{else}}
-                    {{range subTrack := film.SubtitleTracks}}
-                      {{if len(subTrack) >= 3}}
-                        {{if subTrack[2] == "caption"}}
-                            {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
-                        {{else}}
-                            {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
+                  {{if len(film.Languages) > 0 }}
+                    <div class="meta-detail-language">
+                      <h2>{{i18n("meta_detail_languages", len(film.Languages))}}</h2>
+                      <p>{{ film.Languages }}</p>
+                    </div>
+                  {{end}}
+                  {{allSubtitles := film.GetSubtitles()}}
+                  {{if len(allSubtitles) > 0 }}
+                    {{subtitles := ""}}
+                    {{captions := ""}}
+                    {{if len(film.SubtitleTracks) == 0}}
+                      {{subtitles = allSubtitles}}
+                    {{else}}
+                      {{range subTrack := film.SubtitleTracks}}
+                        {{if len(subTrack) >= 3}}
+                          {{if subTrack[2] == "caption"}}
+                              {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
+                          {{else}}
+                              {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
+                          {{end}}
                         {{end}}
                       {{end}}
                     {{end}}
+                    {{if subtitles}}
+                      <div class="meta-detail-subtitle">
+                        <h2>{{i18n("meta_detail_subtitles")}}</h2>
+                        <p>{{subtitles}}</p>
+                      </div>
+                    {{end}}
+                    {{if captions}}
+                      <div class="meta-detail-subtitle">
+                        <h2>{{i18n("meta_detail_captions")}}</h2>
+                        <p>{{captions}}</p>
+                      </div>
+                    {{end}}
                   {{end}}
-                  {{if subtitles}}
-                    <div class="meta-detail-subtitle">
-                      <h2>{{i18n("meta_detail_subtitles")}}</h2>
-                      <p>{{subtitles}}</p>
+                  {{if len(film.Countries) > 0 }}
+                    <div class="meta-detail-country">
+                      <h2>{{i18n("meta_detail_countries", len(film.Countries))}}</h2>
+                      <p>{{ film.Countries }}</p>
                     </div>
                   {{end}}
-                  {{if captions}}
-                    <div class="meta-detail-subtitle">
-                      <h2>{{i18n("meta_detail_captions")}}</h2>
-                      <p>{{captions}}</p>
+                  {{if len(film.Studio) > 0 }}
+                    <div class="meta-detail-studio">
+                      <h2>{{i18n("meta_detail_studios", len(film.Studio))}}</h2>
+                      {*{ FORMAT STUDIOS }*}
+                      {{ studios := "" }}
+                      {{ range studio := film.Studio }}
+                        {{ studios = studios + studio + ", "}}
+                      {{ end }}
+                      {{ if len(studios) > 0 }}
+                        {{ studios = studios[0:len(studios) - 2] }}
+                      {{ end }}
+                      <p>{{ studios }}</p>
                     </div>
                   {{end}}
-                {{end}}
-                {{if len(film.Countries) > 0 }}
-                  <div class="meta-detail-country">
-                    <h2>{{i18n("meta_detail_countries", len(film.Countries))}}</h2>
-                    <p>{{ film.Countries }}</p>
-                  </div>
-                {{end}}
-                {{if len(film.Studio) > 0 }}
-                  <div class="meta-detail-studio">
-                    <h2>{{i18n("meta_detail_studios", len(film.Studio))}}</h2>
-                    {*{ FORMAT STUDIOS }*}
-                    {{ studios := "" }}
-                    {{ range studio := film.Studio }}
-                      {{ studios = studios + studio + ", "}}
-                    {{ end }}
-                    {{ if len(studios) > 0 }}
-                      {{ studios = studios[0:len(studios) - 2] }}
-                    {{ end }}
-                    <p>{{ studios }}</p>
-                  </div>
-                {{end}}
+                </div>
               </div>
-            </div>
             </s72-element-switcher>
             {{yield sponsor() film}}
           </div>

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -175,8 +175,7 @@
                 {{end}}
               {{end}}
             </section>
-          </div>
-        {{end}}
+          {{end}}
         </div>
       </div>
     </div>

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -22,9 +22,7 @@
 {{ sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "") }}
 {{ sponsorLink := film.CustomFields.GetString("sponsor_image_link_film", "") }}
 {{ sponsorLinkIsExternal := film.CustomFields.GetBool("sponsor_image_link_external_film", false) }}
-
 {{ sponsorImage := film.ImageMap["Sponsor"] }}
-
 
   <main id="main" class="page page-film meta-detail meta-detail-film">
     <div class="meta-detail-bg">

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -102,7 +102,6 @@
                       <a href="{{ routeToPath(path) }}">{{member.Name}}</a>
                     </div>
                   {{end}}
-                </div>
                 {{if len(film.Languages) > 0 }}
                   <div class="meta-detail-language">
                     <h2>{{i18n("meta_detail_languages", len(film.Languages))}}</h2>
@@ -160,6 +159,7 @@
                   </div>
                 {{end}}
               </div>
+            </div>
             </s72-element-switcher>
             {{if isset(sponsorImage)}}
               {{yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -21,6 +21,8 @@
 
 {{ sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "") }}
 {{ sponsorLink := film.CustomFields.GetString("sponsor_image_link_film", "") }}
+{{ sponsorLinkIsExternal := film.CustomFields.GetBool("sponsor_image_link_external_film", false) }}
+
 {{ sponsorImage := film.ImageMap["Sponsor"] }}
 
 
@@ -37,7 +39,7 @@
               {{ if sponsorText }}
                 <span>{{sponsorText}}</span>
               {{ end }}
-              <a {{ if sponsorLink }} href="{{ sponsorLink }}" target="_blank" {{ end }}>
+              <a {{ if sponsorLink }} href="{{ sponsorLink }}" {{ if sponsorLinkIsExternal }} target="_blank" {{ end }} {{ end }}>
                 <s72-image src="{{sponsorImage}}"></s72-image>
               </a>
             </div>
@@ -172,7 +174,7 @@
                 {{ if sponsorText }}
                   <span>{{sponsorText}}</span>
                 {{ end }}
-                <a {{ if sponsorLink }} href="{{ sponsorLink }}" target="_blank" {{ end }}>
+                <a {{ if sponsorLink }} href="{{ sponsorLink }}" {{ if sponsorLinkIsExternal }} target="_blank" {{ end }} {{ end }}>
                   <s72-image src="{{sponsorImage}}"></s72-image>
                 </a>
               </div>

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -20,11 +20,6 @@
 
 {{block body()}}
 
-  {{sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "")}}
-  {{sponsorLink := film.CustomFields.GetString("sponsor_image_link_film", "")}}
-  {{sponsorLinkIsExternal := film.CustomFields.GetBool("sponsor_image_link_external_film", false)}}
-  {{sponsorImage := film.ImageMap["Sponsor"]}}
-
   <main id="main" class="page page-film meta-detail meta-detail-film">
     <div class="meta-detail-bg">
       <div class="right-gradient"></div>
@@ -34,9 +29,7 @@
       <div class="meta-detail-main">
         <div class="poster-wrapper">
           {{if config("default_image_type") == "portrait"}}
-            {{if isset(sponsorImage)}}
-              {{yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
-            {{end}}
+            {{yield sponsor() film}}
             <div class="poster poster-portrait">
               <s72-availability-status data-slug="{{film.Slug}}"></s72-availability-status>
               <s72-image src="{{film.ImageMap["Classification"]}}" alt="" class="classification-image">
@@ -160,9 +153,7 @@
               </div>
             </div>
             </s72-element-switcher>
-            {{if isset(sponsorImage)}}
-              {{yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
-            {{end}}
+            {{yield sponsor() film}}
           </div>
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}
             <section class="meta-detail-bonus-content" aria-label="{{i18n("meta_detail_bonus_title")}}">

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -20,7 +20,7 @@
 {{block body()}}
 
 {{ sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "") }}
-{{ sponsorlink := film.CustomFields.GetString("sponsor_image_link_film", "") }}
+{{ sponsorLink := film.CustomFields.GetString("sponsor_image_link_film", "") }}
 {{ sponsorImage := film.ImageMap["Sponsor"] }}
 
 
@@ -32,10 +32,12 @@
     <div class="container">
       <div class="meta-detail-main">
         <div class="sponsor-poster">
-          {{if sponsorText && isset(sponsorImage)}}
+          {{if isset(sponsorImage)}}
             <div class="sponsor d-xl-none">
-              <span>{{ sponsorText }}</span>
-              <a {{ if sponsorlink }} href="{{ sponsorlink }}" target="_blank" {{ end }}>
+              {{ if sponsorText }}
+                <span>{{sponsorText}}</span>
+              {{ end }}
+              <a {{ if sponsorLink }} href="{{ sponsorLink }}" target="_blank" {{ end }}>
                 <s72-image src="{{sponsorImage}}"></s72-image>
               </a>
             </div>
@@ -165,10 +167,12 @@
                 {{end}}
               </div>
             </s72-element-switcher>
-            {{if sponsorText && isset(sponsorImage)}}
+            {{if isset(sponsorImage)}}
               <div class="sponsor d-none d-xl-flex">
-                <span>{{sponsorText}}</span>
-                <a {{ if sponsorlink }} href="{{ sponsorlink }}" target="_blank" {{ end }}>
+                {{ if sponsorText }}
+                  <span>{{sponsorText}}</span>
+                {{ end }}
+                <a {{ if sponsorLink }} href="{{ sponsorLink }}" target="_blank" {{ end }}>
                   <s72-image src="{{sponsorImage}}"></s72-image>
                 </a>
               </div>

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -33,16 +33,15 @@
     <div class="container">
       <div class="meta-detail-main">
         <div class="poster-wrapper">
-          {{if isset(sponsorImage)}}
-            {{yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
-          {{end}}
           {{if config("default_image_type") == "portrait"}}
-              <div class="poster poster-portrait">
-                <s72-availability-status data-slug="{{film.Slug}}"></s72-availability-status>
-                <s72-image src="{{film.ImageMap["Classification"]}}" alt="" class="classification-image">
-                <s72-image src="{{film.ImageMap["Portrait"]}}" alt="{{film.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
-
-              </div>
+            {{if isset(sponsorImage)}}
+              {{yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
+            {{end}}
+            <div class="poster poster-portrait">
+              <s72-availability-status data-slug="{{film.Slug}}"></s72-availability-status>
+              <s72-image src="{{film.ImageMap["Classification"]}}" alt="" class="classification-image">
+              <s72-image src="{{film.ImageMap["Portrait"]}}" alt="{{film.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
+            </div>
           {{end}}
         </div>
         <div class="meta-detail-content">

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -7,6 +7,7 @@
 {{import "../common/list.jet"}}
 {{import "../common/social-media-buttons.jet"}}
 {{import "../common/awards/item.jet"}}
+{{import "../common/sponsor-image.jet"}}
 
 {{block head()}}
   {{yield seo() film}}
@@ -33,14 +34,7 @@
       <div class="meta-detail-main">
         <div class="sponsor-poster">
           {{if isset(sponsorImage)}}
-            <div class="sponsor d-xl-none">
-              {{ if sponsorText }}
-                <span>{{sponsorText}}</span>
-              {{ end }}
-              <a {{ if sponsorLink }} href="{{ sponsorLink }}" {{ if sponsorLinkIsExternal }} target="_blank" {{ end }} {{ end }}>
-                <s72-image src="{{sponsorImage}}"></s72-image>
-              </a>
-            </div>
+            {{ yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
           {{end}}
           {{if config("default_image_type") == "portrait"}}
               <div class="poster poster-portrait">
@@ -168,14 +162,7 @@
               </div>
             </s72-element-switcher>
             {{if isset(sponsorImage)}}
-              <div class="sponsor d-none d-xl-flex">
-                {{ if sponsorText }}
-                  <span>{{sponsorText}}</span>
-                {{ end }}
-                <a {{ if sponsorLink }} href="{{ sponsorLink }}" {{ if sponsorLinkIsExternal }} target="_blank" {{ end }} {{ end }}>
-                  <s72-image src="{{sponsorImage}}"></s72-image>
-                </a>
-              </div>
+              {{ yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
             {{end}}
           </div>
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -20,10 +20,10 @@
 
 {{block body()}}
 
-{{ sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "") }}
-{{ sponsorLink := film.CustomFields.GetString("sponsor_image_link_film", "") }}
-{{ sponsorLinkIsExternal := film.CustomFields.GetBool("sponsor_image_link_external_film", false) }}
-{{ sponsorImage := film.ImageMap["Sponsor"] }}
+{{sponsorText := film.CustomFields.GetString("sponsor_image_text_film", "")}}
+{{sponsorLink := film.CustomFields.GetString("sponsor_image_link_film", "")}}
+{{sponsorLinkIsExternal := film.CustomFields.GetBool("sponsor_image_link_external_film", false)}}
+{{sponsorImage := film.ImageMap["Sponsor"]}}
 
   <main id="main" class="page page-film meta-detail meta-detail-film">
     <div class="meta-detail-bg">
@@ -32,9 +32,9 @@
     </div>
     <div class="container">
       <div class="meta-detail-main">
-        <div class="sponsor-poster">
+        <div class="poster-wrapper">
           {{if isset(sponsorImage)}}
-            {{ yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
+            {{yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
           {{end}}
           {{if config("default_image_type") == "portrait"}}
               <div class="poster poster-portrait">
@@ -162,7 +162,7 @@
               </div>
             </s72-element-switcher>
             {{if isset(sponsorImage)}}
-              {{ yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
+              {{yield sponsor(text=sponsorText, link=sponsorLink, external=sponsorLinkIsExternal, img=sponsorImage)}}
             {{end}}
           </div>
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -75,7 +75,7 @@
 
           {{yield awardNominations() film}}
           <div class="element-switcher-wrapper">
-            <s72-element-switcher class="meta-detail-info-width">
+            <s72-element-switcher>
               {{if isEnabled("element_switcher_enabled")}}
                 <div class="meta-detail-switcher-tagline">
                   <p>{{film.Tagline}}</p>
@@ -166,7 +166,7 @@
             {{end}}
           </div>
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}
-            <section class="meta-detail-bonus-content meta-detail-info-width" aria-label="{{i18n("meta_detail_bonus_title")}}">
+            <section class="meta-detail-bonus-content" aria-label="{{i18n("meta_detail_bonus_title")}}">
               <h2>{{i18n("meta_detail_bonus_title")}}</h2>
               {{yield list(itemsPerRow=4, itemLayout="landscape") content}}
                 {{range bonus := film.Bonuses}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -89,20 +89,20 @@
               {{end}}
               <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}"> {* hide class prevents FOUC *}
                 <div class="meta-detail-synopsis">{{film.Overview | raw}}</div>
-                <div class="meta-detail-cast">
-                {{if len(film.Cast) > 0 }}
-                  <h2>{{i18n("meta_detail_cast_title")}}</h2>
-                {{end}}
-                  <p>
-                    {{range index, member := film.Cast}}
-                      {{ path := "/search.html?q=" + member.Name }}
-                      <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if index < len(film.Cast) - 1}}, {{end}}
-                    {{end}}
-                  </p>
-                </div>
-                <div class="meta-detail-crew d-flex">
+                <div class="meta-detail-info">
+                  {{if len(film.Cast) > 0 }}
+                    <div class="meta-detail-cast">
+                      <h2>{{i18n("meta_detail_cast_title")}}</h2>
+                      <p>
+                        {{range index, member := film.Cast}}
+                          {{ path := "/search.html?q=" + member.Name }}
+                          <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if index < len(film.Cast) - 1}}, {{end}}
+                        {{end}}
+                      </p>
+                    </div>
+                  {{end}}
                   {{range index, member := film.Crew}}
-                    <div class="crew-member">
+                    <div class="meta-detail-crew">
                       <h2>{{member.Job}}</h2>
                       {{ path := "/search.html?q=" + member.Name }}
                       <a href="{{ routeToPath(path) }}">{{member.Name}}</a>

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -25,14 +25,22 @@
     </div>
     <div class="container">
       <div class="meta-detail-main">
-        {{if config("default_image_type") == "portrait"}}
-            <div class="poster poster-portrait">
-              <s72-availability-status data-slug="{{film.Slug}}"></s72-availability-status>
-              <s72-image src="{{film.ImageMap["Classification"]}}" alt="" class="classification-image">
-              <s72-image src="{{film.ImageMap["Portrait"]}}" alt="{{film.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
-
+        <div class="sponsor-poster">
+          {{if isset(film.ImageMap["Sponsor"])}}
+            <div class="sponsor d-xl-none">
+              {{ i18n("sponsor_logo_prefix") }}
+              <s72-image src="{{film.ImageMap["Sponsor"]}}"></s72-image>
             </div>
-        {{end}}
+          {{end}}
+          {{if config("default_image_type") == "portrait"}}
+              <div class="poster poster-portrait">
+                <s72-availability-status data-slug="{{film.Slug}}"></s72-availability-status>
+                <s72-image src="{{film.ImageMap["Classification"]}}" alt="" class="classification-image">
+                <s72-image src="{{film.ImageMap["Portrait"]}}" alt="{{film.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
+
+              </div>
+          {{end}}
+        </div>
         <div class="meta-detail-content">
           <h1>{{ film.Title }}</h1>
           <div class="meta-detail-tagline-and-classification">
@@ -62,92 +70,100 @@
           {{end}}
 
           {{yield awardNominations() film}}
-          <s72-element-switcher>
-            {{if isEnabled("element_switcher_enabled")}}
-              <div class="meta-detail-switcher-tagline">
-                <p>{{film.Tagline}}</p>
-              </div>
-            {{end}}
-            <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}"> {* hide class prevents FOUC *}
-              <div class="meta-detail-synopsis">{{film.Overview | raw}}</div>
-              <div class="meta-detail-cast">
-              {{if len(film.Cast) > 0 }}
-                <h2>{{i18n("meta_detail_cast_title")}}</h2>
-              {{end}}
-                <p>
-                  {{range index, member := film.Cast}}
-                    {{ path := "/search.html?q=" + member.Name }}
-                    <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if index < len(film.Cast) - 1}}, {{end}}
-                  {{end}}
-                </p>
-              </div>
-              <div class="meta-detail-crew d-flex">
-                {{range index, member := film.Crew}}
-                  <div class="crew-member">
-                    <h2>{{member.Job}}</h2>
-                    {{ path := "/search.html?q=" + member.Name }}
-                    <a href="{{ routeToPath(path) }}">{{member.Name}}</a>
-                  </div>
-                {{end}}
-              </div>
-              {{if len(film.Languages) > 0 }}
-                <div class="meta-detail-language">
-                  <h2>{{i18n("meta_detail_languages", len(film.Languages))}}</h2>
-                  <p>{{ film.Languages }}</p>
+          <div class="element-switcher-sponsor">
+            <s72-element-switcher>
+              {{if isEnabled("element_switcher_enabled")}}
+                <div class="meta-detail-switcher-tagline">
+                  <p>{{film.Tagline}}</p>
                 </div>
               {{end}}
-              {{allSubtitles := film.GetSubtitles()}}
-              {{if len(allSubtitles) > 0 }}
-                {{subtitles := ""}}
-                {{captions := ""}}
-                {{if len(film.SubtitleTracks) == 0}}
-                  {{subtitles = allSubtitles}}
-                {{else}}
-                  {{range subTrack := film.SubtitleTracks}}
-                    {{if len(subTrack) >= 3}}
-                      {{if subTrack[2] == "caption"}}
-                          {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
-                      {{else}}
-                          {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
+              <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}"> {* hide class prevents FOUC *}
+                <div class="meta-detail-synopsis">{{film.Overview | raw}}</div>
+                <div class="meta-detail-cast">
+                {{if len(film.Cast) > 0 }}
+                  <h2>{{i18n("meta_detail_cast_title")}}</h2>
+                {{end}}
+                  <p>
+                    {{range index, member := film.Cast}}
+                      {{ path := "/search.html?q=" + member.Name }}
+                      <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if index < len(film.Cast) - 1}}, {{end}}
+                    {{end}}
+                  </p>
+                </div>
+                <div class="meta-detail-crew d-flex">
+                  {{range index, member := film.Crew}}
+                    <div class="crew-member">
+                      <h2>{{member.Job}}</h2>
+                      {{ path := "/search.html?q=" + member.Name }}
+                      <a href="{{ routeToPath(path) }}">{{member.Name}}</a>
+                    </div>
+                  {{end}}
+                </div>
+                {{if len(film.Languages) > 0 }}
+                  <div class="meta-detail-language">
+                    <h2>{{i18n("meta_detail_languages", len(film.Languages))}}</h2>
+                    <p>{{ film.Languages }}</p>
+                  </div>
+                {{end}}
+                {{allSubtitles := film.GetSubtitles()}}
+                {{if len(allSubtitles) > 0 }}
+                  {{subtitles := ""}}
+                  {{captions := ""}}
+                  {{if len(film.SubtitleTracks) == 0}}
+                    {{subtitles = allSubtitles}}
+                  {{else}}
+                    {{range subTrack := film.SubtitleTracks}}
+                      {{if len(subTrack) >= 3}}
+                        {{if subTrack[2] == "caption"}}
+                            {{captions = captions ? captions + ", " + subTrack[1] : subTrack[1]}}
+                        {{else}}
+                            {{subtitles = subtitles ? subtitles + ", " + subTrack[1] : subTrack[1]}}
+                        {{end}}
                       {{end}}
                     {{end}}
                   {{end}}
+                  {{if subtitles}}
+                    <div class="meta-detail-subtitle">
+                      <h2>{{i18n("meta_detail_subtitles")}}</h2>
+                      <p>{{subtitles}}</p>
+                    </div>
+                  {{end}}
+                  {{if captions}}
+                    <div class="meta-detail-subtitle">
+                      <h2>{{i18n("meta_detail_captions")}}</h2>
+                      <p>{{captions}}</p>
+                    </div>
+                  {{end}}
                 {{end}}
-                {{if subtitles}}
-                  <div class="meta-detail-subtitle">
-                    <h2>{{i18n("meta_detail_subtitles")}}</h2>
-                    <p>{{subtitles}}</p>
+                {{if len(film.Countries) > 0 }}
+                  <div class="meta-detail-country">
+                    <h2>{{i18n("meta_detail_countries", len(film.Countries))}}</h2>
+                    <p>{{ film.Countries }}</p>
                   </div>
                 {{end}}
-                {{if captions}}
-                  <div class="meta-detail-subtitle">
-                    <h2>{{i18n("meta_detail_captions")}}</h2>
-                    <p>{{captions}}</p>
+                {{if len(film.Studio) > 0 }}
+                  <div class="meta-detail-studio">
+                    <h2>{{i18n("meta_detail_studios", len(film.Studio))}}</h2>
+                    {*{ FORMAT STUDIOS }*}
+                    {{ studios := "" }}
+                    {{ range studio := film.Studio }}
+                      {{ studios = studios + studio + ", "}}
+                    {{ end }}
+                    {{ if len(studios) > 0 }}
+                      {{ studios = studios[0:len(studios) - 2] }}
+                    {{ end }}
+                    <p>{{ studios }}</p>
                   </div>
                 {{end}}
-              {{end}}
-              {{if len(film.Countries) > 0 }}
-                <div class="meta-detail-country">
-                  <h2>{{i18n("meta_detail_countries", len(film.Countries))}}</h2>
-                  <p>{{ film.Countries }}</p>
-                </div>
-              {{end}}
-              {{if len(film.Studio) > 0 }}
-                <div class="meta-detail-studio">
-                  <h2>{{i18n("meta_detail_studios", len(film.Studio))}}</h2>
-                  {*{ FORMAT STUDIOS }*}
-                  {{ studios := "" }}
-                  {{ range studio := film.Studio }}
-                    {{ studios = studios + studio + ", "}}
-                  {{ end }}
-                  {{ if len(studios) > 0 }}
-                    {{ studios = studios[0:len(studios) - 2] }}
-                  {{ end }}
-                  <p>{{ studios }}</p>
-                </div>
-              {{end}}
-            </div>
-          </s72-element-switcher>
+              </div>
+            </s72-element-switcher>
+            {{if isset(film.ImageMap["Sponsor"])}}
+              <div class="sponsor d-none d-xl-flex">
+                {{ i18n("sponsor_logo_prefix") }}
+                <s72-image src="{{film.ImageMap["Sponsor"]}}"></s72-image>
+              </div>
+            {{end}}
+          </div>
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}
             <section class="meta-detail-bonus-content" aria-label="{{i18n("meta_detail_bonus_title")}}">
               <h2>{{i18n("meta_detail_bonus_title")}}</h2>

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -29,7 +29,7 @@
             <s72-image src="{{tvseason.Images.Portrait}}" alt="{{tvseason.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
           </div>
         {{end}}
-        <div class="meta-detail-content meta-detail-info-width">
+        <div class="meta-detail-content">
           <h1>{{tvseason.GetTitle(i18n)}}</h1>
           <div class="meta-detail-tagline">
             {{yield metaItemTagline() tvseason}}
@@ -46,36 +46,38 @@
               {{yield socialMediaButtons(path=currentUrlPath)}}
             </div>
           </div>
-          <s72-element-switcher>
-            {{if isEnabled("element_switcher_enabled")}}
-              <div class="meta-detail-switcher-tagline">
-                <p>{{tvseason.Tagline}}</p>
+          <div class="element-switcher-wrapper">
+            <s72-element-switcher>
+              {{if isEnabled("element_switcher_enabled")}}
+                <div class="meta-detail-switcher-tagline">
+                  <p>{{tvseason.Tagline}}</p>
+                </div>
+              {{end}}
+              <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}"> {* hide class prevents FOUC *}
+                <div class="meta-detail-synopsis">{{tvseason.Overview | raw}}</div>
+                <div class="meta-detail-info">
+                  {{if len(tvseason.Cast) > 0 }}
+                    <div class="meta-detail-cast">
+                      <h2>{{i18n("meta_detail_cast_title")}}</h2>
+                      <p>
+                        {{range index, member := tvseason.Cast}}
+                          {{ path := "/search.html?q=" + member.Name }}
+                          <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if index < len(tvseason.Cast) - 1}}, {{end}}
+                        {{end}}
+                      </p>
+                    </div>
+                  {{end}}
+                  {{range index, member := tvseason.Crew}}
+                    <div class="meta-detail-crew">
+                      <h2>{{member.Job}}</h2>
+                      {{ path := "/search.html?q=" + member.Name }}
+                      <a href="{{ routeToPath(path) }}"">{{member.Name}}</a>
+                    </div>
+                  {{end}}
+                </div>
               </div>
-            {{end}}
-            <div class="{{ isEnabled("element_switcher_enabled") ? "s72-hide" : "" }}"> {* hide class prevents FOUC *}
-              <div class="meta-detail-synopsis">{{tvseason.Overview | raw}}</div>
-              <div class="meta-detail-info">
-                {{if len(tvseason.Cast) > 0 }}
-                  <div class="meta-detail-cast">
-                    <h2>{{i18n("meta_detail_cast_title")}}</h2>
-                    <p>
-                      {{range index, member := tvseason.Cast}}
-                        {{ path := "/search.html?q=" + member.Name }}
-                        <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if index < len(tvseason.Cast) - 1}}, {{end}}
-                      {{end}}
-                    </p>
-                  </div>
-                {{end}}
-                {{range index, member := tvseason.Crew}}
-                  <div class="meta-detail-crew">
-                    <h2>{{member.Job}}</h2>
-                    {{ path := "/search.html?q=" + member.Name }}
-                    <a href="{{ routeToPath(path) }}"">{{member.Name}}</a>
-                  </div>
-                {{end}}
-              </div>
-            </div>
-          </s72-element-switcher>
+            </s72-element-switcher>
+          </div>
 
           {{if len(tvseason.Episodes) > 0}}
             <div class="meta-detail-episodes-content">

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -106,8 +106,6 @@
           {{end}}
         </div>
       </div>
-        </div>
-      </div>
     </div>
     {{if len(tvseason.Recommendations) > 0 }}
       <section class="page-collection recommendations-collection" aria-label="{{i18n("meta_detail_recommendations_title")}}">

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -29,7 +29,7 @@
             <s72-image src="{{tvseason.Images.Portrait}}" alt="{{tvseason.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
           </div>
         {{end}}
-        <div class="meta-detail-content">
+        <div class="meta-detail-content meta-detail-info-width">
           <h1>{{tvseason.GetTitle(i18n)}}</h1>
           <div class="meta-detail-tagline">
             {{yield metaItemTagline() tvseason}}

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "aboneliklerim"
+  },
+  "sponsor_image_alt": {
+    "other": "sponsor logosu"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "aboneliklerim"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Tarafından getirildi:"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "aboneliklerim"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Tarafından getirildi:"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1314,5 +1314,8 @@
   },
   "nav_subscriptions": {
     "other": "Мої підписки"
+  },
+  "sponsor_image_alt": {
+    "other": "логотип спонсора"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1314,5 +1314,8 @@
   },
   "nav_subscriptions": {
     "other": "Мої підписки"
+  },
+  "sponsor_logo_prefix": {
+    "other": "Надано вам:"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1314,8 +1314,5 @@
   },
   "nav_subscriptions": {
     "other": "Мої підписки"
-  },
-  "sponsor_logo_prefix": {
-    "other": "Надано вам:"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1286,8 +1286,5 @@
   },
   "nav_subscriptions": {
     "other": "我的订阅"
-  },
-  "sponsor_logo_prefix": {
-    "other": "为您带来："
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "我的订阅"
+  },
+  "sponsor_logo_prefix": {
+    "other": "为您带来："
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1286,5 +1286,8 @@
   },
   "nav_subscriptions": {
     "other": "我的订阅"
+  },
+  "sponsor_image_alt": {
+    "other": "赞助商标志"
   }
 }


### PR DESCRIPTION
This PR does the following:
-  If image called "Sponsor" is uploaded on a film, add s72-image (wrapped in .sponsor div) for it in two separate places on film detail page - one for mobile, one for desktop
-  I wanted to only add one image element above poster, and utilise position absolute for desktop, but it is not possible mainly due to the design asks the logo align with the top of film description on desktop.

Note:
- To test point the template to staging-store.shift72.com, I've uploaded sponsor images to most homepage films
- Will add carousel at later date (blocked by upcoming carousel) have to wait until position absolute is removed
- There were no designs for multiline supporting text, so I've tried to come up with a happy medium between the two
- please view diff with 'Hide whitespace'

Designs:
- [Mobile](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/6142ba83fd3fd250f50e6216)
- [Tablet](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/6142baeda13fc726053e405a)
- [Desktop](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/6142bb2eb8582a2b4c2c93ee)