### PR TITLE
AB#8427 Add language string for shopping_card_update_reason_expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Awards icon from star to laurel
 
+### Added
+- Language strings for shopping_card_update_reason_expired
+
 ## [1.0.0-alpha.0](https://github.com/shift72/core-template/compare/0.6.0...1.0.0-alpha.0)
 
 ### Added

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1335,5 +1335,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} أغراض"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "قم بتحديث بطاقتك الائتمانية. البطاقات المدعومة هي Visa و Mastercard و American Express."
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1327,5 +1327,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} elements"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Actualitza la teva targeta de crèdit. Les targetes admeses són Visa, Mastercard i American Express."
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1327,5 +1327,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} elementer"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Opdater dit kreditkort. Understøttede kort er Visa, Mastercard og American Express."
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1327,5 +1327,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} Produkte"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Aktualisieren Sie Ihre Kreditkarte. Unterstützte Karten sind Visa, Mastercard und American Express."
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} αντικείμενα"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Ενημερώστε την πιστωτική σας κάρτα. Οι υποστηριζόμενες κάρτες είναι Visa, Mastercard και American Express."
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} items"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Update your credit card. Supported cards are Visa, Mastercard and American Express."
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} artículos"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Actualice su tarjeta de crédito. Las tarjetas admitidas son Visa, Mastercard y American Express."
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} artículos"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Actualice su tarjeta de crédito. Las tarjetas admitidas son Visa, Mastercard y American Express."
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1327,5 +1327,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} üksused"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Värskendage oma krediitkaarti. Toetatud kaardid on Visa, Mastercard ja American Express."
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} kohteita"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Päivitä luottokorttisi. Tuetut kortit ovat Visa, Mastercard ja American Express."
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} éléments"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Mettez à jour votre carte de crédit. Les cartes acceptées sont Visa, Mastercard et American Express."
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1312,5 +1312,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} stavke"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Ažurirajte svoju kreditnu karticu. Podržane kartice su Visa, Mastercard i American Express."
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1327,5 +1327,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} elemeket"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Frissítse hitelkártyáját. A támogatott kártyák a Visa, Mastercard és az American Express."
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} Oggetti"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Aggiorna la tua carta di credito. Le carte supportate sono Visa, Mastercard e American Express."
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1316,5 +1316,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}}アイテム"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "クレジットカードを更新します。サポートされているカードは、Visa、Mastercard、AmericanExpressです。"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1322,5 +1322,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} elementai"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Atnaujinkite savo kredito kortelę. Palaikomos kortelės yra „Visa“, „Mastercard“ ir „American Express“."
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} artikelen"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Werk uw creditcard bij. Ondersteunde kaarten zijn Visa, Mastercard en American Express."
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} elementer"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Oppdater kredittkortet ditt. Støttede kort er Visa, Mastercard og American Express."
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1367,5 +1367,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} rzeczy"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Zaktualizuj swoją kartę kredytową. Obsługiwane karty to Visa, Mastercard i American Express."
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} Itens"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Atualize seu cartão de crédito. Os cartões suportados são Visa, Mastercard e American Express."
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} Itens"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Atualize seu cartão de crédito. Os cartões suportados são Visa, Mastercard e American Express."
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1344,5 +1344,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} Предметы"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Обновите свою кредитную карту. Поддерживаются карты Visa, Mastercard и American Express."
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1320,5 +1320,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} ставке"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Ажурирајте своју кредитну картицу. Подржане картице су Виса, Мастерцард и Америцан Екпресс."
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1318,5 +1318,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} öğeler"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Kredi kartınızı güncelleyin. Desteklenen kartlar Visa, Mastercard ve American Express'tir."
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1350,5 +1350,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} елементи"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "Оновіть свою кредитну картку. Підтримувані картки Visa, Mastercard та American Express."
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1316,5 +1316,8 @@
   },
   "bundle_items_generic": {
     "other": "{{.Count}} 项目"
+  },
+  "shopping_card_update_reason_expired": {
+    "other": "更新您的信用卡。支持的卡是 Visa、Mastercard 和 American Express。"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#8427](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8427)

## Description of work
Add a language string for shopping_card_update_reason_expired to appear in update credit card details modal.

For now this is the same as the message in shopping_card_update_reason_none but may change

## Checklist
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)

