### PR TITLE
quick refactor and lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - Remove whitespaces from mustaches variables in translations.
 - Fix unwanted variables in translations.
+- Sub-item CSS is no longer broken by the linter.
 
 ## [0.6.0-alpha.0](https://github.com/shift72/core-template/compare/0.5.1...0.6.0-alpha.0)
 

--- a/site/styles/_buttons.scss
+++ b/site/styles/_buttons.scss
@@ -281,6 +281,8 @@ s72-donate-button:not(:empty) {
 }
 
 // sitewide we changed primary btn text to black, but these btns had no bg color, rendering text invisible
-.s72-btn-show-saved-cards, .s72-btn-submit-pin, .s72-btn-reset-pin {
-  color:var(--link-color)!important;
+.s72-btn-show-saved-cards,
+.s72-btn-submit-pin,
+.s72-btn-reset-pin {
+  color: var(--link-color) !important;
 }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -112,8 +112,8 @@ s72-carousel {
   .sponsor {
     @include media-breakpoint-up(lg) {
       align-self: flex-end;
-      margin-left: auto;
       margin-bottom: 8px;
+      margin-left: auto;
       order: 1;
     }
   }

--- a/site/styles/_meta-sub-item.scss
+++ b/site/styles/_meta-sub-item.scss
@@ -6,12 +6,21 @@
   margin-bottom: 15px;
   padding-bottom: 15px;
 
+  @include media-breakpoint-up(sm) {
+    grid-template-columns: 175px minmax(100px, 1fr);
+    grid-template-rows: auto auto minmax(0, 1fr);
+  }
+
   h3 {
     color: var(--body-color);
     font-size: 16px;
     font-weight: $font-weight-normal;
     letter-spacing: 0.4px;
     margin-bottom: 15px;
+
+    @include media-breakpoint-up(sm) {
+      margin-bottom: 0;
+    }
   }
 
   &:not(:last-of-type) {
@@ -24,6 +33,10 @@
 
   .poster-container {
     grid-row: 1 / 3;
+
+    @include media-breakpoint-up(sm) {
+      grid-row: 1 / 4;
+    }
   }
 
   .synopsis {
@@ -33,6 +46,13 @@
     letter-spacing: 0.6px;
     line-height: 1.25;
     margin-top: 5px;
+
+    @include media-breakpoint-up(sm) {
+      grid-column: auto;
+      grid-row: 2;
+      margin-bottom: 10px;
+    }
+
     p {
       margin-bottom: 0;
     }
@@ -80,27 +100,4 @@
       /* stylelint-enable selector-max-compound-selectors */
     }
   }
-
-  /* stylelint-disable */
-  @include media-breakpoint-up(sm) {
-    grid-template-columns: 175px minmax(100px, 1fr);
-    grid-template-rows: auto auto minmax(0, 1fr);
-
-    .synopsis {
-      grid-column: auto;
-      grid-row: 2;
-      margin-bottom: 10px;
-    }
-    .poster-container {
-      grid-row: 1 / 4;
-    }
-    .runtime {
-      margin-bottom: 0;
-      margin-left: 0;
-    }
-    h3 {
-      margin-bottom: 0;
-    }
-  }
-  /* stylelint-enable */
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#8222](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8222)

## Description of work
Problem:
The new sub-item CSS is order-dependant and it breaks when the linter runs (at least it did before a linter disabling rule was added).

Solution:
Trust that the linter knows best and refactor the CSS to not be order-dependant.

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
