### PR TITLE
fix spinner not rotating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.2.0...HEAD)
 
+### Fixed
+- Spinner not rotating
+
 ## [1.2.0](https://github.com/shift72/core-template/compare/1.2.0-alpha.0...1.2.0)
 
 No changes from `alpha-0`.

--- a/site/styles/_icons.scss
+++ b/site/styles/_icons.scss
@@ -6,6 +6,7 @@
 }
 
 .fa {
+  display: inline-block;
   font-family: 'fa-s72' !important;
   font-style: normal !important;
   font-variant: normal !important;
@@ -13,7 +14,6 @@
   line-height: 1;
   text-transform: none !important;
   vertical-align: middle;
-  display: inline-block;
 }
 
 .fa-credit-card::before,

--- a/site/styles/_icons.scss
+++ b/site/styles/_icons.scss
@@ -13,6 +13,7 @@
   line-height: 1;
   text-transform: none !important;
   vertical-align: middle;
+  display: inline-block;
 }
 
 .fa-credit-card::before,


### PR DESCRIPTION
ADO card: ☑️ [AB#9171](https://dev.azure.com/S72/SHIFT72/_workitems/edit/9171)

## Description of work
Fixes spinner icon not rotating

### What happened
Spinner was tested working at time of PR creation https://github.com/shift72/core-template/pull/303. But I forgot to remove font awesome import.

So during the PR I made a [commit ](https://github.com/shift72/core-template/pull/303/commits/df4a7cfa0fa2e9a98620cfed8d4dd8753bb1269c#diff-d634b86743ea9bf5ae117a93030b6adf7329c124a57e4e1738f666cc3816b336L7) to remove it.

This commit inadvertantly removed display: inline-block from `.fa` resulting in animation not being applied to the icon.


### Affected Clients
Any client since PR was merged (29 April) https://github.com/shift72/core-template/pull/303 and then core-template release mid-may

Sorry guys!

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
