### PR TITLE
design typography adjustments

### DIFF
--- a/site/styles/_awards.scss
+++ b/site/styles/_awards.scss
@@ -19,6 +19,7 @@
   .meta-award-nomination {
     display: flex;
     max-width: 370px;
+    @include subtitle-1-style;
   }
 
   .meta-award-nomination-icon {

--- a/site/styles/_awards.scss
+++ b/site/styles/_awards.scss
@@ -17,9 +17,9 @@
   }
 
   .meta-award-nomination {
+    @include subtitle-1-style;
     display: flex;
     max-width: 370px;
-    @include subtitle-1-style;
   }
 
   .meta-award-nomination-icon {

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -402,6 +402,7 @@ s72-element-switcher,
 }
 
 .sponsor {
+  @include body-1-style();
   margin-bottom: 24px;
   max-width: 250px;
 

--- a/site/styles/_typography.scss
+++ b/site/styles/_typography.scss
@@ -31,7 +31,6 @@
   }
 }
 
-
 @mixin heading-3-style() {
   @include typography-style(20px, 0, $font-weight-normal, 6px, null, 24px);
   @include media-breakpoint-up(sm) {

--- a/site/styles/_typography.scss
+++ b/site/styles/_typography.scss
@@ -15,55 +15,105 @@
 }
 
 @mixin heading-1-style() {
-  @include typography-style(32px, 0.4px, $font-weight-normal, 8px, var(--body-color), 42px);
+  @include typography-style(
+    $font-size: 32px,
+    $letter-spacing: 0.4px,
+    $font-weight: $font-weight-normal,
+    $margin-bottom: 8px,
+    $font-color: var(--body-color),
+    $line-height: 42px
+  );
   @include media-breakpoint-up(xs) {
-    @include typography-style(46px, null, null, null, null, 56px);
+    @include typography-style($font-size: 46px, $line-height: 56px);
   }
   small {
-    @include typography-style(24px);
+    @include typography-style($font-size: 24px);
   }
 }
 
 @mixin heading-2-style() {
-  @include typography-style(29px, 0.6px, $font-weight-normal, 13px);
+  @include typography-style(
+    $font-size: 29px,
+    $letter-spacing: 0.6px,
+    $font-weight: $font-weight-normal,
+    $margin-bottom: 13px
+  );
   @include media-breakpoint-up(sm) {
-    @include typography-style(35px);
+    @include typography-style($font-size: 35px);
   }
 }
 
 @mixin heading-3-style() {
-  @include typography-style(20px, 0, $font-weight-normal, 6px, null, 24px);
+  @include typography-style(
+    $font-size: 20px,
+    $letter-spacing: 0,
+    $font-weight: $font-weight-normal,
+    $margin-bottom: 6px,
+    $line-height: 24px
+  );
   @include media-breakpoint-up(sm) {
-    @include typography-style(24px, 0.4px, null, null, null, 30px);
+    @include typography-style($font-size: 24px, $letter-spacing: 0.4px, $line-height: 30px);
   }
 }
 
 @mixin heading-4-style() {
-  @include typography-style(18px, null, $font-weight-light, 20px);
+  @include typography-style(
+    $font-size: 18px,
+    $font-weight: $font-weight-light,
+    $margin-bottom: 20px
+  );
 }
 
 @mixin body-1-style() {
-  @include typography-style(16px, 0.6px, $font-weight-light, null, null, 23px);
+  @include typography-style(
+    $font-size: 16px,
+    $letter-spacing: 0.6px,
+    $font-weight: $font-weight-light,
+    $line-height: 23px
+  );
 }
 
 @mixin body-2-style() {
-  @include typography-style(14px, 0.4px);
+  @include typography-style($font-size: 14px, $letter-spacing: 0.4px);
 }
 
 @mixin subtitle-1-style() {
-  @include typography-style(16px, 0.2px, $font-weight-normal, 2px, null, 20px);
+  @include typography-style(
+    $font-size: 16px,
+    $letter-spacing: 0.2px,
+    $font-weight: $font-weight-normal,
+    $margin-bottom: 2px,
+    $line-height: 20px
+  );
 }
 
 @mixin subtitle-2-style() {
-  @include typography-style(14px, 0.2px, $font-weight-normal, 12px, null, 18px);
+  @include typography-style(
+    $font-size: 14px,
+    $letter-spacing: 0.2px,
+    $font-weight: $font-weight-normal,
+    $margin-bottom: 12px,
+    $line-height: 18px
+  );
 }
 
 @mixin caption-1-style() {
-  @include typography-style(16px, 0.6px, $font-weight-bold, 4px, null, 20px);
+  @include typography-style(
+    $font-size: 16px,
+    $letter-spacing: 0.6px,
+    $font-weight: $font-weight-bold,
+    $margin-bottom: 4px,
+    $line-height: 20px
+  );
 }
 
 @mixin overline-style() {
-  @include typography-style(14px, 1px, $font-weight-normal, null, null, 18px);
+  @include typography-style(
+    $font-size: 14px,
+    $letter-spacing: 1px,
+    $font-weight: $font-weight-normal,
+    $line-height: 18px
+  );
 }
 
 h1 {

--- a/site/styles/_typography.scss
+++ b/site/styles/_typography.scss
@@ -15,9 +15,9 @@
 }
 
 @mixin heading-1-style() {
-  @include typography-style(32px, 0.4px, $font-weight-normal, 8px, var(--body-color));
+  @include typography-style(32px, 0.4px, $font-weight-normal, 8px, var(--body-color), 42px);
   @include media-breakpoint-up(xs) {
-    @include typography-style(45px);
+    @include typography-style(46px, null, null, null, null, 56px);
   }
   small {
     @include typography-style(24px);
@@ -31,10 +31,11 @@
   }
 }
 
+
 @mixin heading-3-style() {
-  @include typography-style(20px, 0, $font-weight-normal, 6px);
+  @include typography-style(20px, 0, $font-weight-normal, 6px, null, 24px);
   @include media-breakpoint-up(sm) {
-    @include typography-style(23px, 0.4px);
+    @include typography-style(24px, 0.4px, null, null, null, 30px);
   }
 }
 
@@ -43,7 +44,7 @@
 }
 
 @mixin body-1-style() {
-  @include typography-style(16px, 0.5px, $font-weight-light, null, null, 23px);
+  @include typography-style(16px, 0.6px, $font-weight-light, null, null, 23px);
 }
 
 @mixin body-2-style() {
@@ -51,19 +52,19 @@
 }
 
 @mixin subtitle-1-style() {
-  @include typography-style(16px, 0.2px, $font-weight-light, 2px);
+  @include typography-style(16px, 0.2px, $font-weight-normal, 2px, null, 20px);
 }
 
 @mixin subtitle-2-style() {
-  @include typography-style(14px, 0.2px, $font-weight-normal, 12px);
+  @include typography-style(14px, 0.2px, $font-weight-normal, 12px, null, 18px);
 }
 
 @mixin caption-1-style() {
-  @include typography-style(16px, 0.5px, $font-weight-bold, 4px);
+  @include typography-style(16px, 0.6px, $font-weight-bold, 4px, null, 20px);
 }
 
 @mixin overline-style() {
-  @include typography-style(14px, 0.8px, $font-weight-light);
+  @include typography-style(14px, 1px, $font-weight-normal, null, null, 18px);
 }
 
 h1 {


### PR DESCRIPTION
ADO card (headings): ☑️ [AB#8089](https://dev.azure.com/S72/SHIFT72/_workitems/edit/8089)

- [ ] Has this been discussed with Delivery Team?

Designs: 
- 🖥 [typography designs section](https://zpl.io/amxOMBr)
- 🖥 [Desktop/tablet](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/61231fda5d02ef1252e998e7)  (font stylesheet)
- 📱 [Mobile](https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/61232090efca7116d70899fe)  (font stylesheet)

## Description of work
Carry out design feedback - listed in [this doc](https://docs.google.com/document/d/1EJlDKaCQ7PIDVE3P_dPo6e765CkYVQPZro7v4m9FEgQ), (ignore sections titled spacing, todo in another card): 
- make some adjustments to the headings 
- apply subtitle-1-style to awards
- apply body-1-style to sponsor text


### Affected Clients
 - All clients who use Kibble


## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [x] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
