### PR TITLE
error key

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1336,7 +1336,7 @@
   "shopping_discount_applied_promo": {
     "other": "تم تطبيق الكود بنجاح."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "الرجاء إدخال رمز ترويجي صالح."
   },
   "shopping_complete_promo_only": {

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1328,7 +1328,7 @@
   "shopping_discount_applied_promo": {
     "other": "El codi s'ha aplicat correctament."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Introduïu un codi promocional vàlid."
   },
   "shopping_complete_promo_only": {

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1328,7 +1328,7 @@
   "shopping_discount_applied_promo": {
     "other": "Koden blev anvendt."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Indtast venligst en gyldig kampagnekode."
   },
   "shopping_complete_promo_only": {

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1328,7 +1328,7 @@
   "shopping_discount_applied_promo": {
     "other": "Code erfolgreich angewendet."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Bitte geben Sie einen gültigen Aktionscode ein."
   },
   "shopping_complete_promo_only": {

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Ο κωδικός εφαρμόστηκε με επιτυχία."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Εισαγάγετε έναν έγκυρο κωδικό προσφοράς."
   },
   "shopping_complete_promo_only": {

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Code successfully applied."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Please enter a valid promo code."
   },
   "shopping_complete_promo_only": {

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Código aplicado con éxito."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Por favor, introduzca un código de promoción válido."
   },
   "shopping_complete_promo_only": {

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Código aplicado con éxito."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Por favor, introduzca un código de promoción válido."
   },
   "shopping_complete_promo_only": {

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1328,7 +1328,7 @@
   "shopping_discount_applied_promo": {
     "other": "Koodi rakendamine õnnestus."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Sisestage kehtiv sooduskood."
   },
   "shopping_complete_promo_only": {

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Koodi lisätty onnistuneesti."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Anna kelvollinen tarjouskoodi."
   },
   "shopping_complete_promo_only": {

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Code appliqué avec succès."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Veuillez saisir un code promotionnel valide."
   },
   "shopping_complete_promo_only": {

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1313,7 +1313,7 @@
   "shopping_discount_applied_promo": {
     "other": "Kôd je uspješno primijenjen."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Unesite važeći promotivni kod."
   },
   "shopping_complete_promo_only": {

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1328,7 +1328,7 @@
   "shopping_discount_applied_promo": {
     "other": "A kód sikeresen alkalmazva."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Adjon meg egy érvényes promóciós kódot."
   },
   "shopping_complete_promo_only": {

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Codice applicato correttamente."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Inserisci un codice promozionale valido."
   },
   "shopping_complete_promo_only": {

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1317,7 +1317,7 @@
   "shopping_discount_applied_promo": {
     "other": "コードが正常に適用されました。"
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "有効なプロモーションコードを入力してください。"
   },
   "shopping_complete_promo_only": {

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1323,7 +1323,7 @@
   "shopping_discount_applied_promo": {
     "other": "Kodas sėkmingai pritaikytas."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Įveskite galiojantį reklamos kredito kodą."
   },
   "shopping_complete_promo_only": {

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Code succesvol toegepast."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Voer een geldige promotiecode in."
   },
   "shopping_complete_promo_only": {

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Koden ble brukt."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Vennligst skriv inn en gyldig kampanjekode."
   },
   "shopping_complete_promo_only": {

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1368,7 +1368,7 @@
   "shopping_discount_applied_promo": {
     "other": "Kod został pomyślnie zastosowany."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Wprowadź prawidłowy kod promocyjny."
   },
   "shopping_complete_promo_only": {

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Código aplicado com sucesso."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Insira um código promocional válido."
   },
   "shopping_complete_promo_only": {

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Código aplicado com sucesso."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Insira um código promocional válido."
   },
   "shopping_complete_promo_only": {

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1345,7 +1345,7 @@
   "shopping_discount_applied_promo": {
     "other": "Код успешно применен."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Пожалуйста, введите действительный промо-код."
   },
   "shopping_complete_promo_only": {

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1321,7 +1321,7 @@
   "shopping_discount_applied_promo": {
     "other": "Код је успешно примењен."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Унесите важећи промотивни код."
   },
   "shopping_complete_promo_only": {

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1319,7 +1319,7 @@
   "shopping_discount_applied_promo": {
     "other": "Kod başarıyla uygulandı."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Lütfen geçerli bir promosyon kodu girin."
   },
   "shopping_complete_promo_only": {

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1351,7 +1351,7 @@
   "shopping_discount_applied_promo": {
     "other": "Код успішно застосовано."
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Введіть дійсний промо-код."
   },
   "shopping_complete_promo_only": {

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1317,7 +1317,7 @@
   "shopping_discount_applied_promo": {
     "other": "代碼成功應用。"
   },
-  "promo_only_purchases_must_be_100_percent_discounted": {
+  "shopping_error_promo_only_purchases_must_be_100_percent_discounted": {
     "other": "請輸入有效的促銷代碼。"
   },
   "shopping_complete_promo_only": {


### PR DESCRIPTION
ADO card: ☑️ [AB#8696](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Web%20team/Stories/?workitem=8696)

- [ ] Has this been discussed with Delivery Team?

## Description of work
This error returned by the api as `promo_only_purchases_must_be_100_percent_discounted` then prefixed by relish with `shopping_error_`

```{i18n('shopping_error_' + error, { 'Ownership': niceVerb, 'Title': title })}```

Changes language files to reflect this.

## Edge cases/Caveats/Known issues
- Edge case 1
- Caveat 2
- Known issue 3

### Affected Clients
 - All clients who use promo only content (none at the minute)

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [x] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
