### PR TITLE
Seperate ownership_plan, owership_subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Language strings changed for `shopping_complete_promo_only`.
 - Text label on save credit card component changed to "Add new card".
 - Grouped carousel awards component with sponsor logo.
+- Separate translations for plans, subscriptions
 
 ### Changed
 - Taglines refactored with new DOM structure.

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -968,7 +968,7 @@
     "other": "بطاقة الائتمان غير صحيحة؟ <a href=\"{{.SubscriptionsURL}}\"> انقر(ي) هنا لتحديث بطاقتك. </a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "الاشتراك"
+    "other": "يخطط"
   },
   "shopping_info_rental_period_coming_soon": {
     "other": "من تاريخ ووقت الإصدار."
@@ -1347,5 +1347,8 @@
   },
   "pricing_ownership_promo": {
     "other": "يسترد"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "الاشتراك"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -971,7 +971,7 @@
     "other": "La targeta de crèdit no és correcta? <a href=\"{{.SubscriptionsURL}}\">Feu clic aquí per actualitzar la vostra targeta.</a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "Subscripció"
+    "other": "Pla"
   },
   "shopping_action_credit": {
     "other": "Omplir"
@@ -1339,5 +1339,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Redimir"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Subscripció"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -953,7 +953,7 @@
     "other": "Kreditkort ikke korrekt? <a href=\"{{.SubscriptionsURL}}\">Klik her for at opdatere dit kort.</a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "Abonnement"
+    "other": "Plan"
   },
   "shopping_action_credit": {
     "other": "Fyld op"
@@ -1339,5 +1339,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Indløs"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Abonnement"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1224,7 +1224,7 @@
     "other": "Aktualisieren Sie Ihre Kreditkarte. Unterstützte Karten sind Visa, Mastercard und American Express."
   },
   "shopping_info_ownership_plan": {
-    "other": "Abonnement"
+    "other": "Planen"
   },
   "shopping_action_credit": {
     "other": "Nachfüllen"
@@ -1339,5 +1339,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Tilgen"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Abonnement"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -881,7 +881,7 @@
     "other": "Αλλαγή κάρτας"
   },
   "shopping_info_ownership_plan": {
-    "other": "Συνδρομή"
+    "other": "Σχέδιο"
   },
   "shopping_action_credit": {
     "other": "Προσθήκη πίστωσης"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Εξαργυρώνω"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Συνδρομή"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -977,7 +977,7 @@
     "other": "Credit card not correct? <a href=\"{{.SubscriptionsURL}}\">Click here to update your card.</a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "Subscription"
+    "other": "Plan"
   },
   "shopping_price_title_plan": {
     "other": "Price"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Redeem"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Subscription"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1215,7 +1215,7 @@
     "other": "Actualice su tarjeta de crédito. Las tarjetas aceptadas son Visa, Mastercard y American Express."
   },
   "shopping_info_ownership_plan": {
-    "other": "Suscripción"
+    "other": "Plan"
   },
   "shopping_action_credit": {
     "other": "añadir crédito"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Redimir"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Suscripción"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1160,7 +1160,7 @@
     "other": "Actualice su tarjeta de crédito. Las tarjetas aceptadas son Visa, Mastercard y American Express."
   },
   "shopping_info_ownership_plan": {
-    "other": "Suscripción"
+    "other": "Plan"
   },
   "shopping_action_credit": {
     "other": "añadir crédito"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Redimir"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Suscripción"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -887,7 +887,7 @@
     "other": "Vaheta kaarti"
   },
   "shopping_info_ownership_plan": {
-    "other": "Tellimus"
+    "other": "Plaan"
   },
   "shopping_action_credit": {
     "other": "Täida"
@@ -1339,5 +1339,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Lunastama"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Tellimus"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1153,7 +1153,7 @@
     "other": "Päivitä luottokorttisi. Tuetut kortit ovat Visa, Mastercard ja American Express."
   },
   "shopping_info_ownership_plan": {
-    "other": "Tilaus"
+    "other": "Suunnitelma"
   },
   "shopping_action_credit": {
     "other": "Täytä"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Lunastaa"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Tilaus"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1203,7 +1203,7 @@
     "other": "Mettez à jour votre carte de crédit. Les cartes acceptées sont Visa, Mastercard et American Express."
   },
   "shopping_info_ownership_plan": {
-    "other": "Abonnement"
+    "other": "Planifier"
   },
   "shopping_action_credit": {
     "other": "Ajouter un crédit"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Racheter"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Abonnement"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1218,7 +1218,7 @@
     "other": "SD Only"
   },
   "shopping_info_ownership_plan": {
-    "other": "Pretplata"
+    "other": "Plan"
   },
   "shopping_action_credit": {
     "other": "Dopuniti"
@@ -1324,5 +1324,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Otkupiti"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Pretplata"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -887,7 +887,7 @@
     "other": "Válts kártyát"
   },
   "shopping_info_ownership_plan": {
-    "other": "Feliratkozás"
+    "other": "Terv"
   },
   "shopping_action_credit": {
     "other": "Feltölt"
@@ -1339,5 +1339,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Beváltani"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Feliratkozás"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1224,7 +1224,7 @@
     "other": "Riempire"
   },
   "shopping_info_ownership_plan": {
-    "other": "Sottoscrizione"
+    "other": "Piano"
   },
   "usersubscriptions_change_payment_method_change": {
     "other": "Cambia carta di credito"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Riscattare"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Sottoscrizione"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1151,7 +1151,7 @@
     "other": "クレジットカードを更新します。 サポートされているカードは、Visa、Mastercard、AmericanExpressです。"
   },
   "shopping_info_ownership_plan": {
-    "other": "サブスクリプション"
+    "other": "プラン"
   },
   "shopping_action_credit": {
     "other": "補充"
@@ -1328,5 +1328,8 @@
   },
   "pricing_ownership_promo": {
     "other": "償還"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "サブスクリプション"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -938,7 +938,7 @@
     "other": "Netinkama kredito kortelė? <a href=\"{{.SubscriptionsURL}}\">Jei norite atnaujinti kortelę, spustelėkite čia.</a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "Prenumerata"
+    "other": "Planuoti"
   },
   "shopping_action_credit": {
     "other": "Prisipilti"
@@ -1334,5 +1334,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Išpirkti"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Prenumerata"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -938,7 +938,7 @@
     "other": "Creditcard niet correct? <a href=\"{{.SubscriptionsURL}}\">Klik hier om uw kaart bij te werken.</a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "Abonnement"
+    "other": "Plan"
   },
   "shopping_action_credit": {
     "other": "Opwaarderen"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Inwisselen"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Abonnement"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -887,7 +887,7 @@
     "other": "Bytt kort"
   },
   "shopping_info_ownership_plan": {
-    "other": "Intekening"
+    "other": "Plan"
   },
   "shopping_action_credit": {
     "other": "fylle opp"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Løs inn"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Abonnement"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1214,7 +1214,7 @@
     "other": "Zaktualizuj swoją kartę kredytową. Obsługiwane karty to Visa, Mastercard i American Express."
   },
   "shopping_info_ownership_plan": {
-    "other": "Subskrypcja"
+    "other": "Plan"
   },
   "shopping_action_credit": {
     "other": "Uzupełniać"
@@ -1379,5 +1379,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Odkupić"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Subskrypcja"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -971,7 +971,7 @@
     "other": "O cartão de crédito não está correto? <a href=\"{{.SubscriptionsURL}}\"> Clique aqui para atualizar seu cartão. </a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "Inscrição"
+    "other": "Plano"
   },
   "shopping_action_credit": {
     "other": "Completar"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Resgatar"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Inscrição"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -881,7 +881,7 @@
     "other": "Alterar cartão"
   },
   "shopping_info_ownership_plan": {
-    "other": "Inscrição"
+    "other": "Plano"
   },
   "shopping_action_credit": {
     "other": "Completar"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Resgatar"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Inscrição"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -909,7 +909,7 @@
     "other": "Изменить карту"
   },
   "shopping_info_ownership_plan": {
-    "other": "Подписка"
+    "other": "План"
   },
   "shopping_action_credit": {
     "other": "Пополнить"
@@ -1356,5 +1356,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Выкупать"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Подписка"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -917,7 +917,7 @@
     "other": "Кредитная карта не правильная? <a href=\"{{.SubscriptionsURL}}\">Нажмите здесь, чтобы обновить свою карту.</a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "Подписка"
+    "other": "План"
   },
   "shopping_action_credit": {
     "other": "Пополнить"
@@ -1332,5 +1332,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Искупити"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Претплата"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -887,7 +887,7 @@
     "other": "Kartı değiştir "
   },
   "shopping_info_ownership_plan": {
-    "other": "Abonelik"
+    "other": "Plan"
   },
   "shopping_action_credit": {
     "other": "Doldurmak"
@@ -1330,5 +1330,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Tazmin etmek"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "abonelik"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -981,7 +981,7 @@
     "other": "Кредитна картка не правильна? <a href=\"{{.SubscriptionsURL}}\">Натисніть тут, щоб оновити свою картку.</a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "Підписка"
+    "other": "План"
   },
   "shopping_action_credit": {
     "other": "Поповнити"
@@ -1362,5 +1362,8 @@
   },
   "pricing_ownership_promo": {
     "other": "Викупити"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "Підписка"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -971,7 +971,7 @@
     "other": "信用卡錯誤 <a href=\"{{.SubscriptionsURL}}\">請按此更新。</a>"
   },
   "shopping_info_ownership_plan": {
-    "other": "訂閱"
+    "other": "计划"
   },
   "shopping_action_credit": {
     "other": "頂尖"
@@ -1328,5 +1328,8 @@
   },
   "pricing_ownership_promo": {
     "other": "贖回"
+  },
+  "shopping_info_ownership_subscription": {
+    "other": "订阅"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#8875](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8875)

- [ ] Has this been discussed with Delivery Team? 

## Description of work
Shopping session modal only checked if item is a plan, then assigned a language string for being a subscription. Added a check for plan type and added/modified the language strings in the core template.

## Config settings/Toggles required for the feature to work
- Site needs plans

## Related PRs 

### Any PRs which depend on this PR
- [Relish](https://github.com/indiereign/shift72-web/pull/329)

### Affected Clients
- Clients with SVOD without the new language string

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
