### PR TITLE
re-add playback-progress, add css from relish and adjust to design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ No changes from `alpha-0`.
 ### Added
 - Keyboard controls for the carousel.
 - Pull request template file.
+- Playback progress component and style
 
 ### Changed
 - Reworked the carousel UI.

--- a/site/styles/_meta-sub-item.scss
+++ b/site/styles/_meta-sub-item.scss
@@ -101,3 +101,16 @@
     }
   }
 }
+
+.s72-playback-progress,
+.s72-playback-progress-bar {
+  height: 6px;
+}
+
+.s72-playback-progress {
+  background-color: rgba(var(--body-bg-rgb), 0.5);
+}
+
+.s72-playback-progress-bar {
+  background-color: var(--secondary);
+}

--- a/site/templates/items/sub_item.jet
+++ b/site/templates/items/sub_item.jet
@@ -4,6 +4,7 @@
       <s72-availability-status slug="{{item.Slug}}"></s72-availability-status>
       <s72-image src="{{item.Images.Landscape}}" alt="{{item.Title}}" class="poster-image poster-image-landscape"></s72-image>
       <s72-play-button data-slug="{{item.Slug}}" title="{{item.Title}}"></s72-play-button>
+      <s72-playback-progress slug="{{item.Slug}}"></s72-playback-progress>
     </div>
   </div>
   <h3>{{item.Title}}</h3>


### PR DESCRIPTION
ADO card: ☑️ [AB#8102](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8102)

Designs: 
- 📱 [Mobile](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/6142ba83fd3fd250f50e6216)
- 💊 [Tablet](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/6142baeda13fc726053e405a)
- 🖥 [Desktop](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/6142bb2eb8582a2b4c2c93ee)

## Description of work
- At some point s72-playback-progress was removed from template
- This pr just adds it to bonus/episodes, adds style for height and color
