### PR TITLE
AB#8128 Pass explicit paths into share modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ No changes from `alpha-0`.
 ### Added
 - Keyboard controls for the carousel.
 - Pull request template file.
+- `path` parameter in share modals
 
 ### Changed
 - Reworked the carousel UI.

--- a/site/templates/bundle/extras.jet
+++ b/site/templates/bundle/extras.jet
@@ -8,6 +8,6 @@
 
     <s72-userwishlist-button data-slug="{{slug}}" class="btn-wishlist"></s72-userwishlist-button>
 
-    {{yield socialMediaButtons(path=currentUrlPath)}}
+    {{yield socialMediaButtons(path=site.SiteConfig.SiteURL + routeToSlug(slug))}}
   </div>
 {{end}}

--- a/site/templates/bundle/extras.jet
+++ b/site/templates/bundle/extras.jet
@@ -8,6 +8,6 @@
 
     <s72-userwishlist-button data-slug="{{slug}}" class="btn-wishlist"></s72-userwishlist-button>
 
-    {{yield socialMediaButtons(path=site.SiteConfig.SiteURL + routeToSlug(slug))}}
+    {{yield socialMediaButtons(url=site.SiteConfig.SiteURL + routeToSlug(slug))}}
   </div>
 {{end}}

--- a/site/templates/collection/carousel/item/extras.jet
+++ b/site/templates/collection/carousel/item/extras.jet
@@ -13,6 +13,6 @@
 
     <s72-userwishlist-button data-slug="{{slug}}" class="btn-wishlist"></s72-userwishlist-button>
 
-    {{yield socialMediaButtons(path=currentUrlPath, letterboxdID=letterboxdID)}}
+    {{yield socialMediaButtons(path=site.SiteConfig.SiteURL + routeToSlug(slug), letterboxdID=letterboxdID)}}
   </div>
 {{end}}

--- a/site/templates/collection/carousel/item/extras.jet
+++ b/site/templates/collection/carousel/item/extras.jet
@@ -13,6 +13,6 @@
 
     <s72-userwishlist-button data-slug="{{slug}}" class="btn-wishlist"></s72-userwishlist-button>
 
-    {{yield socialMediaButtons(path=site.SiteConfig.SiteURL + routeToSlug(slug), letterboxdID=letterboxdID)}}
+    {{yield socialMediaButtons(url=site.SiteConfig.SiteURL + routeToSlug(slug), letterboxdID=letterboxdID)}}
   </div>
 {{end}}

--- a/site/templates/common/social-media-buttons.jet
+++ b/site/templates/common/social-media-buttons.jet
@@ -1,11 +1,11 @@
-{{block socialMediaButtons(path="", title="", letterboxdID="")}}
+{{block socialMediaButtons(url="", title="", letterboxdID="")}}
 {{show_facebook_share := config("show_facebook_share", "true") == "true"}}
 {{show_twitter_share := config("show_twitter_share", "true") == "true"}}
 {{show_linkedin_share := config("show_linkedin_share", "true") == "true"}}
 
 	{{if show_facebook_share || show_twitter_share || show_linkedin_share || letterboxdID}}
 		<div class="social-media-buttons">
-			<s72-share-modal {{letterboxdID ? "letterboxd=" + letterboxdID : ""}} path="{{path}}"></s72-share-modal>
+			<s72-share-modal {{letterboxdID ? "letterboxd=" + letterboxdID : ""}} url="{{url}}"></s72-share-modal>
 		</div>
 	{{end}}
 {{end}}

--- a/site/templates/common/social-media-buttons.jet
+++ b/site/templates/common/social-media-buttons.jet
@@ -5,7 +5,7 @@
 
 	{{if show_facebook_share || show_twitter_share || show_linkedin_share || letterboxdID}}
 		<div class="social-media-buttons">
-			<s72-share-modal {{letterboxdID ? "letterboxd=" + letterboxdID : ""}}></s72-share-modal>
+			<s72-share-modal {{letterboxdID ? "letterboxd=" + letterboxdID : ""}} path="{{path}}"></s72-share-modal>
 		</div>
 	{{end}}
 {{end}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -57,7 +57,7 @@
                   <s72-modal-player src="{{film.Trailers[0].URL}}" class="s72-btn-trailer" data-slug="{{film.Slug}}" data-label="{{i18n("play_trailer")}}" autoplay="querystring"></s72-modal-player>
               {{end}}
               <s72-userwishlist-button data-slug="{{film.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
-                {{yield socialMediaButtons(path=site.SiteConfig.SiteURL + routeToSlug(film.Slug), letterboxdID=film.Refs.LetterboxdID)}}
+                {{yield socialMediaButtons(url=site.SiteConfig.SiteURL + routeToSlug(film.Slug), letterboxdID=film.Refs.LetterboxdID)}}
             </div>
           </div>
           {{if config("default_image_type") != "portrait"}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -57,7 +57,7 @@
                   <s72-modal-player src="{{film.Trailers[0].URL}}" class="s72-btn-trailer" data-slug="{{film.Slug}}" data-label="{{i18n("play_trailer")}}" autoplay="querystring"></s72-modal-player>
               {{end}}
               <s72-userwishlist-button data-slug="{{film.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
-              {{yield socialMediaButtons(path=currentUrlPath, letterboxdID=film.Refs.LetterboxdID)}}
+                {{yield socialMediaButtons(path=site.SiteConfig.SiteURL + routeToSlug(film.Slug), letterboxdID=film.Refs.LetterboxdID)}}
             </div>
           </div>
           {{if config("default_image_type") != "portrait"}}

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -42,7 +42,7 @@
                 <s72-modal-player src="{{tvseason.Trailers[0].URL}}" class="s72-btn-trailer" data-slug="{{tvseason.Slug}}" data-label="{{i18n("play_trailer")}}" autoplay="querystring"></s72-modal-player>
               {{end}}
               <s72-userwishlist-button data-slug="{{tvseason.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
-              {{yield socialMediaButtons(path=currentUrlPath)}}
+              {{yield socialMediaButtons(path=site.SiteConfig.SiteURL + routeToSlug(tvseason.Slug))}}
             </div>
           </div>
           <div class="element-switcher-wrapper">

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -42,7 +42,7 @@
                 <s72-modal-player src="{{tvseason.Trailers[0].URL}}" class="s72-btn-trailer" data-slug="{{tvseason.Slug}}" data-label="{{i18n("play_trailer")}}" autoplay="querystring"></s72-modal-player>
               {{end}}
               <s72-userwishlist-button data-slug="{{tvseason.Slug}}" class="btn-wishlist"></s72-userwishlist-button>
-              {{yield socialMediaButtons(path=site.SiteConfig.SiteURL + routeToSlug(tvseason.Slug))}}
+              {{yield socialMediaButtons(url=site.SiteConfig.SiteURL + routeToSlug(tvseason.Slug))}}
             </div>
           </div>
           <div class="element-switcher-wrapper">


### PR DESCRIPTION
ADO card: ☑️ [AB#8128](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Web%20team/Stories/?workitem=8128)

Elab notes/AC: 📃 [Google Docs](https://docs.google.com)
- [❌] Has this been discussed with Delivery Team?

## Description of work
- Currently the share modal "shares" the current URL (i.e. `window.location.href`)
- This means clicking the share modal from the homepage carousel shares the homepage URL to Facebook, Twitter etc
- Support for an explicit attribute "path" in the ShareModal component has been introduced into Relish (under review)
- Template function `socialMediaButtons` had support for passing a path into the social media buttons but it wasn't used for anything
- Pass this path into the share modal
- If this is empty or missing it falls back to `window.location.href` in the component
- Update files film/item.jet, bundle/extras.jet, tv/detail.jet and carousel/item/extras.jet to include URLs (including domain name) when calling `socialMediaButtons`
- Possibly net positive of explicit URLs is removing query string parameters from URLs

## Edge cases/Caveats/Known issues
(none)

## Config settings/Toggles required for the feature to work
(nothing new)

## Related PRs 
https://github.com/indiereign/shift72-web/pull/307

### Any PRs which this PR depends on
- Relish - as above

### Affected Clients
 - I don't think the new carousel is rolled out yet

## Checklist
- [✅] CI tests are passing Github actions (inc. linting)
- [✅] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [✅] Updated changelog (if applicable)
- [✅] I promise to document any new feature toggles/configurations in the appropriate documentation
