### PR TITLE
Carousel right aligned backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Keyboard controls for the carousel.
 - Pull request template file.
+- Carousel background can now be right-aligned or centered.
 
 ### Changed
 - Reworked the carousel UI.

--- a/kibble.json
+++ b/kibble.json
@@ -1,7 +1,7 @@
 {
   "name": "core-template",
   "version": "0.0.1",
-  "siteUrl": "https://staging-test.shift72.com",
+  "siteUrl": "https://abccinemas.screenplus.co",
   "builderVersion": "0.16.6",
   "defaultLanguage": "en",
   "languages": {

--- a/kibble.json
+++ b/kibble.json
@@ -1,7 +1,7 @@
 {
   "name": "core-template",
   "version": "0.0.1",
-  "siteUrl": "https://abccinemas.screenplus.co",
+  "siteUrl": "https://staging-test.shift72.com",
   "builderVersion": "0.16.6",
   "defaultLanguage": "en",
   "languages": {

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -41,11 +41,30 @@ s72-carousel {
     white-space: nowrap;
   }
 }
-.carousel-item-link > s72-image {
+.carousel-item-image-container {
   height: 100%;
   position: absolute;
   top: 0;
   width: 100%;
+
+  s72-image {
+    position: relative;
+    height: 100%;
+  }
+
+  &.center s72-image {
+    width: 100%;
+  }
+
+  &.right s72-image {
+    width: auto;
+    float: right;
+  }
+
+  .left-gradient-bg {
+    height: 100%;
+    width: 60%;
+  }
 
   img {
     height: 100%;

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -63,7 +63,7 @@ s72-carousel {
 
   .left-gradient-bg {
     height: 100%;
-    width: 60%;
+    width: var(--carousel-left-gradient-width);
   }
 
   img {

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -48,8 +48,8 @@ s72-carousel {
   width: 100%;
 
   s72-image {
-    position: relative;
     height: 100%;
+    position: relative;
   }
 
   &.center s72-image {
@@ -57,8 +57,8 @@ s72-carousel {
   }
 
   &.right s72-image {
-    width: auto;
     float: right;
+    width: auto;
   }
 
   .left-gradient-bg {

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -40,6 +40,8 @@
   --s72-carousel-container-height: 480px;
   --s72-carousel-container-height-sm: 480px; // 550 - 100 + 30
   --s72-carousel-container-height-lg: 478px; // 620 - 172 + 30
+
+  --carousel-left-gradient-width: 60%; // Percentage of image width
 }
 
 // Bootstrap 4 overrides START

--- a/site/templates/collection/carousel/item/image.jet
+++ b/site/templates/collection/carousel/item/image.jet
@@ -1,5 +1,15 @@
 {{block carouselItemImage()}}
   {{if isset(.Images["Carousel"])}}
-    <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image"></s72-image>
+    {{alignment := "center"}}
+    {{if config("carousel_image_alignment") == "true"}}
+      {{alignment = "right"}}
+    {{end}}
+    <div class="carousel-item-image-container {{alignment}}">
+      <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image">
+        {{if alignment == "right"}}
+          <div class="left-gradient-bg"></div>
+        {{end}}
+      </s72-image>
+    </div>
   {{end}}
 {{end}}

--- a/site/templates/collection/carousel/item/image.jet
+++ b/site/templates/collection/carousel/item/image.jet
@@ -1,7 +1,7 @@
 {{block carouselItemImage()}}
   {{if isset(.Images["Carousel"])}}
     {{alignment := "center"}}
-    {{if config("carousel_image_alignment") == "true"}}
+    {{if config("carousel_image_right_aligned") == "true"}}
       {{alignment = "right"}}
     {{end}}
     <div class="carousel-item-image-container {{alignment}}">


### PR DESCRIPTION
ADO card: ☑️ [AB#8123](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8123)

## Description of work
Allows carousel images to be right aligned with a left gradient. This can be used as a failsafe if clients want their images to continue being right aligned after we upgrade them.

This work is currently deployed to [staging-test](https://staging-test.shift72.com).

## Config settings/Toggles required for the feature to work
- `Uber Admin > Users > Configuarations > carousel_image_right_alignment`. Set to `true` (public)

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [ ] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
