### PR TITLE
AB#6124 Subscribe to watch button

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1313,5 +1313,8 @@
   },
   "sponsor_image_alt": {
     "other": "شعار الراعي"
+  },
+  "subscribe_to_watch": {
+    "other": "اشترك للمشاهدة"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1313,5 +1313,8 @@
   },
   "sponsor_image_alt": {
     "other": "logotip del patrocinador"
+  },
+  "subscribe_to_watch": {
+    "other": "Subscriu-te per veure'l"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1313,5 +1313,8 @@
   },
   "sponsor_image_alt": {
     "other": "sponsor logo"
+  },
+  "subscribe_to_watch": {
+    "other": "Abonner for at se"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1313,5 +1313,8 @@
   },
   "sponsor_image_alt": {
     "other": "Sponsorenlogo"
+  },
+  "subscribe_to_watch": {
+    "other": "Zum Ansehen abonnieren"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "λογότυπο χορηγού"
+  },
+  "subscribe_to_watch": {
+    "other": "Εγγραφείτε για να παρακολουθήσετε"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "sponsor logo"
+  },
+  "subscribe_to_watch": {
+    "other": "Subscribe to watch"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "logotipo del patrocinador"
+  },
+  "subscribe_to_watch": {
+    "other": "Suscríbete para ver"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "logotipo del patrocinador"
+  },
+  "subscribe_to_watch": {
+    "other": "Suscríbete para ver"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1313,5 +1313,8 @@
   },
   "sponsor_image_alt": {
     "other": "sponsori logo"
+  },
+  "subscribe_to_watch": {
+    "other": "Tellige vaatamiseks"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "sponsorin logo"
+  },
+  "subscribe_to_watch": {
+    "other": "Tilaa katsoaksesi"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "logo du sponsor"
+  },
+  "subscribe_to_watch": {
+    "other": "Abonnez-vous pour regarder"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1296,5 +1296,8 @@
   },
   "sponsor_image_alt": {
     "other": "logotip sponzora"
+  },
+  "subscribe_to_watch": {
+    "other": "Pretplatite se na gledanje"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1313,5 +1313,8 @@
   },
   "sponsor_image_alt": {
     "other": "szponzor logó"
+  },
+  "subscribe_to_watch": {
+    "other": "Iratkozz fel a nézéshez"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "logo dello sponsor"
+  },
+  "subscribe_to_watch": {
+    "other": "Iscriviti per guardare"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "スポンサーロゴ"
+  },
+  "subscribe_to_watch": {
+    "other": "視聴するために購読する"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "rėmėjo logotipas"
+  },
+  "subscribe_to_watch": {
+    "other": "Prenumeruokite žiūrėti"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "sponsorlogo"
+  },
+  "subscribe_to_watch": {
+    "other": "Abonneer om te kijken"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "sponsorlogo"
+  },
+  "subscribe_to_watch": {
+    "other": "Abonner for å se"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1349,5 +1349,8 @@
   },
   "sponsor_image_alt": {
     "other": "logo sponsora"
+  },
+  "subscribe_to_watch": {
+    "other": "Zapisz się do oglądania"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "logotipo do patrocinador"
+  },
+  "subscribe_to_watch": {
+    "other": "Inscreva-se para assistir"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "logotipo do patrocinador"
+  },
+  "subscribe_to_watch": {
+    "other": "Inscreva-se para assistir"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1326,5 +1326,8 @@
   },
   "sponsor_image_alt": {
     "other": "логотип спонсора"
+  },
+  "subscribe_to_watch": {
+    "other": "Подпишитесь, чтобы смотреть"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "логотип спонзора"
+  },
+  "subscribe_to_watch": {
+    "other": "Претплатите се на гледање"
   }
 }

--- a/site/styles/_buttons.scss
+++ b/site/styles/_buttons.scss
@@ -40,7 +40,8 @@
 }
 
 .btn.btn-signin-primary,
-.btn.btn-signup {
+.btn.btn-signup,
+.s72-btn-subscribe {
   align-items: center;
   background-color: $signup-background;
   border: 3px solid $signup-border-color;

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -221,6 +221,7 @@ s72-carousel {
     margin-left: -0.5rem;
     margin-right: -0.5rem;
 
+    /* stylelint-disable selector-max-compound-selectors */
     .s72-subscribe{
       margin-right: 0.5em;
       .s72-btn-subscribe{
@@ -228,7 +229,6 @@ s72-carousel {
       }
     }
 
-    /* stylelint-disable selector-max-compound-selectors */
     s72-pricing-buttons .s72-btn,
     .meta-detail-extras,
     .meta-item-extras,

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -238,6 +238,7 @@ s72-carousel {
       margin-bottom: 10px;
       margin-left: 0.5rem;
       margin-right: 0.5rem;
+      padding-top: 6px;
     }
 
     // Handles spacing when there is only rent, only buy, or only play button

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -221,12 +221,20 @@ s72-carousel {
     margin-left: -0.5rem;
     margin-right: -0.5rem;
 
+    .s72-subscribe{
+      margin-right: 0.5em;
+      .s72-btn-subscribe{
+        margin-bottom: 5px;
+      }
+    }
+
     /* stylelint-disable selector-max-compound-selectors */
     s72-pricing-buttons .s72-btn,
     .meta-detail-extras,
     .meta-item-extras,
     s72-play-button,
     can-be-watched-button:not(:empty) {
+      align-self: flex-start;
       margin-bottom: 10px;
       margin-left: 0.5rem;
       margin-right: 0.5rem;

--- a/site/styles/_collections.scss
+++ b/site/styles/_collections.scss
@@ -244,6 +244,10 @@
       }
     }
 
+    .s72-subscribe-trial-label {
+      display: none;
+    }
+
     &:hover {
       .hover {
         display: none !important;

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -209,16 +209,19 @@ s72-element-switcher,
   .meta-detail-buttons {
     margin-left: -0.5rem;
 
-    .s72-subscribe{
-      margin-right: 0.5em;
-    }
-
     // Purchase, play, trailer, wishlist are all in one group now
     // Need similar bootstrap approach of handling/wrapping rows and columns via negative margin
     margin-right: -0.5rem;
     min-height: 45px;
 
     /* stylelint-disable selector-max-compound-selectors */
+    .s72-subscribe{
+      margin-right: 0.5em;
+      .s72-btn-subscribe{
+        margin-bottom: 5px;
+      }
+    }
+
     s72-pricing-buttons .s72-btn,
     .meta-detail-extras,
     s72-play-button,

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -209,6 +209,10 @@ s72-element-switcher,
   .meta-detail-buttons {
     margin-left: -0.5rem;
 
+    .s72-subscribe{
+      margin-right: 0.5em;
+    }
+
     // Purchase, play, trailer, wishlist are all in one group now
     // Need similar bootstrap approach of handling/wrapping rows and columns via negative margin
     margin-right: -0.5rem;

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -230,6 +230,7 @@ s72-element-switcher,
       animation: fadein 2s;
       margin-left: 0.5rem;
       margin-right: 0.5rem;
+      padding-top: 6px;
     }
 
     s72-modal-player,

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -219,6 +219,7 @@ s72-element-switcher,
     .meta-detail-extras,
     s72-play-button,
     can-be-watched-button:not(:empty) {
+      align-self: flex-start;
       animation: fadein 2s;
       margin-left: 0.5rem;
       margin-right: 0.5rem;

--- a/site/styles/_pages.scss
+++ b/site/styles/_pages.scss
@@ -189,6 +189,10 @@
       padding: 0 5px 10px;
     }
   }
+
+  .s72-btn-subscribe-trial-label {
+    display: none;
+  }
 }
 
 .wishlist-page,

--- a/site/styles/_plans.scss
+++ b/site/styles/_plans.scss
@@ -83,3 +83,17 @@ s72-plan-label {
     display: inline !important;
   }
 }
+
+.s72-subscribe-trial-label {
+  display: block;
+  font-size: 12px;
+  margin-left: 5px;
+  min-width: 140px;
+  padding-left: 15px;
+  white-space: nowrap;
+  width: 0;
+
+  @include media-breakpoint-down(sm) {
+    display: none;
+  }
+}

--- a/site/styles/_shift72.scss
+++ b/site/styles/_shift72.scss
@@ -30,6 +30,10 @@
   @extend .btn-primary-override;
 }
 
+.s72-btn-subscribe {
+  @extend .btn-primary-override;
+}
+
 .s72-btn-close {
   @extend .close;
 }

--- a/site/styles/_slider.scss
+++ b/site/styles/_slider.scss
@@ -106,4 +106,8 @@ s72-slider.has-next.s72-slider-scroll::after {
       position: static;
     }
   }
+
+  .s72-subscribe-trial-label {
+    display: none;
+  }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "sponsor logosu"
+  },
+  "subscribe_to_watch": {
+    "other": "izlemek için abone ol"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1332,5 +1332,8 @@
   },
   "sponsor_image_alt": {
     "other": "логотип спонсора"
+  },
+  "subscribe_to_watch": {
+    "other": "Підпишіться на перегляд"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1304,5 +1304,8 @@
   },
   "sponsor_image_alt": {
     "other": "赞助商标志"
+  },
+  "subscribe_to_watch": {
+    "other": "订阅观看"
   }
 }


### PR DESCRIPTION
[Doc](https://docs.google.com/document/d/1STBQ4nV7Fbu2HXE1aJkbd0--IUeXfPNKEqJxkJsN3Rs/edit#heading=h.xjzfqq5c4okm) || [ADO AB#6124](https://dev.azure.com/S72/SHIFT72/_workitems/edit/6124) || [Design](https://app.zeplin.io/project/607f961cf9f03790cc66e475/screen/6205cb301e8ac288b07757ee)^
 [Related relish work](https://github.com/indiereign/shift72-web/pull/295)

Since there is a change in scope of work I've created this new PR.
There is only subscribe to watch OR pricing buttons. 
3 button state is delayed. 

## Changes in this branch
- Translations
- Styling for the subscribe button to be the primary button styling
- Trial label styling
- Hide trial label on curated pages and mobile size
- ^Trial label will not wrap if it is too long. Go underneath the trailer/share buttons
- ^Subscribe button text will wrap on posters if it can't fit
