### PR TITLE
Update tagline.jet

### DIFF
--- a/site/templates/items/tagline.jet
+++ b/site/templates/items/tagline.jet
@@ -26,7 +26,7 @@
     {{end}}
 
     {{if isset(.Items)}}
-      {{yield taglineItem() content}}
+      {{yield item() content}}
         {{i18n("bundle_items_generic", len(.Items))}}
       {{end}}
       {{showDivider = true}}


### PR DESCRIPTION
One of the cases got missed for migrating `taglineItem` to `item`.