### PR TITLE
AB#7964-generalise bundle tagline for n items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * Subscribe to watch button
+* Bundles tagline to show n items rather than n films
 ## [0.6.0](https://github.com/shift72/core-template/compare/0.6.0-alpha.0...0.6.0)
 
 No changes from `alpha-0`.

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1332,5 +1332,8 @@
   },
   "subscribe_to_watch": {
     "other": "اشترك للمشاهدة"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} أغراض"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1324,5 +1324,8 @@
   },
   "subscribe_to_watch": {
     "other": "Subscriu-te per veure'l"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} elements"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1324,5 +1324,8 @@
   },
   "subscribe_to_watch": {
     "other": "Abonner for at se"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} elementer"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1324,5 +1324,8 @@
   },
   "subscribe_to_watch": {
     "other": "Zum Ansehen abonnieren"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} Produkte"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Εγγραφείτε για να παρακολουθήσετε"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} αντικείμενα"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Subscribe to watch"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} items"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Suscríbete para ver"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} artículos"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Suscríbete para ver"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} artículos"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1324,5 +1324,8 @@
   },
   "subscribe_to_watch": {
     "other": "Tellige vaatamiseks"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} üksused"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Tilaa katsoaksesi"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} kohteita"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Abonnez-vous pour regarder"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} éléments"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1309,5 +1309,8 @@
   },
   "subscribe_to_watch": {
     "other": "Pretplatite se na gledanje"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} stavke"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1324,5 +1324,8 @@
   },
   "subscribe_to_watch": {
     "other": "Iratkozz fel a nézéshez"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} elemeket"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Iscriviti per guardare"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} Oggetti"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1313,5 +1313,8 @@
   },
   "subscribe_to_watch": {
     "other": "視聴するために購読する"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}}アイテム"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1319,5 +1319,8 @@
   },
   "subscribe_to_watch": {
     "other": "Prenumeruokite žiūrėti"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} elementai"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Abonneer om te kijken"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} artikelen"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Abonner for å se"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} elementer"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1364,5 +1364,8 @@
   },
   "subscribe_to_watch": {
     "other": "Zapisz się do oglądania"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} rzeczy"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Inscreva-se para assistir"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} Itens"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "Inscreva-se para assistir"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} Itens"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1341,5 +1341,8 @@
   },
   "subscribe_to_watch": {
     "other": "Подпишитесь, чтобы смотреть"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} Предметы"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1317,5 +1317,8 @@
   },
   "subscribe_to_watch": {
     "other": "Претплатите се на гледање"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} ставке"
   }
 }

--- a/site/templates/items/tagline.jet
+++ b/site/templates/items/tagline.jet
@@ -28,7 +28,7 @@
     {{end}}
     {*{ There should be one less dividers than tagline items. }*}
     {{dividers = dividers - 1}}
-    
+
     {{if classification}}
       <s72-classification-label data-slug="{{.Slug}}" data-layout="tooltip"></s72-classification-label>
     {{end}}
@@ -47,7 +47,7 @@
 
     {{if isset(.Items)}}
       {{yield taglineItem() content}}
-        {{i18n("bundle_items_all_films", len(.Items))}}
+        {{i18n("bundle_items_generic", len(.Items))}}
       {{end}}
       {{yield taglineDivider(dividers=dividers)}}
       {{dividers = dividers - 1}}

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1315,5 +1315,8 @@
   },
   "subscribe_to_watch": {
     "other": "izlemek için abone ol"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} öğeler"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1347,5 +1347,8 @@
   },
   "subscribe_to_watch": {
     "other": "Підпишіться на перегляд"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} елементи"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1313,5 +1313,8 @@
   },
   "subscribe_to_watch": {
     "other": "订阅观看"
+  },
+  "bundle_items_generic": {
+    "other": "{{.Count}} 项目"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#XXXX](https://dev.azure.com/S72/SHIFT72/_workitems/edit/7964)

~~Elab notes/AC: 📃 [Google Docs](https://docs.google.com)~~
- [x] Has this been discussed with Delivery Team? @PeculiarGoat  

## Description of work
Bundle taglines show n films despite containing tv seasons
Change to use "n items"

## Related PRs 

### Any PRs which this PR depends on
Nope

### Any PRs dependent on this one
Nope

### Affected Clients
 - All clients who use Kibble


## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)

