### PR TITLE
AB#8677: add translations for subscription recurrence on purchase CTAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Tooltips on meta detail/item CTA buttons.
+- Add translations for subscription recurrence on purchase CTA.
 
 ## [1.1.0](https://github.com/shift72/core-template/compare/1.0.0...1.1.0)
 

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1354,33 +1354,33 @@
   "subscription_recurrence_year": {
     "zero": "سنة",
     "one": "سنة",
-    "two": "سنوات",
-    "few": "سنوات",
-    "many": "سنوات",
-    "other": "سنوات"
+    "two": "{{.Count}} سنوات",
+    "few": "{{.Count}} سنوات",
+    "many": "{{.Count}} سنوات",
+    "other": "{{.Count}} سنوات"
   },
   "subscription_recurrence_month": {
     "zero": "شهر",
     "one": "شهر",
-    "two": "شهور",
-    "few": "شهور",
-    "many": "شهور",
-    "other": "شهور"
+    "two": "{{.Count}} شهور",
+    "few": "{{.Count}} شهور",
+    "many": "{{.Count}} شهور",
+    "other": "{{.Count}} شهور"
   },
   "subscription_recurrence_week": {
     "zero": "أسبوع",
     "one": "أسبوع",
-    "two": "أسابيع",
-    "few": "أسابيع",
-    "many": "أسابيع",
-    "other": "أسابيع"
+    "two": "{{.Count}} أسابيع",
+    "few": "{{.Count}} أسابيع",
+    "many": "{{.Count}} أسابيع",
+    "other": "{{.Count}} أسابيع"
   },
   "subscription_recurrence_day": {
     "zero": "يوم",
-    "one": "يوم",
-    "two": "أيام",
-    "few": "أيام",
-    "many": "أيام",
-    "other": "أيام"
+    "one": "{{.Count}} يوم",
+    "two": "{{.Count}} أيام",
+    "few": "{{.Count}} أيام",
+    "many": "{{.Count}} أيام",
+    "other": "{{.Count}} أيام"
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1349,7 +1349,7 @@
     "other": "يسترد"
   },
   "subscription_cta_label": {
-    "other": "{{.Recurrence}}/{{.Verb}} {{.Price}}"
+    "other": "{{.Recurrence}}/الإشتراك {{.Price}}"
   },
   "subscription_recurrence_year": {
     "zero": "سنة",

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1348,16 +1348,39 @@
   "pricing_ownership_promo": {
     "other": "يسترد"
   },
-  "subscription_recurrence_daily": {
-    "other": "اليومي"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "أسبوعي"
+  "subscription_recurrence_year": {
+    "zero": "سنة",
+    "one": "سنة",
+    "two": "سنوات",
+    "few": "سنوات",
+    "many": "سنوات",
+    "other": "سنوات"
   },
-  "subscription_recurrence_monthly": {
-    "other": "شهريا"
+  "subscription_recurrence_month": {
+    "zero": "شهر",
+    "one": "شهر",
+    "two": "شهور",
+    "few": "شهور",
+    "many": "شهور",
+    "other": "شهور"
   },
-  "subscription_recurrence_yearly": {
-    "other": "سنوي"
+  "subscription_recurrence_week": {
+    "zero": "أسبوع",
+    "one": "أسبوع",
+    "two": "أسابيع",
+    "few": "أسابيع",
+    "many": "أسابيع",
+    "other": "أسابيع"
+  },
+  "subscription_recurrence_day": {
+    "zero": "يوم",
+    "one": "يوم",
+    "two": "أيام",
+    "few": "أيام",
+    "many": "أيام",
+    "other": "أيام"
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1347,5 +1347,17 @@
   },
   "pricing_ownership_promo": {
     "other": "يسترد"
+  },
+  "subscription_recurrence_daily": {
+    "other": "اليومي"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "أسبوعي"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "شهريا"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "سنوي"
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1349,7 +1349,7 @@
     "other": "يسترد"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "{{.Recurrence}}/{{.Verb}} {{.Price}}"
   },
   "subscription_recurrence_year": {
     "zero": "سنة",

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1340,16 +1340,23 @@
   "pricing_ownership_promo": {
     "other": "Redimir"
   },
-  "subscription_recurrence_daily": {
-    "other": "diàriament"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "setmanalment"
+  "subscription_recurrence_year": {
+    "one": "Curs",
+    "other": "Anys"
   },
-  "subscription_recurrence_monthly": {
-    "other": "mensual"
+  "subscription_recurrence_month": {
+    "one": "Mes",
+    "other": "Mesos"
   },
-  "subscription_recurrence_yearly": {
-    "other": "anualment"
+  "subscription_recurrence_week": {
+    "one": "Setmana",
+    "other": "Setmanes"
+  },
+  "subscription_recurrence_day": {
+    "one": "Dia",
+    "other": "Dies"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1341,7 +1341,7 @@
     "other": "Redimir"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Subscriu-te {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Curs",

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1339,5 +1339,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Redimir"
+  },
+  "subscription_recurrence_daily": {
+    "other": "diàriament"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "setmanalment"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "mensual"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "anualment"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1345,18 +1345,18 @@
   },
   "subscription_recurrence_year": {
     "one": "Curs",
-    "other": "Anys"
+    "other": "{{.Count}} Anys"
   },
   "subscription_recurrence_month": {
     "one": "Mes",
-    "other": "Mesos"
+    "other": "{{.Count}} Mesos"
   },
   "subscription_recurrence_week": {
     "one": "Setmana",
-    "other": "Setmanes"
+    "other": "{{.Count}} Setmanes"
   },
   "subscription_recurrence_day": {
     "one": "Dia",
-    "other": "Dies"
+    "other": "{{.Count}} Dies"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1339,5 +1339,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Indløs"
+  },
+  "subscription_recurrence_daily": {
+    "other": "daglige"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "ugentlig"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "månedlige"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "årligt"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1341,7 +1341,7 @@
     "other": "Indløs"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Abonner {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "År",

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1340,16 +1340,23 @@
   "pricing_ownership_promo": {
     "other": "Indløs"
   },
-  "subscription_recurrence_daily": {
-    "other": "daglige"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "ugentlig"
+  "subscription_recurrence_year": {
+    "one": "År",
+    "other": "Flere år"
   },
-  "subscription_recurrence_monthly": {
-    "other": "månedlige"
+  "subscription_recurrence_month": {
+    "one": "Måned",
+    "other": "Måneder"
   },
-  "subscription_recurrence_yearly": {
-    "other": "årligt"
+  "subscription_recurrence_week": {
+    "one": "Uge",
+    "other": "Uger"
+  },
+  "subscription_recurrence_day": {
+    "one": "Dag",
+    "other": "Dage"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1345,18 +1345,18 @@
   },
   "subscription_recurrence_year": {
     "one": "År",
-    "other": "Flere år"
+    "other": "{{.Count}} Flere år"
   },
   "subscription_recurrence_month": {
     "one": "Måned",
-    "other": "Måneder"
+    "other": "{{.Count}} Måneder"
   },
   "subscription_recurrence_week": {
     "one": "Uge",
-    "other": "Uger"
+    "other": "{{.Count}} Uger"
   },
   "subscription_recurrence_day": {
     "one": "Dag",
-    "other": "Dage"
+    "other": "{{.Count}} Dage"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1339,5 +1339,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Tilgen"
+  },
+  "subscription_recurrence_daily": {
+    "other": "Täglich"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "wöchentlich"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "monatlich"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "jährlich"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1340,16 +1340,23 @@
   "pricing_ownership_promo": {
     "other": "Tilgen"
   },
-  "subscription_recurrence_daily": {
-    "other": "Täglich"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "wöchentlich"
+  "subscription_recurrence_year": {
+    "one": "Jahr",
+    "other": "Jahre"
   },
-  "subscription_recurrence_monthly": {
-    "other": "monatlich"
+  "subscription_recurrence_month": {
+    "one": "Monat",
+    "other": "Monate"
   },
-  "subscription_recurrence_yearly": {
-    "other": "jährlich"
+  "subscription_recurrence_week": {
+    "one": "Woche",
+    "other": "Wochen"
+  },
+  "subscription_recurrence_day": {
+    "one": "Tag",
+    "other": "Tage"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1345,18 +1345,18 @@
   },
   "subscription_recurrence_year": {
     "one": "Jahr",
-    "other": "Jahre"
+    "other": "{{.Count}} Jahre"
   },
   "subscription_recurrence_month": {
     "one": "Monat",
-    "other": "Monate"
+    "other": "{{.Count}} Monate"
   },
   "subscription_recurrence_week": {
     "one": "Woche",
-    "other": "Wochen"
+    "other": "{{.Count}} Wochen"
   },
   "subscription_recurrence_day": {
     "one": "Tag",
-    "other": "Tage"
+    "other": "{{.Count}} Tage"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1341,7 +1341,7 @@
     "other": "Tilgen"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Abonnieren {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Jahr",

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1336,18 +1336,18 @@
   },
   "subscription_recurrence_year": {
     "one": "Ετος",
-    "other": "Χρόνια"
+    "other": "{{.Count}} Χρόνια"
   },
   "subscription_recurrence_month": {
     "one": "Μήνας",
-    "other": "Μήνες"
+    "other": "{{.Count}} Μήνες"
   },
   "subscription_recurrence_week": {
     "one": "Εβδομάδα",
-    "other": "Εβδομάδες"
+    "other": "{{.Count}} Εβδομάδες"
   },
   "subscription_recurrence_day": {
     "one": "Ημέρα",
-    "other": "Ημέρες"
+    "other": "{{.Count}} Ημέρες"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1331,16 +1331,23 @@
   "pricing_ownership_promo": {
     "other": "Εξαργυρώνω"
   },
-  "subscription_recurrence_daily": {
-    "other": "καθημερινά"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "εβδομαδιαίος"
+  "subscription_recurrence_year": {
+    "one": "Ετος",
+    "other": "Χρόνια"
   },
-  "subscription_recurrence_monthly": {
-    "other": "Μηνιαίο"
+  "subscription_recurrence_month": {
+    "one": "Μήνας",
+    "other": "Μήνες"
   },
-  "subscription_recurrence_yearly": {
-    "other": "ετήσια"
+  "subscription_recurrence_week": {
+    "one": "Εβδομάδα",
+    "other": "Εβδομάδες"
+  },
+  "subscription_recurrence_day": {
+    "one": "Ημέρα",
+    "other": "Ημέρες"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Εξαργυρώνω"
+  },
+  "subscription_recurrence_daily": {
+    "other": "καθημερινά"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "εβδομαδιαίος"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "Μηνιαίο"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "ετήσια"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1332,7 +1332,7 @@
     "other": "Εξαργυρώνω"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Εγγραφείτε {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Ετος",

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1331,16 +1331,23 @@
   "pricing_ownership_promo": {
     "other": "Redeem"
   },
-  "subscription_recurrence_daily": {
-    "other": "daily"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "weekly"
+  "subscription_recurrence_day": {
+    "one": "Day",
+    "other": "{{.Count}} Days"
   },
-  "subscription_recurrence_monthly": {
-    "other": "monthly"
+  "subscription_recurrence_week": {
+    "one": "Week",
+    "other": "{{.Count}} Weeks"
   },
-  "subscription_recurrence_yearly": {
-    "other": "yearly"
+  "subscription_recurrence_month": {
+    "one": "Month",
+    "other": "{{.Count}} Months"
+  },
+  "subscription_recurrence_year": {
+    "one": "Year",
+    "other": "{{.Count}} Years"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Redeem"
+  },
+  "subscription_recurrence_daily": {
+    "other": "daily"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "weekly"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "monthly"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "yearly"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1332,7 +1332,7 @@
     "other": "Redeem"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Subscribe {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_day": {
     "one": "Day",

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Redimir"
+  },
+  "subscription_recurrence_daily": {
+    "other": "diariamente"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "semanalmente"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "mensual"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "anual"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1336,22 +1336,22 @@
   },
   "subscription_recurrence_year": {
     "one": "Año",
-    "many": "Años",
-    "other": "Años"
+    "many": "{{.Count}} Años",
+    "other": "{{.Count}} Años"
   },
   "subscription_recurrence_month": {
     "one": "Mes",
-    "many": "Meses",
-    "other": "Meses"
+    "many": "{{.Count}} Meses",
+    "other": "{{.Count}} Meses"
   },
   "subscription_recurrence_week": {
     "one": "Semana",
-    "many": "Semanas",
-    "other": "Semanas"
+    "many": "{{.Count}} Semanas",
+    "other": "{{.Count}} Semanas"
   },
   "subscription_recurrence_day": {
     "one": "Día",
-    "many": "Días",
-    "other": "Días"
+    "many": "{{.Count}} Días",
+    "other": "{{.Count}} Días"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1331,16 +1331,27 @@
   "pricing_ownership_promo": {
     "other": "Redimir"
   },
-  "subscription_recurrence_daily": {
-    "other": "diariamente"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "semanalmente"
+  "subscription_recurrence_year": {
+    "one": "Año",
+    "many": "Años",
+    "other": "Años"
   },
-  "subscription_recurrence_monthly": {
-    "other": "mensual"
+  "subscription_recurrence_month": {
+    "one": "Mes",
+    "many": "Meses",
+    "other": "Meses"
   },
-  "subscription_recurrence_yearly": {
-    "other": "anual"
+  "subscription_recurrence_week": {
+    "one": "Semana",
+    "many": "Semanas",
+    "other": "Semanas"
+  },
+  "subscription_recurrence_day": {
+    "one": "Día",
+    "many": "Días",
+    "other": "Días"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1332,7 +1332,7 @@
     "other": "Redimir"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Suscribir {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Año",

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Redimir"
+  },
+  "subscription_recurrence_daily": {
+    "other": "diariamente"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "semanalmente"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "mensual"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "anual"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1336,22 +1336,22 @@
   },
   "subscription_recurrence_year": {
     "one": "Año",
-    "many": "Años",
-    "other": "Años"
+    "many": "{{.Count}} Años",
+    "other": "{{.Count}} Años"
   },
   "subscription_recurrence_month": {
     "one": "Mes",
-    "many": "Meses",
-    "other": "Meses"
+    "many": "{{.Count}} Meses",
+    "other": "{{.Count}} Meses"
   },
   "subscription_recurrence_week": {
     "one": "Semana",
-    "many": "Semanas",
-    "other": "Semanas"
+    "many": "{{.Count}} Semanas",
+    "other": "{{.Count}} Semanas"
   },
   "subscription_recurrence_day": {
     "one": "Día",
-    "many": "Días",
-    "other": "Días"
+    "many": "{{.Count}} Días",
+    "other": "{{.Count}} Días"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1331,16 +1331,27 @@
   "pricing_ownership_promo": {
     "other": "Redimir"
   },
-  "subscription_recurrence_daily": {
-    "other": "diariamente"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "semanalmente"
+  "subscription_recurrence_year": {
+    "one": "Año",
+    "many": "Años",
+    "other": "Años"
   },
-  "subscription_recurrence_monthly": {
-    "other": "mensual"
+  "subscription_recurrence_month": {
+    "one": "Mes",
+    "many": "Meses",
+    "other": "Meses"
   },
-  "subscription_recurrence_yearly": {
-    "other": "anual"
+  "subscription_recurrence_week": {
+    "one": "Semana",
+    "many": "Semanas",
+    "other": "Semanas"
+  },
+  "subscription_recurrence_day": {
+    "one": "Día",
+    "many": "Días",
+    "other": "Días"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1332,7 +1332,7 @@
     "other": "Redimir"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Suscribir {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Año",

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1340,16 +1340,23 @@
   "pricing_ownership_promo": {
     "other": "Lunastama"
   },
-  "subscription_recurrence_daily": {
-    "other": "iga päev"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "iganädalane"
+  "subscription_recurrence_year": {
+    "one": "aasta",
+    "other": "Aastaid"
   },
-  "subscription_recurrence_monthly": {
-    "other": "igakuine"
+  "subscription_recurrence_month": {
+    "one": "Kuu",
+    "other": "Kuud"
   },
-  "subscription_recurrence_yearly": {
-    "other": "igal aastal"
+  "subscription_recurrence_week": {
+    "one": "Nädal",
+    "other": "Nädalad"
+  },
+  "subscription_recurrence_day": {
+    "one": "päev",
+    "other": "Päevad"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1339,5 +1339,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Lunastama"
+  },
+  "subscription_recurrence_daily": {
+    "other": "iga päev"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "iganädalane"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "igakuine"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "igal aastal"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1345,18 +1345,18 @@
   },
   "subscription_recurrence_year": {
     "one": "aasta",
-    "other": "Aastaid"
+    "other": "{{.Count}} Aastaid"
   },
   "subscription_recurrence_month": {
     "one": "Kuu",
-    "other": "Kuud"
+    "other": "{{.Count}} Kuud"
   },
   "subscription_recurrence_week": {
     "one": "Nädal",
-    "other": "Nädalad"
+    "other": "{{.Count}} Nädalad"
   },
   "subscription_recurrence_day": {
     "one": "päev",
-    "other": "Päevad"
+    "other": "{{.Count}} Päevad"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1341,7 +1341,7 @@
     "other": "Lunastama"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Telli {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "aasta",

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1336,18 +1336,18 @@
   },
   "subscription_recurrence_year": {
     "one": "vuosi",
-    "other": "Vuosia"
+    "other": "{{.Count}} Vuosia"
   },
   "subscription_recurrence_month": {
     "one": "Kuukausi",
-    "other": "Kuukaudet"
+    "other": "{{.Count}} Kuukaudet"
   },
   "subscription_recurrence_week": {
     "one": "Viikko",
-    "other": "Viikot"
+    "other": "{{.Count}} Viikot"
   },
   "subscription_recurrence_day": {
     "one": "Päivä",
-    "other": "päivää"
+    "other": "{{.Count}} päivää"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1331,16 +1331,23 @@
   "pricing_ownership_promo": {
     "other": "Lunastaa"
   },
-  "subscription_recurrence_daily": {
-    "other": "päivittäin"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "viikoittain"
+  "subscription_recurrence_year": {
+    "one": "vuosi",
+    "other": "Vuosia"
   },
-  "subscription_recurrence_monthly": {
-    "other": "kuukausittain"
+  "subscription_recurrence_month": {
+    "one": "Kuukausi",
+    "other": "Kuukaudet"
   },
-  "subscription_recurrence_yearly": {
-    "other": "vuosittain"
+  "subscription_recurrence_week": {
+    "one": "Viikko",
+    "other": "Viikot"
+  },
+  "subscription_recurrence_day": {
+    "one": "Päivä",
+    "other": "päivää"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1332,7 +1332,7 @@
     "other": "Lunastaa"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Tilaa {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "vuosi",

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Lunastaa"
+  },
+  "subscription_recurrence_daily": {
+    "other": "päivittäin"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "viikoittain"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "kuukausittain"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "vuosittain"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1331,16 +1331,27 @@
   "pricing_ownership_promo": {
     "other": "Racheter"
   },
-  "subscription_recurrence_daily": {
-    "other": "du quotidien"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "hebdomadaire"
+  "subscription_recurrence_year": {
+    "one": "An",
+    "many": "Années",
+    "other": "Années"
   },
-  "subscription_recurrence_monthly": {
-    "other": "mensuel"
+  "subscription_recurrence_month": {
+    "one": "Mois",
+    "many": "Mois",
+    "other": "Mois"
   },
-  "subscription_recurrence_yearly": {
-    "other": "annuel"
+  "subscription_recurrence_week": {
+    "one": "La semaine",
+    "many": "Semaines",
+    "other": "Semaines"
+  },
+  "subscription_recurrence_day": {
+    "one": "Jour",
+    "many": "Journées",
+    "other": "Journées"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1332,7 +1332,7 @@
     "other": "Racheter"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "S'abonner {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "An",

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1336,22 +1336,22 @@
   },
   "subscription_recurrence_year": {
     "one": "An",
-    "many": "Années",
-    "other": "Années"
+    "many": "{{.Count}} Années",
+    "other": "{{.Count}} Années"
   },
   "subscription_recurrence_month": {
     "one": "Mois",
-    "many": "Mois",
-    "other": "Mois"
+    "many": "{{.Count}} Mois",
+    "other": "{{.Count}} Mois"
   },
   "subscription_recurrence_week": {
     "one": "La semaine",
-    "many": "Semaines",
-    "other": "Semaines"
+    "many": "{{.Count}} Semaines",
+    "other": "{{.Count}} Semaines"
   },
   "subscription_recurrence_day": {
     "one": "Jour",
-    "many": "Journées",
-    "other": "Journées"
+    "many": "{{.Count}} Journées",
+    "other": "{{.Count}} Journées"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Racheter"
+  },
+  "subscription_recurrence_daily": {
+    "other": "du quotidien"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "hebdomadaire"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "mensuel"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "annuel"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1324,5 +1324,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Otkupiti"
+  },
+  "subscription_recurrence_daily": {
+    "other": "dnevno"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "tjedni"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "mjesečno"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "godišnje"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1330,22 +1330,22 @@
   },
   "subscription_recurrence_year": {
     "one": "Godina",
-    "few": "Godine",
-    "other": "Godine"
+    "few": "{{.Count}} Godine",
+    "other": "{{.Count}} Godine"
   },
   "subscription_recurrence_month": {
     "one": "Mjesec",
-    "few": "mjeseci",
-    "other": "mjeseci"
+    "few": "{{.Count}} mjeseci",
+    "other": "{{.Count}} mjeseci"
   },
   "subscription_recurrence_week": {
     "one": "Tjedan",
-    "few": "Tjedni",
-    "other": "Tjedni"
+    "few": "{{.Count}} Tjedni",
+    "other": "{{.Count}} Tjedni"
   },
   "subscription_recurrence_day": {
     "one": "Dan",
-    "few": "dana",
-    "other": "dana"
+    "few": "{{.Count}} dana",
+    "other": "{{.Count}} dana"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1325,16 +1325,27 @@
   "pricing_ownership_promo": {
     "other": "Otkupiti"
   },
-  "subscription_recurrence_daily": {
-    "other": "dnevno"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "tjedni"
+  "subscription_recurrence_year": {
+    "one": "Godina",
+    "few": "Godine",
+    "other": "Godine"
   },
-  "subscription_recurrence_monthly": {
-    "other": "mjesečno"
+  "subscription_recurrence_month": {
+    "one": "Mjesec",
+    "few": "mjeseci",
+    "other": "mjeseci"
   },
-  "subscription_recurrence_yearly": {
-    "other": "godišnje"
+  "subscription_recurrence_week": {
+    "one": "Tjedan",
+    "few": "Tjedni",
+    "other": "Tjedni"
+  },
+  "subscription_recurrence_day": {
+    "one": "Dan",
+    "few": "dana",
+    "other": "dana"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1326,7 +1326,7 @@
     "other": "Otkupiti"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Pretplatite se {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Godina",

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1340,16 +1340,23 @@
   "pricing_ownership_promo": {
     "other": "Beváltani"
   },
-  "subscription_recurrence_daily": {
-    "other": "napi"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "heti"
+  "subscription_recurrence_year": {
+    "one": "Év",
+    "other": "{{.Count}} Évek"
   },
-  "subscription_recurrence_monthly": {
-    "other": "havi"
+  "subscription_recurrence_month": {
+    "one": "Hónap",
+    "other": "{{.Count}} Hónapok"
   },
-  "subscription_recurrence_yearly": {
-    "other": "évi"
+  "subscription_recurrence_week": {
+    "one": "Hét",
+    "other": "{{.Count}} Hetek"
+  },
+  "subscription_recurrence_day": {
+    "one": "Nap",
+    "other": "{{.Count}} Napok"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1339,5 +1339,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Beváltani"
+  },
+  "subscription_recurrence_daily": {
+    "other": "napi"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "heti"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "havi"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "évi"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1341,7 +1341,7 @@
     "other": "Beváltani"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Iratkozz fel {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Év",

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1331,16 +1331,27 @@
   "pricing_ownership_promo": {
     "other": "Riscattare"
   },
-  "subscription_recurrence_daily": {
-    "other": "quotidiano"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "settimanalmente"
+  "subscription_recurrence_year": {
+    "one": "Anno",
+    "many": "Anni",
+    "other": "Anni"
   },
-  "subscription_recurrence_monthly": {
-    "other": "mensile"
+  "subscription_recurrence_month": {
+    "one": "Mese",
+    "many": "Mesi",
+    "other": "Mesi"
   },
-  "subscription_recurrence_yearly": {
-    "other": "annuale"
+  "subscription_recurrence_week": {
+    "one": "Settimana",
+    "many": "Settimane",
+    "other": "Settimane"
+  },
+  "subscription_recurrence_day": {
+    "one": "Giorno",
+    "many": "Giorni",
+    "other": "Giorni"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Riscattare"
+  },
+  "subscription_recurrence_daily": {
+    "other": "quotidiano"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "settimanalmente"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "mensile"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "annuale"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1336,22 +1336,22 @@
   },
   "subscription_recurrence_year": {
     "one": "Anno",
-    "many": "Anni",
-    "other": "Anni"
+    "many": "{{.Count}} Anni",
+    "other": "{{.Count}} Anni"
   },
   "subscription_recurrence_month": {
     "one": "Mese",
-    "many": "Mesi",
-    "other": "Mesi"
+    "many": "{{.Count}} Mesi",
+    "other": "{{.Count}} Mesi"
   },
   "subscription_recurrence_week": {
     "one": "Settimana",
-    "many": "Settimane",
-    "other": "Settimane"
+    "many": "{{.Count}} Settimane",
+    "other": "{{.Count}} Settimane"
   },
   "subscription_recurrence_day": {
     "one": "Giorno",
-    "many": "Giorni",
-    "other": "Giorni"
+    "many": "{{.Count}} Giorni",
+    "other": "{{.Count}} Giorni"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1332,7 +1332,7 @@
     "other": "Riscattare"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Sottoscrivi {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Anno",

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1329,16 +1329,19 @@
   "pricing_ownership_promo": {
     "other": "償還"
   },
-  "subscription_recurrence_daily": {
-    "other": "毎日"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "毎週"
+  "subscription_recurrence_year": {
+    "other": "年"
   },
-  "subscription_recurrence_monthly": {
-    "other": "毎月"
+  "subscription_recurrence_month": {
+    "other": "月"
   },
-  "subscription_recurrence_yearly": {
-    "other": "毎年"
+  "subscription_recurrence_week": {
+    "other": "週"
+  },
+  "subscription_recurrence_day": {
+    "other": "日"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1333,15 +1333,15 @@
     "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
-    "other": "年"
+    "other": "{{.Count}} 年"
   },
   "subscription_recurrence_month": {
-    "other": "月"
+    "other": "{{.Count}} 月"
   },
   "subscription_recurrence_week": {
-    "other": "週"
+    "other": "{{.Count}} 週"
   },
   "subscription_recurrence_day": {
-    "other": "日"
+    "other": "{{.Count}} 日"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1328,5 +1328,17 @@
   },
   "pricing_ownership_promo": {
     "other": "償還"
+  },
+  "subscription_recurrence_daily": {
+    "other": "毎日"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "毎週"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "毎月"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "毎年"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1330,7 +1330,7 @@
     "other": "償還"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "申し込む {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "other": "{{.Count}} 年"

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1335,40 +1335,31 @@
   "pricing_ownership_promo": {
     "other": "Išpirkti"
   },
-  "subscription_recurrence_daily": {
-    "other": "kasdien"
-  },
-  "subscription_recurrence_weekly": {
-    "other": "kas savaitę"
-  },
-  "subscription_recurrence_monthly": {
-    "other": "kas mėnesį"
-  },
-  "subscription_recurrence_yearly": {
-    "other": "kasmet"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
-    "other": "Metai"
-  },
-  "subscription_recurrence_years": {
-    "other": "Metai"
+    "one": "Metai",
+    "few": "{{.Count}} Metai",
+    "many": "{{.Count}} Metai",
+    "other": "{{.Count}} Metai"
   },
   "subscription_recurrence_month": {
-    "other": "Mėnuo"
-  },
-  "subscription_recurrence_months": {
-    "other": "Mėnesių"
+    "one": "Mėnuo",
+    "few": "{{.Count}} Mėnesių",
+    "many": "{{.Count}} Mėnesių",
+    "other": "{{.Count}} Mėnesių"
   },
   "subscription_recurrence_week": {
-    "other": "Savaitė"
-  },
-  "subscription_recurrence_weeks": {
-    "other": "Savaitės"
+    "one": "Savaitė",
+    "few": "{{.Count}} Savaitės",
+    "many": "{{.Count}} Savaitės",
+    "other": "{{.Count}} Savaitės"
   },
   "subscription_recurrence_day": {
-    "other": "Diena"
-  },
-  "subscription_recurrence_days": {
-    "other": "Dienos"
+    "one": "Diena",
+    "few": "{{.Count}} Dienos",
+    "many": "{{.Count}} Dienos",
+    "other": "{{.Count}} Dienos"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1336,7 +1336,7 @@
     "other": "Išpirkti"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Prenumeruoti {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Metai",

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1346,5 +1346,29 @@
   },
   "subscription_recurrence_yearly": {
     "other": "kasmet"
+  },
+  "subscription_recurrence_year": {
+    "other": "Metai"
+  },
+  "subscription_recurrence_years": {
+    "other": "Metai"
+  },
+  "subscription_recurrence_month": {
+    "other": "Mėnuo"
+  },
+  "subscription_recurrence_months": {
+    "other": "Mėnesių"
+  },
+  "subscription_recurrence_week": {
+    "other": "Savaitė"
+  },
+  "subscription_recurrence_weeks": {
+    "other": "Savaitės"
+  },
+  "subscription_recurrence_day": {
+    "other": "Diena"
+  },
+  "subscription_recurrence_days": {
+    "other": "Dienos"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1334,5 +1334,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Išpirkti"
+  },
+  "subscription_recurrence_daily": {
+    "other": "kasdien"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "kas savaitę"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "kas mėnesį"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "kasmet"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Inwisselen"
+  },
+  "subscription_recurrence_daily": {
+    "other": "dagelijks"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "wekelijks"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "maandelijks"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "jaarlijks"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1332,7 +1332,7 @@
     "other": "Inwisselen"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Abonneren {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Jaar",

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1331,16 +1331,23 @@
   "pricing_ownership_promo": {
     "other": "Inwisselen"
   },
-  "subscription_recurrence_daily": {
-    "other": "dagelijks"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "wekelijks"
+  "subscription_recurrence_year": {
+    "one": "Jaar",
+    "other": "{{.Count}} jaren"
   },
-  "subscription_recurrence_monthly": {
-    "other": "maandelijks"
+  "subscription_recurrence_month": {
+    "one": "Maand",
+    "other": "{{.Count}} Maanden"
   },
-  "subscription_recurrence_yearly": {
-    "other": "jaarlijks"
+  "subscription_recurrence_week": {
+    "one": "Week",
+    "other": "{{.Count}} Weken"
+  },
+  "subscription_recurrence_day": {
+    "one": "Dag",
+    "other": "{{.Count}} dagen"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1331,16 +1331,23 @@
   "pricing_ownership_promo": {
     "other": "Løs inn"
   },
-  "subscription_recurrence_daily": {
-    "other": "daglig"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "ukentlig"
+  "subscription_recurrence_year": {
+    "one": "År",
+    "other": "{{.Count}} år"
   },
-  "subscription_recurrence_monthly": {
-    "other": "månedlig"
+  "subscription_recurrence_month": {
+    "one": "Måned",
+    "other": "{{.Count}} Måneder"
   },
-  "subscription_recurrence_yearly": {
-    "other": "årlig"
+  "subscription_recurrence_week": {
+    "one": "Uke",
+    "other": "{{.Count}} Uker"
+  },
+  "subscription_recurrence_day": {
+    "one": "Dag",
+    "other": "{{.Count}} Dager"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Løs inn"
+  },
+  "subscription_recurrence_daily": {
+    "other": "daglig"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "ukentlig"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "månedlig"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "årlig"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1332,7 +1332,7 @@
     "other": "Løs inn"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Abonnere {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "År",

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1380,16 +1380,31 @@
   "pricing_ownership_promo": {
     "other": "Odkupić"
   },
-  "subscription_recurrence_daily": {
-    "other": "codzienny"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "co tydzień"
+  "subscription_recurrence_year": {
+    "one": "Rok",
+    "few": "{{.Count}} Lata",
+    "many": "{{.Count}} Lata",
+    "other": "{{.Count}} Lata"
   },
-  "subscription_recurrence_monthly": {
-    "other": "miesięczny"
+  "subscription_recurrence_month": {
+    "one": "Miesiąc",
+    "few": "{{.Count}} Miesiące",
+    "many": "{{.Count}} Miesiące",
+    "other": "{{.Count}} Miesiące"
   },
-  "subscription_recurrence_yearly": {
-    "other": "rocznie"
+  "subscription_recurrence_week": {
+    "one": "Tydzień",
+    "few": "{{.Count}} Tygodnie",
+    "many": "{{.Count}} Tygodnie",
+    "other": "{{.Count}} Tygodnie"
+  },
+  "subscription_recurrence_day": {
+    "one": "Dzień",
+    "few": "{{.Count}} Dni",
+    "many": "{{.Count}} Dni",
+    "other": "{{.Count}} Dni"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1379,5 +1379,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Odkupić"
+  },
+  "subscription_recurrence_daily": {
+    "other": "codzienny"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "co tydzień"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "miesięczny"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "rocznie"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1381,7 +1381,7 @@
     "other": "Odkupić"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Subskrybuj {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Rok",

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1331,16 +1331,27 @@
   "pricing_ownership_promo": {
     "other": "Resgatar"
   },
-  "subscription_recurrence_daily": {
-    "other": "diário"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "semanalmente"
+  "subscription_recurrence_year": {
+    "one": "Ano",
+    "many": "{{.Count}} Anos",
+    "other": "{{.Count}} Anos"
   },
-  "subscription_recurrence_monthly": {
-    "other": "por mês"
+  "subscription_recurrence_month": {
+    "one": "Mês",
+    "many": "{{.Count}} Meses",
+    "other": "{{.Count}} Meses"
   },
-  "subscription_recurrence_yearly": {
-    "other": "anual"
+  "subscription_recurrence_week": {
+    "one": "Semana",
+    "many": "{{.Count}} Semanas",
+    "other": "{{.Count}} Semanas"
+  },
+  "subscription_recurrence_day": {
+    "one": "Dia",
+    "many": "{{.Count}} Dias",
+    "other": "{{.Count}} Dias"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1332,7 +1332,7 @@
     "other": "Resgatar"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Se inscrever {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Ano",

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Resgatar"
+  },
+  "subscription_recurrence_daily": {
+    "other": "diário"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "semanalmente"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "por mês"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "anual"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1331,16 +1331,27 @@
   "pricing_ownership_promo": {
     "other": "Resgatar"
   },
-  "subscription_recurrence_daily": {
-    "other": "diário"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "semanalmente"
+  "subscription_recurrence_year": {
+    "one": "Ano",
+    "many": "{{.Count}} Anos",
+    "other": "{{.Count}} Anos"
   },
-  "subscription_recurrence_monthly": {
-    "other": "por mês"
+  "subscription_recurrence_month": {
+    "one": "Mês",
+    "many": "{{.Count}} Meses",
+    "other": "{{.Count}} Meses"
   },
-  "subscription_recurrence_yearly": {
-    "other": "anual"
+  "subscription_recurrence_week": {
+    "one": "Semana",
+    "many": "{{.Count}} Semanas",
+    "other": "{{.Count}} Semanas"
+  },
+  "subscription_recurrence_day": {
+    "one": "Dia",
+    "many": "{{.Count}} Dias",
+    "other": "{{.Count}} Dias"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1332,7 +1332,7 @@
     "other": "Resgatar"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Se inscrever {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Ano",

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Resgatar"
+  },
+  "subscription_recurrence_daily": {
+    "other": "diário"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "semanalmente"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "por mês"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "anual"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1357,16 +1357,31 @@
   "pricing_ownership_promo": {
     "other": "Выкупать"
   },
-  "subscription_recurrence_daily": {
-    "other": "повседневная"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "еженедельно"
+  "subscription_recurrence_year": {
+    "one": "Год",
+    "few": "{{.Count}} Годы",
+    "many": "{{.Count}} Годы",
+    "other": "{{.Count}} Годы"
   },
-  "subscription_recurrence_monthly": {
-    "other": "ежемесячно"
+  "subscription_recurrence_month": {
+    "one": "Месяц",
+    "few": "{{.Count}} Месяцы",
+    "many": "{{.Count}} Месяцы",
+    "other": "{{.Count}} Месяцы"
   },
-  "subscription_recurrence_yearly": {
-    "other": "ежегодно"
+  "subscription_recurrence_week": {
+    "one": "Неделя",
+    "few": "{{.Count}} Недели",
+    "many": "{{.Count}} Недели",
+    "other": "{{.Count}} Недели"
+  },
+  "subscription_recurrence_day": {
+    "one": "День",
+    "few": "{{.Count}} Дни",
+    "many": "{{.Count}} Дни",
+    "other": "{{.Count}} Дни"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1358,7 +1358,7 @@
     "other": "Выкупать"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Подписывайся {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Год",

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1356,5 +1356,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Выкупать"
+  },
+  "subscription_recurrence_daily": {
+    "other": "повседневная"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "еженедельно"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "ежемесячно"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "ежегодно"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1334,7 +1334,7 @@
     "other": "Искупити"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "претплатити се {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Година",

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1333,16 +1333,27 @@
   "pricing_ownership_promo": {
     "other": "Искупити"
   },
-  "subscription_recurrence_daily": {
-    "other": "дневно"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "недељно"
+  "subscription_recurrence_year": {
+    "one": "Година",
+    "few": "{{.Count}} Године",
+    "other": "{{.Count}} Године"
   },
-  "subscription_recurrence_monthly": {
-    "other": "месечно"
+  "subscription_recurrence_month": {
+    "one": "Месец дана",
+    "few": "{{.Count}} месеци",
+    "other": "{{.Count}} месеци"
   },
-  "subscription_recurrence_yearly": {
-    "other": "годишње"
+  "subscription_recurrence_week": {
+    "one": "Недеља",
+    "few": "{{.Count}} Недеље",
+    "other": "{{.Count}} Недеље"
+  },
+  "subscription_recurrence_day": {
+    "one": "Дан",
+    "few": "{{.Count}} Дани",
+    "other": "{{.Count}} Дани"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1332,5 +1332,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Искупити"
+  },
+  "subscription_recurrence_daily": {
+    "other": "дневно"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "недељно"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "месечно"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "годишње"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1330,5 +1330,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Tazmin etmek"
+  },
+  "subscription_recurrence_daily": {
+    "other": "günlük"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "haftalık"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "aylık"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "yıllık"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1331,16 +1331,23 @@
   "pricing_ownership_promo": {
     "other": "Tazmin etmek"
   },
-  "subscription_recurrence_daily": {
-    "other": "günlük"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "haftalık"
+  "subscription_recurrence_year": {
+    "one": "Yıl",
+    "other": "{{.Count}} yıllar"
   },
-  "subscription_recurrence_monthly": {
-    "other": "aylık"
+  "subscription_recurrence_month": {
+    "one": "Ay",
+    "other": "{{.Count}} ay"
   },
-  "subscription_recurrence_yearly": {
-    "other": "yıllık"
+  "subscription_recurrence_week": {
+    "one": "Hafta",
+    "other": "{{.Count}} Haftalar"
+  },
+  "subscription_recurrence_day": {
+    "one": "Gün",
+    "other": "{{.Count}} Günler"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1332,7 +1332,7 @@
     "other": "Tazmin etmek"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Abone olmak {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "Yıl",

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1363,16 +1363,31 @@
   "pricing_ownership_promo": {
     "other": "Викупити"
   },
-  "subscription_recurrence_daily": {
-    "other": "щоденно"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "щотижня"
+  "subscription_recurrence_year": {
+    "one": "рік",
+    "few": "{{.Count}} років",
+    "many": "{{.Count}} років",
+    "other": "{{.Count}} років"
   },
-  "subscription_recurrence_monthly": {
-    "other": "щомісячно"
+  "subscription_recurrence_month": {
+    "one": "місяць",
+    "few": "{{.Count}} Місяці",
+    "many": "{{.Count}} Місяці",
+    "other": "{{.Count}} Місяці"
   },
-  "subscription_recurrence_yearly": {
-    "other": "щорічно"
+  "subscription_recurrence_week": {
+    "one": "тиждень",
+    "few": "{{.Count}} тижнів",
+    "many": "{{.Count}} тижнів",
+    "other": "{{.Count}} тижнів"
+  },
+  "subscription_recurrence_day": {
+    "one": "День",
+    "few": "{{.Count}} днів",
+    "many": "{{.Count}} днів",
+    "other": "{{.Count}} днів"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1364,7 +1364,7 @@
     "other": "Викупити"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "Підпишіться {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "one": "рік",

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1362,5 +1362,17 @@
   },
   "pricing_ownership_promo": {
     "other": "Викупити"
+  },
+  "subscription_recurrence_daily": {
+    "other": "щоденно"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "щотижня"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "щомісячно"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "щорічно"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1330,7 +1330,7 @@
     "other": "贖回"
   },
   "subscription_cta_label": {
-    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
+    "other": "订阅 {{.Price}}/{{.Recurrence}}"
   },
   "subscription_recurrence_year": {
     "other": "{{.Count}} 年"

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1329,16 +1329,19 @@
   "pricing_ownership_promo": {
     "other": "贖回"
   },
-  "subscription_recurrence_daily": {
-    "other": "日常的"
+  "subscription_cta_label": {
+    "other": "{{.Verb}} {{.Price}}/{{.Recurrence}}"
   },
-  "subscription_recurrence_weekly": {
-    "other": "每周"
+  "subscription_recurrence_year": {
+    "other": "{{.Count}} 年"
   },
-  "subscription_recurrence_monthly": {
-    "other": "每月"
+  "subscription_recurrence_month": {
+    "other": "{{.Count}} 月"
   },
-  "subscription_recurrence_yearly": {
-    "other": "每年"
+  "subscription_recurrence_week": {
+    "other": "{{.Count}} 星期"
+  },
+  "subscription_recurrence_day": {
+    "other": "{{.Count}} 天"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1328,5 +1328,17 @@
   },
   "pricing_ownership_promo": {
     "other": "贖回"
+  },
+  "subscription_recurrence_daily": {
+    "other": "日常的"
+  },
+  "subscription_recurrence_weekly": {
+    "other": "每周"
+  },
+  "subscription_recurrence_monthly": {
+    "other": "每月"
+  },
+  "subscription_recurrence_yearly": {
+    "other": "每年"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#8677](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8677)

- [] Has this been discussed with Delivery Team? - No

Designs: 
[Preliminary Designs in Figma](https://www.figma.com/file/wVniCXFhnwvOw2KzvslHdW/Plans?node-id=519:18872) 

![image](https://user-images.githubusercontent.com/7448443/178177702-d03e9a91-2c1f-490e-aba4-f8d196a522ac.png)
(Arabic)

![image](https://user-images.githubusercontent.com/7448443/178177646-37853f25-8f3a-42c7-a50c-c2949632707c.png)
(English)
## Description of work
Add translations for subscription recurrence on purchase CTAs

## Related PRs 

### Affected Clients
 - All clients who use Kibble

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
