### PR TITLE
add sponsor logo image carousel

### DIFF
--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -17,7 +17,7 @@ s72-carousel {
     height: var(--carousel-height-md) !important;
   }
 
-  s72-image {
+  .carousel-item-link > s72-image {
     float: right;
     height: var(--carousel-height);
     max-width: 1600px;
@@ -103,6 +103,8 @@ s72-carousel {
 
 .carousel-item-caption {
   left: 0;
+  right: 0;
+  bottom: 0;
   padding: 0 20px;
   position: absolute;
   top: var(--carousel-caption-top);
@@ -110,30 +112,31 @@ s72-carousel {
   @include media-breakpoint-up(xs) {
     left: 60px;
     top: var(--carousel-caption-top-xs);
-    width: 70%;
   }
   @include media-breakpoint-up(md) {
     left: 60px;
     top: var(--carousel-caption-top-md);
-    width: 70%;
   }
   @include media-breakpoint-up(lg) {
     left: 70px;
     top: var(--carousel-caption-top-md);
-    width: 70%;
   }
   @include media-breakpoint-up(xl) {
     left: 120px;
     top: var(--carousel-caption-top-md);
-    width: 50%;
   }
   @include media-breakpoint-up(xxxl) {
     top: var(--carousel-caption-top-md);
-    width: 50%;
   }
 
   .meta-item-content {
     color: var(--body-color);
+    @include media-breakpoint-up(xs) {
+      width: 70%;
+    }
+    @include media-breakpoint-up(xl) {
+      width: 50%;
+    }
 
     h3 {
       color: var(--body-color);
@@ -243,6 +246,15 @@ s72-carousel {
   .s72-btn-play {
     circle {
       fill: transparent;
+    }
+  }
+
+  .sponsor {
+    @include media-breakpoint-up(xl) {
+      position: absolute;
+      right: 140px;
+      bottom: 140px;
+      text-align: right;
     }
   }
 }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -104,11 +104,11 @@ s72-carousel {
 }
 
 .carousel-item-caption {
-  left: 0;
-  right: 0;
   bottom: 0;
+  left: 0;
   padding: 0 20px;
   position: absolute;
+  right: 0;
   top: var(--carousel-caption-top);
   z-index: 999;
   @include media-breakpoint-up(xs) {
@@ -253,9 +253,9 @@ s72-carousel {
 
   .sponsor {
     @include media-breakpoint-up(xl) {
+      bottom: 140px;
       position: absolute;
       right: 140px;
-      bottom: 140px;
       text-align: right;
     }
   }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -49,6 +49,7 @@ s72-carousel {
       }
     }
 
+    /* stylelint-disable selector-max-compound-selectors */
     img {
       height: var(--carousel-height);
       margin-left: 50%;
@@ -62,6 +63,7 @@ s72-carousel {
         width: auto;
       }
     }
+    /* stylelint-enable selector-max-compound-selectors */
   }
 
   .s72-pricing-button-container {

--- a/site/templates/collection/carousel_item.jet
+++ b/site/templates/collection/carousel_item.jet
@@ -1,5 +1,6 @@
 {{import "../items/tagline.jet"}}
 {{import "../common/awards/carousel.jet"}}
+{{import "../common/sponsor-image.jet"}}
 
 {{block carouselItem(item)}}
   {{ trailer := "" }}
@@ -19,6 +20,9 @@
 
       {{if !isset(item["PageType"]) || item.PageType != "external"}}
         <div class="carousel-item-caption">
+          {{if item.ItemType == "film"}}
+            {{yield sponsor(hideLink="true") item.InnerItem}}
+          {{end}}
           <div class="meta-item-content">
             <h3>{{item.GetTitle(i18n)}}
               {{if isset(item.InnerItem["ReleaseDate"]) && item.InnerItem.ReleaseDate.Year() > 1}}

--- a/site/templates/common/sponsor-image.jet
+++ b/site/templates/common/sponsor-image.jet
@@ -1,4 +1,4 @@
-{{block sponsor()}}
+{{block sponsor(hideLink)}}
   {{sponsorImage := .ImageMap["Sponsor"]}}
 
   {{if isset(sponsorImage)}}
@@ -10,9 +10,9 @@
       {{if sponsorText}}
         <div>{{sponsorText}}</div>
       {{end}}
-      {{if sponsorLink}}<a href="{{sponsorLink}}" {{if sponsorLinkIsExternal}} target="_blank" {{end}}>{{end}}
+      {{if sponsorLink && !hideLink}}<a href="{{sponsorLink}}" {{if sponsorLinkIsExternal}} target="_blank" {{end}}>{{end}}
         <s72-image src="{{sponsorImage}}" alt="{{ i18n("sponsor_image_alt") }}" ></s72-image>
-      {{if sponsorLink}}</a>{{end}}
+      {{if sponsorLink && !hideLink}}</a>{{end}}
     </div>
   {{end}}
 {{end}}


### PR DESCRIPTION
In a [previous PR](https://github.com/shift72/core-template/pull/320) we added sponsor images to a film detail page. This PR adds this to carousel also.

- upload a 'sponsor' type image to a film to see it (point template to staging-store.shift72.com a couple already uploaded)
- also set custom field: "sponsor_image_text_film" to add text above it
- [AB#5032](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Web%20team/Stories/?workitem=5032)
- [Designs](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/6209be832a8eafa8366b818c)