### PR TITLE
Fix: Handle multiple sentences in script

### DIFF
--- a/scripts/translate.mjs
+++ b/scripts/translate.mjs
@@ -40,7 +40,8 @@ glob('./site/*.json', {}, (err, files) => {
         })
         .then(translated => {
           if (translated) {
-            const translatedValue = translated[0][0][0];
+            let translatedValue = '';
+            translated[0].forEach(each => translatedValue += each[0]);
             writeTranslationFile(translatedValue);
           }
         });


### PR DESCRIPTION
Seems like Transalate API return response in array if there are more
than one sentence.

API sample:
https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=fr&dt=t&q=First sentance. Second sentance
vs
https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=fr&dt=t&q=First sentance Second sentance