### PR TITLE
Detail page mobile - CTA button adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix font weight on the can-be-watched button to match primary button styling
 - Replaces nav_homepage and site_owner translations with dynamic data via Kibble function.
 - Carousel heading is limited to a maximum of 3 lines.
+- Meta detail page pricing buttons full width stacked on mobile.
 
 ## [1.0.0](https://github.com/shift72/core-template/compare/1.0.0-alpha.0...1.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,28 @@
 
 ### Added
 - Tooltips on meta detail/item CTA buttons.
+- Language strings changed for `shopping_complete_promo_only`.
+- Text label on save credit card component changed to "Add new card".
+- Grouped carousel awards component with sponsor logo.
+- Separate translations for plans, subscriptions
+
+### Changed
+- Taglines refactored with new DOM structure.
 
 ## [1.1.0](https://github.com/shift72/core-template/compare/1.0.0...1.1.0)
 
 ### Added
-- Language strings for shopping_card_update_reason_expired
+- Language strings for `shopping_card_update_reason_expired`.
 - Carousel images can now be positioned via variables.
 
 ### Changed
-- Awards icon from star to laurel
-- Meta detail page poster width, layout direction, spacing between nav and start of content adjusted at different breakpoints
-- Show play and pricing buttons based on item type on `meta_item.jet`
+- Awards icon from star to laurel.
+- Meta detail page poster width, layout direction, spacing between nav and start of content adjusted at different breakpoints.
+- Show play and pricing buttons based on item type on `meta_item.jet`.
 - Carousel height now scales based on browser window height.
-- Fix font weight on the can-be-watched button to match primary button styling
-- Replaces nav_homepage and site_owner translations with dynamic data via Kibble function.
-- Grouped carousel awards component with sponsor logo
-
-### Added
-- Language strings for shopping_card_update_reason_expired
+- Fix font weight on the `can-be-watched button` to match primary button styling.
+- Replaces `nav_homepage` and` site_owner` translations with dynamic data via Kibble function.
 - Carousel heading is limited to a maximum of 3 lines.
-- Meta detail page pricing buttons full width stacked on mobile.
-- Language strings changed for shopping_complete_promo_only
 
 ## [1.0.0](https://github.com/shift72/core-template/compare/1.0.0-alpha.0...1.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Text label on save credit card component changed to "Add new card".
 - Grouped carousel awards component with sponsor logo.
 - Separate translations for plans, subscriptions
+- Play button i18n changed to 'Watch now' instead of 'Play now'
 
 ### Changed
 - Taglines refactored with new DOM structure.

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -125,7 +125,7 @@
     "other": "Envia la cerca"
   },
   "play_button_watch": {
-    "other": "Visualitza ara"
+    "other": "Veure ara"
   },
   "play_button_resume": {
     "other": "Continuar"

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -122,7 +122,7 @@
     "other": "Søg nu"
   },
   "play_button_watch": {
-    "other": "Afspil nu"
+    "other": "Se nu"
   },
   "play_button_resume": {
     "other": "Fortsæt"

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -107,7 +107,7 @@
     "other": "Suche einreichen"
   },
   "play_button_watch": {
-    "other": "Jetzt abspielen"
+    "other": "Schau jetzt"
   },
   "play_button_resume": {
     "other": "Fortsetzen"

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -122,7 +122,7 @@
     "other": "Υποβάλετε αναζήτηση"
   },
   "play_button_watch": {
-    "other": "Αναπαραγωγή"
+    "other": "Παρακολουθήσετε τώρα"
   },
   "play_button_resume": {
     "other": "Συνέχιση"

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -128,7 +128,7 @@
     "other": "Submit search"
   },
   "play_button_watch": {
-    "other": "Play Now"
+    "other": "Watch now"
   },
   "play_button_resume": {
     "other": "Continue"

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -122,7 +122,7 @@
     "other": "Aplicar búsqueda"
   },
   "play_button_watch": {
-    "other": "Reproducir"
+    "other": "Ver ahora"
   },
   "play_button_resume": {
     "other": "Reproducir"

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -122,7 +122,7 @@
     "other": "Enviar busqueda"
   },
   "play_button_watch": {
-    "other": "Reproducir"
+    "other": "Ver ahora"
   },
   "play_button_resume": {
     "other": "Continuar"

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -122,7 +122,7 @@
     "other": "Otsi"
   },
   "play_button_watch": {
-    "other": "Vaata"
+    "other": "Vaata nüüd"
   },
   "play_button_resume": {
     "other": "Jätka"

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -102,7 +102,7 @@
     "other": "Hae"
   },
   "play_button_watch": {
-    "other": "Toista"
+    "other": "Katso nyt"
   },
   "play_button_resume": {
     "other": "Jatka"
@@ -1330,5 +1330,5 @@
   },
   "pricing_ownership_promo": {
     "other": "Lunastaa"
-    }
+  }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -119,7 +119,7 @@
     "other": "Rechercher"
   },
   "play_button_watch": {
-    "other": "Voir le film"
+    "other": "Regarde maintenant"
   },
   "play_button_resume": {
     "other": "Continuer"

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -123,7 +123,7 @@
     "other": "Potvrdi pretraživanje"
   },
   "play_button_watch": {
-    "other": "Pokreni sadržaj"
+    "other": "Gledajte sad"
   },
   "play_button_resume": {
     "other": "Nastavi"

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -122,7 +122,7 @@
     "other": "Keresés indítása"
   },
   "play_button_watch": {
-    "other": "Lejátszás"
+    "other": "Nézd meg most"
   },
   "play_button_resume": {
     "other": "Folytatás"

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -102,7 +102,7 @@
     "other": "検索する"
   },
   "play_button_watch": {
-    "other": "再生する"
+    "other": "今見る"
   },
   "play_button_resume": {
     "other": "続きから見る"

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -122,7 +122,7 @@
     "other": "Pateikti paiešką"
   },
   "play_button_watch": {
-    "other": "Žiūrėti dabar"
+    "other": "Žiūrėk dabar"
   },
   "play_button_resume": {
     "other": "Tęsti"

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -122,7 +122,7 @@
     "other": "Søk"
   },
   "play_button_watch": {
-    "other": "Spill av"
+    "other": "Se nå"
   },
   "play_button_resume": {
     "other": "Fortsett"

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -102,7 +102,7 @@
     "other": "Wyszukaj"
   },
   "play_button_watch": {
-    "other": "Odtwórz"
+    "other": "Patrz teraz"
   },
   "play_button_resume": {
     "other": "Kontynuuj"

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -125,7 +125,7 @@
     "other": "Buscar"
   },
   "play_button_watch": {
-    "other": "Assistir Agora"
+    "other": "Assista agora"
   },
   "play_button_resume": {
     "other": "Continuar"

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -122,7 +122,7 @@
     "other": "Buscar"
   },
   "play_button_watch": {
-    "other": "Assistir Agora"
+    "other": "Assista agora"
   },
   "play_button_resume": {
     "other": "Continuar"

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -124,7 +124,7 @@
     "other": "Начать поиск"
   },
   "play_button_watch": {
-    "other": "Запустить сейчас"
+    "other": "Смотри"
   },
   "play_button_resume": {
     "other": "Поделиться"

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -122,7 +122,7 @@
     "other": "Пошаљите претрагу"
   },
   "play_button_watch": {
-    "other": "Гледајте одмах"
+    "other": "Гледај сада"
   },
   "play_button_resume": {
     "other": "Наставите"

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -283,6 +283,19 @@ s72-element-switcher,
       font-size: 12px;
     }
   }
+
+  .s72-pricing-button-container {
+    display: flex;
+    flex-wrap: wrap;
+
+    @include media-breakpoint-up(xs) {
+      display: grid;
+    }
+
+    .s72-subscribe {
+      flex-grow: 1;
+    }
+  }
 }
 
 .recommendations-collection {

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -240,19 +240,6 @@ s72-element-switcher,
       animation: fadein 2s;
     }
   }
-
-  .s72-pricing-button-container {
-    display: flex;
-    flex-wrap: wrap;
-
-    @include media-breakpoint-up(xs) {
-      display: grid;
-    }
-
-    .s72-subscribe {
-      flex-grow: 1;
-    }
-  }
 }
 
 .recommendations-collection {

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -122,7 +122,7 @@
     "other": "Aramayı gönder"
   },
   "play_button_watch": {
-    "other": "Şimdi Oynat"
+    "other": "İzle şimdi"
   },
   "play_button_resume": {
     "other": "Devam et"

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -124,7 +124,7 @@
     "other": "Шукати"
   },
   "play_button_watch": {
-    "other": "Дивитися"
+    "other": "Дивитися зараз"
   },
   "play_button_resume": {
     "other": "Продовжити"

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -125,7 +125,7 @@
     "other": "送出"
   },
   "play_button_watch": {
-    "other": "播放"
+    "other": "立即观看"
   },
   "play_button_resume": {
     "other": "繼續播放"


### PR DESCRIPTION
ADO card: ☑️ [AB#8093](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8093)

Elab notes/AC: 📃 [Google Docs](https://docs.google.com)
- [ ] Has this been discussed with Delivery Team?

Designs: 
- 📱 [Mobile](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/62030a7ff375ab015a507fad)

## Description of work
- ~Makes detail page pricing buttons full width on xs breakpoint~ this PR is now just translations
- Changes translation "Play now" to "Watch now"

### Affected Clients
 - All new clients who use Kibble

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
