### PR TITLE
Missing translations for SVOD

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -988,9 +988,6 @@
   "usersubscriptions_subscription_status_cancelled": {
     "other": "ألغيت"
   },
-  "usersubscriptions_subscription_status_errored": {
-    "other": "usersubscriptions_subscription_status_errored"
-  },
   "usersubscriptions_subscription_status_past_due": {
     "other": "فات موعد الاستحقاق"
   },

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -986,13 +986,13 @@
     "other": "تنتهي {{.Expiry}}"
   },
   "usersubscriptions_subscription_status_cancelled": {
-    "other": "usersubscriptions_subscription_status_cancelled"
+    "other": "ألغيت"
   },
   "usersubscriptions_subscription_status_errored": {
     "other": "usersubscriptions_subscription_status_errored"
   },
   "usersubscriptions_subscription_status_past_due": {
-    "other": "usersubscriptions_subscription_status_past_due"
+    "other": "فات موعد الاستحقاق"
   },
   "usersubscriptions_subscription_status_trialing": {
     "other": "فترة النسخة التجريبية"
@@ -1391,5 +1391,11 @@
   },
   "stripe_card_not_supported": {
     "other": "بطاقتك غير مدعومة."
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "غير مدفوعة"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "الإلغاء"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -992,13 +992,13 @@
     "other": "Caduca {{.Expiry}}"
   },
   "usersubscriptions_subscription_status_cancelled": {
-    "other": "usersubscriptions_subscription_status_cancelled"
+    "other": "Cancel·lat"
   },
   "usersubscriptions_subscription_status_errored": {
     "other": "usersubscriptions_subscription_status_errored"
   },
   "usersubscriptions_subscription_status_past_due": {
-    "other": "usersubscriptions_subscription_status_past_due"
+    "other": "Vençuda"
   },
   "usersubscriptions_subscription_status_trialing": {
     "other": "Període de prova"
@@ -1367,5 +1367,11 @@
   },
   "stripe_card_not_supported": {
     "other": "La teva targeta no és compatible."
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Sense pagar"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "S'està cancel·lant"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -994,9 +994,6 @@
   "usersubscriptions_subscription_status_cancelled": {
     "other": "Cancel·lat"
   },
-  "usersubscriptions_subscription_status_errored": {
-    "other": "usersubscriptions_subscription_status_errored"
-  },
   "usersubscriptions_subscription_status_past_due": {
     "other": "Vençuda"
   },

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -974,13 +974,13 @@
     "other": "Udløber {{.Expiry}}"
   },
   "usersubscriptions_subscription_status_cancelled": {
-    "other": "usersubscriptions_subscription_status_cancelled"
+    "other": "Annulleret"
   },
   "usersubscriptions_subscription_status_errored": {
     "other": "usersubscriptions_subscription_status_errored"
   },
   "usersubscriptions_subscription_status_past_due": {
-    "other": "usersubscriptions_subscription_status_past_due"
+    "other": "Ikke betalt til tiden"
   },
   "usersubscriptions_subscription_status_trialing": {
     "other": "Prøveperiode"
@@ -1367,5 +1367,11 @@
   },
   "stripe_card_not_supported": {
     "other": "Dit kort er ikke understøttet."
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Ubetalt"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Annullerer"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -976,9 +976,6 @@
   "usersubscriptions_subscription_status_cancelled": {
     "other": "Annulleret"
   },
-  "usersubscriptions_subscription_status_errored": {
-    "other": "usersubscriptions_subscription_status_errored"
-  },
   "usersubscriptions_subscription_status_past_due": {
     "other": "Ikke betalt til tiden"
   },

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1082,9 +1082,6 @@
   "usersubscriptions_subscription_status_cancelled": {
     "other": "Abgesagt"
   },
-  "usersubscriptions_subscription_status_errored": {
-    "other": "usersubscriptions_subscription_status_errored"
-  },
   "usersubscriptions_subscription_status_past_due": {
     "other": "Überfällig"
   },

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1080,13 +1080,13 @@
     "other": "Läuft ab {{.Expiry}}"
   },
   "usersubscriptions_subscription_status_cancelled": {
-    "other": "usersubscriptions_subscription_status_cancelled"
+    "other": "Abgesagt"
   },
   "usersubscriptions_subscription_status_errored": {
     "other": "usersubscriptions_subscription_status_errored"
   },
   "usersubscriptions_subscription_status_past_due": {
-    "other": "usersubscriptions_subscription_status_past_due"
+    "other": "Überfällig"
   },
   "usersubscriptions_subscription_status_trialing": {
     "other": "Probezeit"
@@ -1367,5 +1367,11 @@
   },
   "stripe_card_not_supported": {
     "other": "Ihre Karte wird nicht unterstützt."
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Unbezahlt"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Stornieren"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1358,5 +1358,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Η κάρτα σας δεν υποστηρίζεται."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Παρελθούσα"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Απλήρωτος"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Ακυρώθηκε"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Ακύρωση"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1358,5 +1358,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Your card is not supported."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Past due"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Unpaid"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Cancelled"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Cancelling"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1356,9 +1356,6 @@
   "something_bad_happened": {
     "other": "Please try again"
   },
-  "stripe_card_not_supported": {
-    "other": "Your card is not supported."
-  },
   "usersubscriptions_subscription_status_past_due": {
     "other": "Past due"
   },

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1362,5 +1362,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Su tarjeta no es compatible."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Atrasado"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "No pagado"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Cancelado"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Cancelado"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1362,5 +1362,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Su tarjeta no es compatible."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Atrasado"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "No pagado"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Cancelado"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Cancelado"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -910,9 +910,6 @@
   "usersubscriptions_subscription_status_cancelled": {
     "other": "Tühistatud"
   },
-  "usersubscriptions_subscription_status_errored": {
-    "other": "usersubscriptions_subscription_status_errored"
-  },
   "usersubscriptions_subscription_status_past_due": {
     "other": "Tähtaeg ületatud"
   },

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -908,13 +908,13 @@
     "other": "Aegub {{.Expiry}}"
   },
   "usersubscriptions_subscription_status_cancelled": {
-    "other": "usersubscriptions_subscription_status_cancelled"
+    "other": "Tühistatud"
   },
   "usersubscriptions_subscription_status_errored": {
     "other": "usersubscriptions_subscription_status_errored"
   },
   "usersubscriptions_subscription_status_past_due": {
-    "other": "usersubscriptions_subscription_status_past_due"
+    "other": "Tähtaeg ületatud"
   },
   "usersubscriptions_subscription_status_trialing": {
     "other": "Prooviperiood"
@@ -1367,5 +1367,11 @@
   },
   "stripe_card_not_supported": {
     "other": "Teie kaarti ei toetata."
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Tasumata"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Tühistamine"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1358,5 +1358,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Korttiasi ei tueta."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Erääntynyt"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Palkaton"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Peruutettu"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Peruutetaan"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1362,5 +1362,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Votre carte n'est pas prise en charge."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "En souffrance"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Non payé"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Annulé"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Annulation"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1175,9 +1175,6 @@
   "usersubscriptions_subscription_status_cancelled": {
     "other": "Otkazano"
   },
-  "usersubscriptions_subscription_status_errored": {
-    "other": "usersubscriptions_subscription_status_errored"
-  },
   "usersubscriptions_subscription_status_past_due": {
     "other": "Dospjelo"
   },

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1173,13 +1173,13 @@
     "other": "Istječe {{.Expiry}}"
   },
   "usersubscriptions_subscription_status_cancelled": {
-    "other": "usersubscriptions_subscription_status_cancelled"
+    "other": "Otkazano"
   },
   "usersubscriptions_subscription_status_errored": {
     "other": "usersubscriptions_subscription_status_errored"
   },
   "usersubscriptions_subscription_status_past_due": {
-    "other": "usersubscriptions_subscription_status_past_due"
+    "other": "Dospjelo"
   },
   "usersubscriptions_subscription_status_trialing": {
     "other": "Probni rok"
@@ -1356,5 +1356,11 @@
   },
   "stripe_card_not_supported": {
     "other": "Vaša kartica nije podržana."
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Neplaćeno"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Otkazivanje"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -908,13 +908,13 @@
     "other": "Lejár: {{.Expiry}}"
   },
   "usersubscriptions_subscription_status_cancelled": {
-    "other": "usersubscriptions_subscription_status_cancelled"
+    "other": "Törölve"
   },
   "usersubscriptions_subscription_status_errored": {
     "other": "usersubscriptions_subscription_status_errored"
   },
   "usersubscriptions_subscription_status_past_due": {
-    "other": "usersubscriptions_subscription_status_past_due"
+    "other": "Határidőn túl"
   },
   "usersubscriptions_subscription_status_trialing": {
     "other": "Próbaidő"
@@ -1367,5 +1367,11 @@
   },
   "stripe_card_not_supported": {
     "other": "A kártya nem támogatott."
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Kifizetetlen"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Törlés"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -910,9 +910,6 @@
   "usersubscriptions_subscription_status_cancelled": {
     "other": "Törölve"
   },
-  "usersubscriptions_subscription_status_errored": {
-    "other": "usersubscriptions_subscription_status_errored"
-  },
   "usersubscriptions_subscription_status_past_due": {
     "other": "Határidőn túl"
   },

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1362,5 +1362,17 @@
   },
   "stripe_card_not_supported": {
     "other": "La tua carta non è supportata."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Scaduto"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Non pagato"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Annullato"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Cancellazione"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1352,5 +1352,17 @@
   },
   "stripe_card_not_supported": {
     "other": "カードはサポートされていません。"
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "延滞"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "未払い"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "キャンセル"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "キャンセル中"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1370,5 +1370,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Jūsų kortelė nepalaikoma."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Pradelsta"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Neapmokėta"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Atšauktas"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Atšaukiamas"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1358,5 +1358,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Uw kaart wordt niet ondersteund."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Verlopen"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "onbetaald"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Geannuleerd"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Annuleren"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1358,5 +1358,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Kortet ditt støttes ikke."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Forfalt"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Ubetalt"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "avbrutt"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Avbryter"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1415,5 +1415,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Twoja karta nie jest obsługiwana."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Termin przekroczony"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Nie zapłacony"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Anulowany"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Anulowanie"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1362,5 +1362,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Seu cartão não é compatível."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Vencido"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Não pago"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Cancelado"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Cancelando"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1362,5 +1362,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Seu cartão não é compatível."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Vencido"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Não pago"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Cancelado"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Cancelando"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1392,5 +1392,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Ваша карта не поддерживается."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Просроченный"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Неоплачиваемый"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Отменено"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Отмена"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1364,5 +1364,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Ваша картица није подржана."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Касни рок"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Неплаћено"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Отказано"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Отказивање"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1358,5 +1358,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Kartınız desteklenmiyor."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "vadesi geçmiş"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "ödenmemiş"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "İptal edildi"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "İptal"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1398,5 +1398,17 @@
   },
   "stripe_card_not_supported": {
     "other": "Ваша картка не підтримується."
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "Прострочено"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "Неоплачений"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "Скасовано"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "Скасування"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1352,5 +1352,17 @@
   },
   "stripe_card_not_supported": {
     "other": "不支持您的卡。"
+  },
+  "usersubscriptions_subscription_status_past_due": {
+    "other": "逾期"
+  },
+  "usersubscriptions_subscription_status_unpaid": {
+    "other": "未付"
+  },
+  "usersubscriptions_subscription_status_cancelled": {
+    "other": "取消"
+  },
+  "usersubscriptions_subscription_status_cancelling": {
+    "other": "取消"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#9319](https://dev.azure.com/S72/SHIFT72/_workitems/edit/9319)

## Description of work
Theres a few translations missing for SVOD, [which we default to English](https://github.com/indiereign/shift72-web/blame/fe7a6b5f1dadc8f9030ed03d9a756195bbfdc0cc/src/transactional/subscriptions/user-subscription.component.js#L135), which isn't great for our international customers. Since we aren't using the site_api_translation yet for filmicca, I've added them here.

