### PR TITLE
AB#8719 remove success from message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix font weight on the can-be-watched button to match primary button styling
 - Replaces nav_homepage and site_owner translations with dynamic data via Kibble function.
 - Carousel heading is limited to a maximum of 3 lines.
+- Language strings changed for shopping_complete_promo_only
 
 ## [1.0.0](https://github.com/shift72/core-template/compare/1.0.0-alpha.0...1.0.0)
 

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1340,7 +1340,7 @@
     "other": "الرجاء إدخال رمز ترويجي صالح."
   },
   "shopping_complete_promo_only": {
-    "other": "يمكنك الآن {{.Title}}."
+    "other": "يمكنك الآن مشاهدة {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "يسترد"

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1340,7 +1340,7 @@
     "other": "الرجاء إدخال رمز ترويجي صالح."
   },
   "shopping_complete_promo_only": {
-    "other": "النجاح! يمكنك الآن {{.Title}}."
+    "other": "يمكنك الآن {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "يسترد"

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1332,7 +1332,7 @@
     "other": "Introduïu un codi promocional vàlid."
   },
   "shopping_complete_promo_only": {
-    "other": "Èxit! Ja podeu veure {{.Title}}."
+    "other": "Ja podeu veure {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Redimir"

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1332,7 +1332,7 @@
     "other": "Indtast venligst en gyldig kampagnekode."
   },
   "shopping_complete_promo_only": {
-    "other": "Succes! Du kan nu se {{.Title}}."
+    "other": "Du kan nu se {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Indløs"

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1332,7 +1332,7 @@
     "other": "Bitte geben Sie einen gültigen Aktionscode ein."
   },
   "shopping_complete_promo_only": {
-    "other": "Erfolg! Sie können jetzt {{.Title}} ansehen."
+    "other": "Sie können jetzt {{.Title}} ansehen."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Tilgen"

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1323,7 +1323,7 @@
     "other": "Εισαγάγετε έναν έγκυρο κωδικό προσφοράς."
   },
   "shopping_complete_promo_only": {
-    "other": "Επιτυχία! Τώρα μπορείτε να παρακολουθήσετε {{.Title}}."
+    "other": "Τώρα μπορείτε να παρακολουθήσετε {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Εξαργυρώνω"

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1323,7 +1323,7 @@
     "other": "Please enter a valid promo code."
   },
   "shopping_complete_promo_only": {
-    "other": "Success! You can now watch {{.Title}}."
+    "other": "You can now watch {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Redeem"

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1323,7 +1323,7 @@
     "other": "Por favor, introduzca un código de promoción válido."
   },
   "shopping_complete_promo_only": {
-    "other": "¡Éxito! Ahora puedes ver {{.Title}}."
+    "other": "Ahora puedes ver {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Redimir"

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1323,7 +1323,7 @@
     "other": "Por favor, introduzca un código de promoción válido."
   },
   "shopping_complete_promo_only": {
-    "other": "¡Éxito! Ahora puedes ver {{.Title}}."
+    "other": "Ahora puedes ver {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Redimir"

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1332,7 +1332,7 @@
     "other": "Sisestage kehtiv sooduskood."
   },
   "shopping_complete_promo_only": {
-    "other": "Edu! Nüüd saate vaadata {{.Title}}."
+    "other": "Nüüd saate vaadata {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Lunastama"

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1317,18 +1317,18 @@
     "other": "Päivitä luottokorttisi. Tuetut kortit ovat Visa, Mastercard ja American Express."
   },
   "shopping_discount_applied_promo": {
-    "other": "Koodi lisätty onnistuneesti."
+    "other": "Koodi on otettu käyttöön."
   },
   "promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Anna kelvollinen tarjouskoodi."
   },
   "shopping_complete_promo_only": {
-    "other": "Menestys! Voit nyt katsoa {{.Title}}."
+    "other": "Voit nyt katsoa {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Lunastaa"
   },
   "pricing_ownership_promo": {
     "other": "Lunastaa"
-    }
+  }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1317,7 +1317,7 @@
     "other": "Päivitä luottokorttisi. Tuetut kortit ovat Visa, Mastercard ja American Express."
   },
   "shopping_discount_applied_promo": {
-    "other": "Koodi on otettu käyttöön."
+    "other": "Koodi lisätty onnistuneesti."
   },
   "promo_only_purchases_must_be_100_percent_discounted": {
     "other": "Anna kelvollinen tarjouskoodi."

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1323,7 +1323,7 @@
     "other": "Veuillez saisir un code promotionnel valide."
   },
   "shopping_complete_promo_only": {
-    "other": "Succès! Vous pouvez maintenant regarder {{.Title}}."
+    "other": "Vous pouvez maintenant regarder {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Racheter"

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1317,7 +1317,7 @@
     "other": "Unesite važeći promotivni kod."
   },
   "shopping_complete_promo_only": {
-    "other": "Uspjeh! Sada možete gledati {{.Title}}."
+    "other": "Sada možete gledati {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Otkupiti"

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1332,7 +1332,7 @@
     "other": "Adjon meg egy érvényes promóciós kódot."
   },
   "shopping_complete_promo_only": {
-    "other": "Siker! Most megtekintheti a {{.Title}}."
+    "other": "Most megtekintheti a {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Beváltani"

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1323,7 +1323,7 @@
     "other": "Inserisci un codice promozionale valido."
   },
   "shopping_complete_promo_only": {
-    "other": "Successo! Ora puoi guardare {{.Title}}."
+    "other": "Ora puoi guardare {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Riscattare"

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1321,7 +1321,7 @@
     "other": "有効なプロモーションコードを入力してください。"
   },
   "shopping_complete_promo_only": {
-    "other": "成功！これで、 {{.Title}}を見ることができます。"
+    "other": "これで、 {{.Title}}を見ることができます。"
   },
   "shopping_action_redeem_promo_code": {
     "other": "償還"

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1327,7 +1327,7 @@
     "other": "Įveskite galiojantį reklamos kredito kodą."
   },
   "shopping_complete_promo_only": {
-    "other": "Sėkmė! Dabar galite žiūrėti {{.Title}}."
+    "other": "Dabar galite žiūrėti {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Išpirkti"

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1326,9 +1326,9 @@
     "other": "Je kunt nu {{.Title}} bekijken."
   },
   "shopping_action_redeem_promo_code": {
-    "other": "Redeem"
+    "other": "Inwisselen"
   },
   "pricing_ownership_promo": {
-    "other": "Redeem"
+    "other": "Inwisselen"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1323,12 +1323,12 @@
     "other": "Voer een geldige promotiecode in."
   },
   "shopping_complete_promo_only": {
-    "other": "Succes! Je kunt nu {{.Title}} bekijken."
+    "other": "Je kunt nu {{.Title}} bekijken."
   },
   "shopping_action_redeem_promo_code": {
-    "other": "Inwisselen"
+    "other": "Redeem"
   },
   "pricing_ownership_promo": {
-    "other": "Inwisselen"
+    "other": "Redeem"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1323,7 +1323,7 @@
     "other": "Vennligst skriv inn en gyldig kampanjekode."
   },
   "shopping_complete_promo_only": {
-    "other": "Suksess! Du kan nå se {{.Title}}."
+    "other": "Du kan nå se {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Løs inn"

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1372,7 +1372,7 @@
     "other": "Wprowadź prawidłowy kod promocyjny."
   },
   "shopping_complete_promo_only": {
-    "other": "Powodzenie! Możesz teraz oglądać {{.Title}}."
+    "other": "Możesz teraz oglądać {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Odkupić"

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1323,7 +1323,7 @@
     "other": "Insira um código promocional válido."
   },
   "shopping_complete_promo_only": {
-    "other": "Sucesso! Agora você pode assistir {{.Title}}."
+    "other": "Agora você pode assistir {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Resgatar"

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1323,7 +1323,7 @@
     "other": "Insira um código promocional válido."
   },
   "shopping_complete_promo_only": {
-    "other": "Sucesso! Agora você pode assistir {{.Title}}."
+    "other": "Agora você pode assistir {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Resgatar"

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1349,7 +1349,7 @@
     "other": "Пожалуйста, введите действительный промо-код."
   },
   "shopping_complete_promo_only": {
-    "other": "Успех! Теперь вы можете смотреть {{.Title}}."
+    "other": "Теперь вы можете смотреть {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Выкупать"

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1325,7 +1325,7 @@
     "other": "Унесите важећи промотивни код."
   },
   "shopping_complete_promo_only": {
-    "other": "Успех! Сада можете гледати {{.Title}}."
+    "other": "Сада можете гледати {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Искупити"

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1323,7 +1323,7 @@
     "other": "Lütfen geçerli bir promosyon kodu girin."
   },
   "shopping_complete_promo_only": {
-    "other": "Başarı! Artık {{.Title}} izleyebilirsiniz."
+    "other": "Artık {{.Title}} izleyebilirsiniz."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Tazmin etmek"

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1355,7 +1355,7 @@
     "other": "Введіть дійсний промо-код."
   },
   "shopping_complete_promo_only": {
-    "other": "Успіху! Тепер ви можете дивитися {{.Title}}."
+    "other": "Тепер ви можете дивитися {{.Title}}."
   },
   "shopping_action_redeem_promo_code": {
     "other": "Викупити"

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1321,7 +1321,7 @@
     "other": "請輸入有效的促銷代碼。"
   },
   "shopping_complete_promo_only": {
-    "other": "成功！您現在可以觀看{{.Title}}。"
+    "other": "您現在可以觀看{{.Title}}。"
   },
   "shopping_action_redeem_promo_code": {
     "other": "贖回"


### PR DESCRIPTION
ADO card: ☑️ [AB#8719](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Web%20team/Stories/?workitem=8719)

- [x] Has this been discussed with Delivery Team?

## Description of work
"Success!" needs to be marked up as larger than the rest of the message to match designs. Removed from this translation string. Images of changes in related PR.

## Related PRs 

https://github.com/indiereign/shift72-web/pull/325/files


## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [x] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
