### PR TITLE
rm outline on click respecting screen readers

### DIFF
--- a/site/styles/_shift72.scss
+++ b/site/styles/_shift72.scss
@@ -9,6 +9,10 @@
   .s72-icon {
     margin-left: 0.3em;
   }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: none;
+  }
 }
 
 .s72-btn-search {


### PR DESCRIPTION
As per [AB#7775](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/7775) fix "Blue outline is showing after any of the Share Modal options are selected"

Using a fix that doesnt break screen readers:
https://css-tricks.com/the-focus-visible-trick/