### PR TITLE
Language strings for usersubscriptions_unsubscribe_modal_cancel and usersubscriptions_unsubscribe_modal_confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Show play and pricing buttons based on item type on `meta_item.jet`
 - Fix font weight on the can-be-watched button to match primary button styling
 - Replaces nav_homepage and site_owner translations with dynamic data via Kibble function.
+- Language strings for usersubscriptions_unsubscribe_modal_cancel and usersubscriptions_unsubscribe_modal_confirm
 
 ### Added
 - Language strings for shopping_card_update_reason_expired

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1001,10 +1001,10 @@
     "other": "إلغاء اشتراكي"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "يلغي"
+    "other": "لا شكرا"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "نعم ، إلغاء اشتراكي"
+    "other": "نعم ، إلغاء"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "إلغاء الاشتراك؟"

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1007,10 +1007,10 @@
     "other": "Cancel·la la meva subscripció"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Cancel · lar"
+    "other": "No gràcies"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Sí, cancel·lar la meva subscripció"
+    "other": "Sí, cancel·la"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Cancel·lar la subscripció?"

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -989,10 +989,10 @@
     "other": "Opsig mit abonnement"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Afbestille"
+    "other": "Nej tak"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Ja, opsige mit abonnement"
+    "other": "Ja, annuller"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Vil du opsige abonnement?"

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1095,10 +1095,10 @@
     "other": "Mein Abonnement kündigen"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Stornieren"
+    "other": "Nein Danke"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Ja, mein Abonnement kündigen"
+    "other": "Ja Abbrechen"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Abonnement beenden?"

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -908,10 +908,10 @@
     "other": "Ακύρωση της συνδρομής μου"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Ματαίωση"
+    "other": "Οχι ευχαριστώ"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Ναι, ακυρώστε τη συνδρομή μου"
+    "other": "Ναι, ακύρωση"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Ακύρωση συνδρομής;"

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1086,10 +1086,10 @@
     "other": "Cancel my subscription"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Cancel"
+    "other": "No thanks"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Yes, cancel my subscription"
+    "other": "Yes, cancel"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Cancel subscription?"

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1146,10 +1146,10 @@
     "other": "Cancelar mi suscripción"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Cancelar"
+    "other": "No, gracias"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Sí, cancelar mi suscripción"
+    "other": "Sí, cancelar"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "¿Cancelar suscripción?"

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1106,10 +1106,10 @@
     "other": "Cancelar mi suscripción"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Cancelar"
+    "other": "No, gracias"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Sí, cancelar mi suscripción"
+    "other": "Sí, cancelar"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "¿Cancelar suscripción?"

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -923,10 +923,10 @@
     "other": "Tühista minu tellimus"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Tühista"
+    "other": "Ei aitäh"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Jah, tühistage minu tellimus"
+    "other": "Jah, tühista"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Kas tühistada tellimus?"

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1102,10 +1102,10 @@
     "other": "Peruuta tilaukseni"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Peruuttaa"
+    "other": "Ei kiitos"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Kyllä, peruuta tilaukseni"
+    "other": "Kyllä, peruuta"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Peruuta tilaus?"
@@ -1330,5 +1330,5 @@
   },
   "pricing_ownership_promo": {
     "other": "Lunastaa"
-    }
+  }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1134,10 +1134,10 @@
     "other": "Annuler mon abonnement"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Annuler"
+    "other": "Non merci"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Oui, résilier mon abonnement"
+    "other": "Oui, annuler"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Se désabonner?"

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1188,10 +1188,10 @@
     "other": "Otkaži moju pretplatu"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Otkazati"
+    "other": "Ne hvala"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Da, otkaži moju pretplatu"
+    "other": "Da, otkaži"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Otkazati pretplatu?"

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -923,10 +923,10 @@
     "other": "Lemondom az előfizetésemet"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Megszünteti"
+    "other": "Nem köszönöm"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Igen, mondd le az előfizetésemet"
+    "other": "Igen, mégsem"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Feliratkozás visszavonása?"

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1146,10 +1146,10 @@
     "other": "Annulla il mio abbonamento"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Annulla"
+    "other": "No grazie"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Sì, cancella il mio abbonamento"
+    "other": "Sì, annulla"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Annullare l'iscrizione?"

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1097,10 +1097,10 @@
     "other": "サブスクリプションをキャンセルする"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "キャンセル"
+    "other": "結構です"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "はい、サブスクリプションをキャンセルします"
+    "other": "はい、キャンセルします"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "サブスクリプションをキャンセルしますか？"

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -965,10 +965,10 @@
     "other": "Atšaukti mano prenumeratą"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Atšaukti"
+    "other": "Ne, ačiū"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Taip, atšaukite mano prenumeratą"
+    "other": "Taip, atšaukti"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Atšaukti prenumeratą?"

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -965,10 +965,10 @@
     "other": "Mijn abonnement opzeggen"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Annuleren"
+    "other": "Nee, dank u wel"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Ja, zeg mijn abonnement op"
+    "other": "Ja, annuleren"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Annuleer abonnement"

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -914,10 +914,10 @@
     "other": "Si opp abonnementet mitt"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Avbryt"
+    "other": "Nei takk"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Ja, kanseller abonnementet mitt"
+    "other": "Ja, avbryt"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Avbestille abonnementet?"

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1160,10 +1160,10 @@
     "other": "Anuluj moją subskrypcję"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Anulować"
+    "other": "Nie, dziękuję"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Tak, anuluj moją subskrypcję"
+    "other": "Tak, anuluj"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Anuluj subskrypcje?"

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -998,10 +998,10 @@
     "other": "Cancelar minha assinaturan"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Cancelar"
+    "other": "Não, obrigado"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Sim, cancelar minha assinatura"
+    "other": "Sim, cancelar"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Cancelar assinatura?"

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -908,10 +908,10 @@
     "other": "Cancelar minha assinaturan"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Cancelar"
+    "other": "Não, obrigado"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Sim, cancelar minha assinatura"
+    "other": "Sim, cancelar"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Cancelar assinatura?"

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -936,10 +936,10 @@
     "other": "Отменить мою подписку"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Отмена"
+    "other": "Спасибо, не надо"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Да, отмените мою подписку"
+    "other": "Да, отменить"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Отменить подписку?"

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -944,10 +944,10 @@
     "other": "Отменить мою подписку"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Отмена"
+    "other": "Не хвала"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Да, отмените мою подписку"
+    "other": "Да, откажи"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Отменить подписку?"

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -914,10 +914,10 @@
     "other": "Aboneliğimi iptal et"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "İptal"
+    "other": "Hayır, teşekkürler"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Evet, aboneliğimi iptal et "
+    "other": "Evet İptal"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Aboneliği iptal et?"

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1008,10 +1008,10 @@
     "other": "Скасувати мою підписку"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "Скасувати"
+    "other": "Ні, дякую"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "Так, скасувати мою підписку"
+    "other": "Так, скасувати"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "Скасувати підписку?"

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -998,10 +998,10 @@
     "other": "取消我的訂閱"
   },
   "usersubscriptions_unsubscribe_modal_cancel": {
-    "other": "取消"
+    "other": "不，谢谢"
   },
   "usersubscriptions_unsubscribe_modal_confirm": {
-    "other": "是的，取消我的訂閱"
+    "other": "是的，取消"
   },
   "usersubscriptions_unsubscribe_modal_title": {
     "other": "取消訂閱？"


### PR DESCRIPTION
ADO card: ☑️ [AB#8846](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8846)

## Description of work
More translation strings amended for SVOD work

## Edge cases/Caveats/Known issues
N/A
## Config settings/Toggles required for the feature to work
N/A

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
