### PR TITLE
Translations relish split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add new variables to change the font sizes and letter spacing of headings, subtitles, body text, etc.
+- New keys for translations that were used by Relish and Core-template removing their overlapping usage
 
 ## Changed
 - Moved the carousel availability label above the CTA's.

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1391,5 +1391,22 @@
   },
   "stripe_card_not_supported": {
     "other": "بطاقتك غير مدعومة."
+  },
+  "nav_search_control_placeholder":{
+    "other": "البحث"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "تأكيد البحث"
+  },
+  "shopping_info_plan_interval":{
+    "one": "يجدد تلقائيا كل. {{.Interval}}",
+    "other": "يجدد تلقائيا كل {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "جرب الإصدار التجريبي المجاني لمدة 24 ساعة الآن!",
+    "other": "{{.Count}} التجريبي المجاني من {{.Count}} day!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "الاشتراكات والفواتير"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1367,5 +1367,22 @@
   },
   "stripe_card_not_supported": {
     "other": "La teva targeta no és compatible."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Cerca"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Envia la cerca"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Renova automàticament cada {{.Interval}}",
+    "other": "Renova automàticament cada {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Prova la teva prova gratuïta de 24 hores ara!",
+    "other": "Prova la teva prova gratuïta de {{.Count}} day!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Subscripcions i facturació"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1367,5 +1367,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Dit kort er ikke understøttet."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Søg"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Søg nu"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Fornyer automatisk hver {{.Interval}}",
+    "other": "{{.Count}} automatisk hver {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Prøv din gratis 24 timers prøveperiode nu!",
+    "other": "Prøv din gratis {{.Count}} day prøveperiode!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Abonnementer og fakturering"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1367,5 +1367,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Ihre Karte wird nicht unterstützt."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Suche"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Suche einreichen"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Erneuert automatisch alle {{.Interval}}",
+    "other": "Erneuert automatisch alle {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Testen Sie jetzt Ihre kostenlose 24-Stunden-Testversion!",
+    "other": "Testen Sie Ihre kostenlose {{.Count}} Tage-Testversion!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Abonnements und Abrechnung"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1358,5 +1358,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Η κάρτα σας δεν υποστηρίζεται."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Αναζήτηση"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Υποβάλετε αναζήτηση"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Ανανεώνει αυτόματα κάθε {{.Interval}}",
+    "other": "Ανανεώνει αυτόματα κάθε {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Δοκιμάστε τη δωρεάν δοκιμή 24 ωρών τώρα!",
+    "other": "Δοκιμάστε τη δωρεάν {{.Count}} day!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Συνδρομές και Χρεώσεις"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1358,5 +1358,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Your card is not supported."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Search"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Submit search"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Automatically renews every {{.Interval}}",
+    "other": "Automatically renews every {{.Count}} {{.Interval}}s"
+  },
+  "shopping_info_trial_period":{
+    "one": "Try your free 24hr trial now!",
+    "other": "Try your free {{.Count}} day trial!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Subscriptions and Billing"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1362,5 +1362,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Su tarjeta no es compatible."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Buscar"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Aplicar búsqueda"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Renueva automáticamente cada {{.Interval}}",
+    "other": "Renueva automáticamente cada {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "¡Pruebe ahora su prueba gratuita de 24 horas!",
+    "other": "¡Pruebe su prueba gratuita de {{.Count}} day!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Suscripciones y Facturación"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1362,5 +1362,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Su tarjeta no es compatible."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Buscar"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Enviar busqueda"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Se renueva automáticamente cada {{.Interval}}",
+    "other": "Se renueva automáticamente cada {{.Count}} {{.Interval}}s"
+  },
+  "shopping_info_trial_period":{
+    "one": "Renueva automáticamente cada {{.Interval}}",
+    "other": "Renueva automáticamente cada {{.Count}} {{.Interval}}"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Suscripciones y Facturación"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1367,5 +1367,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Teie kaarti ei toetata."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Otsing"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Otsi"
+  },
+  "shopping_info_plan_interval":{
+    "one": "{{.Interval}} automaatselt iga .intervall",
+    "other": "{{.Count}} automaatselt iga {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Proovige oma tasuta 24-tunnist prooviperioodi kohe!",
+    "other": "Proovige oma tasuta {{.Count}} päevast prooviversiooni!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Tellimused ja arveldamine"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1358,5 +1358,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Korttiasi ei tueta."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Haku"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Hae"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Uusiutuu automaattisesti joka {{.Interval}}",
+    "other": "{{.Count}} automaattisesti joka {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Kokeile ilmaista 24 tunnin kokeilua nyt!",
+    "other": "Kokeile ilmaista {{.Count}} päivän kokeiluversiota!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Tilaukset ja laskutus"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1362,5 +1362,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Votre carte n'est pas prise en charge."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Rechercher"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Soumettre la recherche"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Se renouvelle automatiquement tous les {{.Interval}}",
+    "other": "{{.Count}} automatiquement chaque {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Essayez votre essai gratuit de 24 heures maintenant !",
+    "other": "Essayez votre essai gratuit de {{.Count}} day !"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Abonnements et facturation"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1356,5 +1356,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Vaša kartica nije podržana."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Pretraživanje"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Potvrdi pretraživanje"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Automatski obnavlja svaki {{.Interval}}",
+    "other": "Automatski obnavlja svaki {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Isprobajte svoju besplatnu probnu verziju od 24 sata sada!",
+    "other": "Isprobajte svoju besplatnu {{.Count}} day!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Pretplate i naplata"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1367,5 +1367,22 @@
   },
   "stripe_card_not_supported": {
     "other": "A kártya nem támogatott."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Keresés"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Keresés indítása"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Automatikusan megújítja minden {{.Interval}}",
+    "other": "Automatikusan {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Próbálja ki most az ingyenes 24 órás próbaverziót!",
+    "other": "Próbálja ki ingyenes {{.Count}} napos próbaverzióját!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Előfizetések és számlázás"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1362,5 +1362,22 @@
   },
   "stripe_card_not_supported": {
     "other": "La tua carta non è supportata."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Cerca"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Invia la ricerca"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Si rinnova automaticamente ogni {{.Interval}}",
+    "other": "Rinnova automaticamente ogni {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Prova subito la tua prova gratuita di 24 ore!",
+    "other": "Prova la tua prova gratuita di {{.Count}} Day!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Abbonamenti e fatturazione"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1352,5 +1352,22 @@
   },
   "stripe_card_not_supported": {
     "other": "カードはサポートされていません。"
+  },
+  "nav_search_control_placeholder":{
+    "other": "検索"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "検索する"
+  },
+  "shopping_info_plan_interval":{
+    "one": "{{.Interval}}ごとに自動的に更新されます",
+    "other": "{{.Count}} {{.Interval}}ごとに自動的に更新されます"
+  },
+  "shopping_info_trial_period":{
+    "one": "今すぐ無料の24時間トライアルをお試しください！",
+    "other": "{{.Count}}日トライアルをお試しください！"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "サブスクリプションと請求"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1370,5 +1370,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Jūsų kortelė nepalaikoma."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Paieška"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Pateikti paiešką"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Automatiškai atnaujina kiekvieną {{.Interval}}",
+    "other": "Automatiškai atnaujina kiekvieną {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Išbandykite nemokamą 24 valandų bandomąją versiją dabar!",
+    "other": "Išbandykite nemokamą {{.Count}} dienos bandomąją versiją!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Prenumeratos ir atsiskaitymas"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1358,5 +1358,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Uw kaart wordt niet ondersteund."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Zoek"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Zoekopdracht indienen"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Vernieuwt automatisch elke {{.Interval}}",
+    "other": "{{.Count}} automatisch elke {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Probeer nu uw gratis proefperiode van 24 uur!",
+    "other": "Probeer uw gratis {{.Count}} !"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Abonnementen en facturering"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1358,5 +1358,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Kortet ditt støttes ikke."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Søk"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Søk"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Fornyes automatisk hver {{.Interval}}",
+    "other": "{{.Count}} automatisk hver {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Prøv din gratis 24-timers prøveversjon nå!",
+    "other": "Prøv din gratis {{.Count}} day prøveversjon!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Abonnementer og fakturering"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1415,5 +1415,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Twoja karta nie jest obsługiwana."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Szukaj"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Wyszukaj"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Automatycznie odnawia co {{.Interval}}",
+    "other": "Automatycznie odnawia co {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Wypróbuj bezpłatny 24-godzinny okres próbny już teraz!",
+    "other": "Wypróbuj bezpłatny {{.Count}}-dniowy okres próbny!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Subskrypcje i rozliczenia"
   }
 }

--- a/site/plans.html.jet
+++ b/site/plans.html.jet
@@ -55,9 +55,9 @@
 
                   <p class="plan-description">{{p.Description}}</p>
                   {{ if p.Interval }}
-                    <p class="plan-interval">{{i18n("shopping_info_plan_offer", map("Interval", p.Interval, "Count", p.IntervalCount))}}</p>
+                    <p class="plan-interval">{{i18n("shopping_info_plan_interval", map("Interval", p.Interval, "Count", p.IntervalCount))}}</p>
                     {{ if p.TrialPeriodDays }}
-                      <p class="plan-trial-period">{{i18n("shopping_info_trial_period_offer", p.TrialPeriodDays)}}</p>
+                      <p class="plan-trial-period">{{i18n("shopping_info_trial_period", p.TrialPeriodDays)}}</p>
                     {{ end }}
                   {{ end }}
                 </div>

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1362,5 +1362,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Seu cartão não é compatível."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Buscar"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Buscar"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Renova automaticamente a cada {{.Interval}}",
+    "other": "Renova automaticamente cada {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Experimente agora o seu teste gratuito de 24 horas!",
+    "other": "Experimente o seu teste gratuito de {{.Count}} dia!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Assinaturas e cobrança"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1362,5 +1362,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Seu cartão não é compatível."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Buscar"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Buscar"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Renova automaticamente a cada {{.Interval}}",
+    "other": "Renova automaticamente cada {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Experimente agora o seu teste gratuito de 24 horas!",
+    "other": "Experimente o seu teste gratuito de {{.Count}} dia!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Assinaturas e cobrança"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1392,5 +1392,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Ваша карта не поддерживается."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Поиск"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Начать поиск"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Автоматически обновляется каждые {{.Interval}}",
+    "other": "Автоматически обновляется каждые {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "Попробуйте бесплатную 24-часовую пробную версию прямо сейчас!",
+    "other": "Попробуйте бесплатную дневную пробную версию {{.Count}}"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Подписки и выставление счетов"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1364,5 +1364,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Ваша картица није подржана."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Претрага"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Пошаљите претрагу"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Аутоматски обнавља сваки {{.Interval}}",
+    "other": "Аутоматски обнавља на сваких {{.Count}} {{.Interval}} с"
+  },
+  "shopping_info_trial_period":{
+    "one": "Испробајте своју бесплатну пробну верзију од 24 сата сада!",
+    "other": "Испробајте своју бесплатну пробну верзију {{.Count}}"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Претплате и наплата"
   }
 }

--- a/site/subscriptions.html.jet
+++ b/site/subscriptions.html.jet
@@ -1,7 +1,7 @@
 {{extends "templates/application/application.jet"}}
 
 {{block head()}}
-  {{yield seo(title=i18n("usersubscriptions_page_header"), index=false)}}
+  {{yield seo(title=i18n("usersubscriptions_page_header_seo"), index=false)}}
 {{end}}
 
 {{block body()}}

--- a/site/templates/application/nav/nav.jet
+++ b/site/templates/application/nav/nav.jet
@@ -18,8 +18,8 @@
         <button type="button" class="btn-search-open" aria-label="open search" tabindex="-1">
           <i class="fa fa-search search-icon"></i>
         </button>
-        <input class="form-control form-control-search" type="search" placeholder="{{i18n("search_control_placeholder")}}" name="q" aria-label="{{i18n("search_control_placeholder")}}">
-        <button class="sr-only" type="submit">{{i18n("search_control_submit")}}</button>
+        <input class="form-control form-control-search" type="search" placeholder="{{i18n("nav_search_control_placeholder")}}" name="q" aria-label="{{i18n("nav_search_control_placeholder")}}">
+        <button class="sr-only" type="submit">{{i18n("nav_search_control_sr_submit")}}</button>
         <button type="button" class="btn-search-close" aria-label="close search" tabindex="-1">
           <i class="fa fa-times"></i>
         </button>

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1358,5 +1358,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Kartınız desteklenmiyor."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Arama"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Aramayı gönder"
+  },
+  "shopping_info_plan_interval":{
+    "one": "{{.Interval}} otomatik olarak yeniler",
+    "other": "Otomatik olarak her yeniler {{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "24 saatlik ücretsiz denemenizi şimdi deneyin!",
+    "other": "Ücretsiz {{.Count}} günlük denemenizi deneyin!"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Abonelikler ve Faturalandırma"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1398,5 +1398,22 @@
   },
   "stripe_card_not_supported": {
     "other": "Ваша картка не підтримується."
+  },
+  "nav_search_control_placeholder":{
+    "other": "Пошук"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "Шукати"
+  },
+  "shopping_info_plan_interval":{
+    "one": "Автоматично поновлюється через кожний {{.Interval}}",
+    "other": "Автоматично оновлює кожні {{.Count}} {{.Interval}} сек"
+  },
+  "shopping_info_trial_period":{
+    "one": "Спробуйте безкоштовну 24-годинну пробну версію зараз!",
+    "other": "Спробуйте безкоштовну пробну версію {{.Count}}"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "Підписки та виставлення рахунків"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1352,5 +1352,22 @@
   },
   "stripe_card_not_supported": {
     "other": "不支持您的卡。"
+  },
+  "nav_search_control_placeholder":{
+    "other": "關鍵字搜尋"
+  },
+  "nav_search_control_sr_submit": {
+    "other": "送出"
+  },
+  "shopping_info_plan_interval":{
+    "one": "{{.Interval}}自動更新",
+    "other": "自動更新每個{{.Count}} {{.Interval}}"
+  },
+  "shopping_info_trial_period":{
+    "one": "立即試用您的 24 小時免費試用版！",
+    "other": "免費{{.Count}}天！"
+  },
+  "usersubscriptions_page_header_seo":{
+    "other": "订阅和计费"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#9329](https://dev.azure.com/S72/SHIFT72/_workitems/edit/9329)

Elab notes/AC: 📃 [Google Docs](https://docs.google.com/document/d/11svAR84B4KcYdYIQju41HlQXsMgeXq9r8tZKoDuN_QE/edit#heading=h.bny0ht7u7uqz)
- [☑️ ] Has this been discussed with Delivery Team?

## Description of work
Split out translation keys that were used by Core-template and Relish to remove overlapping usage. Updated .jet files to use the core-template specific keys



