### PR TITLE
Tweak:  change CanBeWatchedButton font weight to match play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Awards icon from star to laurel
 - Show play and pricing buttons based on item type on `meta_item.jet`
+- Fix font weight on the can-be-watched button to match primary button styling
 
 ### Added
 - Language strings for shopping_card_update_reason_expired

--- a/site/styles/_can-be-watched-button.scss
+++ b/site/styles/_can-be-watched-button.scss
@@ -18,7 +18,7 @@
   .verb {
     color: $button-text-color;
     font-size: 18px;
-    font-weight: $font-weight-bold;
+    font-weight: $font-weight-normal;
   }
 }
 


### PR DESCRIPTION
Not sure if it's intentional, but the can-be-watched button has a heavier font weight than the play button next to it.

This PR makes it normal weight to match the regular button styling. It seemed like this might have just been some copypasta styles that got overlooked when the button styling was changed.

Please close if this was the design intent.

Before:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/98778140/173706322-1c8f648d-8d94-495b-924a-0d467833801f.png">

After:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/98778140/173706826-b4addc21-41c8-4def-9ebd-0900b3993ee1.png">
