### PR TITLE
Fix issue caused by linter moving media query

### DIFF
--- a/site/styles/_meta-sub-item.scss
+++ b/site/styles/_meta-sub-item.scss
@@ -6,27 +6,6 @@
   margin-bottom: 15px;
   padding-bottom: 15px;
 
-  @include media-breakpoint-up(sm) {
-    grid-template-columns: 175px minmax(100px, 1fr);
-    grid-template-rows: auto auto minmax(0, 1fr);
-
-    .synopsis {
-      grid-column: auto;
-      grid-row: 2;
-      margin-bottom: 10px;
-    }
-    .poster-container {
-      grid-row: 1 / 4;
-    }
-    .runtime {
-      margin-bottom: 0;
-      margin-left: 0;
-    }
-    h3 {
-      margin-bottom: 0;
-    }
-  }
-
   h3 {
     color: var(--body-color);
     font-size: 16px;
@@ -101,4 +80,27 @@
       /* stylelint-enable selector-max-compound-selectors */
     }
   }
+
+  /* stylelint-disable */
+  @include media-breakpoint-up(sm) {
+    grid-template-columns: 175px minmax(100px, 1fr);
+    grid-template-rows: auto auto minmax(0, 1fr);
+
+    .synopsis {
+      grid-column: auto;
+      grid-row: 2;
+      margin-bottom: 10px;
+    }
+    .poster-container {
+      grid-row: 1 / 4;
+    }
+    .runtime {
+      margin-bottom: 0;
+      margin-left: 0;
+    }
+    h3 {
+      margin-bottom: 0;
+    }
+  }
+  /* stylelint-enable */
 }


### PR DESCRIPTION
**TLDR: stylelint moved some code, broke bonus/episodes style. Move back and add lint ignore rule.**


- I forgot to add an ignore to stylelint, so when someone else ran it, it moved a media query ([commit](
https://github.com/shift72/core-template/commit/59ddbd13#diff-8621f91c695f61e8fd0f3a81890fd5251371d9eacabd842ed490500ad5403e45R9-R29
)) to above the code it was targeting, making the media query overridden, resulting in layout issues. This PR moves the code back and adds an ignore.

Note: I had to just use /* stylelint-disable */ sorry - couldn't find the exact stylelint rule that moves the code block.