### PR TITLE
Max width fix

### DIFF
--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -155,11 +155,9 @@ s72-element-switcher,
 .meta-detail-bonus-content,
 .meta-detail-episodes-content {
   flex: 1 1 100%;
+  max-width: 728px;
 
-  @include media-breakpoint-up(md) {
-    max-width: 563px;
-  }
-  @include media-breakpoint-up(xl) {
+  @include media-breakpoint-up(xxxl) {
     max-width: 1100px;
   }
 }
@@ -173,14 +171,17 @@ s72-element-switcher,
     font-weight: $font-weight-bold;
     margin-bottom: 0;
     text-shadow: none;
+    max-width: 728px;
+    
     @include media-breakpoint-up(md) {
       font-size: 34px;
     }
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(xl) {
       font-size: 38px;
     }
     @include media-breakpoint-up(xxxl) {
       font-size: 54px;
+      max-width: 1100px;
     }
 
     small {
@@ -249,6 +250,13 @@ s72-element-switcher,
       }
     }
     /* stylelint-enable selector-max-compound-selectors */
+  }
+
+  .meta-detail-synopsis {
+    max-width: 728px;
+    @include media-breakpoint-up(xl) {
+      max-width: 1100px;
+    }
   }
 
   .meta-detail-synopsis,

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -170,9 +170,9 @@ s72-element-switcher,
     font-size: 28px;
     font-weight: $font-weight-bold;
     margin-bottom: 0;
-    text-shadow: none;
     max-width: 728px;
-    
+    text-shadow: none;
+
     @include media-breakpoint-up(md) {
       font-size: 34px;
     }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -176,7 +176,7 @@ s72-element-switcher,
     @include media-breakpoint-up(md) {
       font-size: 34px;
     }
-    @include media-breakpoint-up(xl) {
+    @include media-breakpoint-up(lg) {
       font-size: 38px;
     }
     @include media-breakpoint-up(xxxl) {


### PR DESCRIPTION
ADO card: ☑️ [AB#8287](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8287)

## Description of work
The max-width was removed from `meta-detail-content` on film-detail pages when the s72-element-switcher was added. It resulted in titles being the full width of the screen. This work adds the max-width back in.

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [x] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
