### PR TITLE
AB#9282 User correct translation for intervals in the templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,11 @@
 ## Changed
 - Moved the carousel availability label above the CTA's.
 - The site url in kibble.json now points to [tvoddemo.shift72.com](https://tvoddemo.shift72.com).
-
-### Changed
 - Various links and buttons now use new colour variables.
 
 ### Fixed
 - Broken share modal styles.
+- Fixed translation for plan frequency in plans.html
 
 ## [1.3.0](https://github.com/shift72/core-template/compare/1.3.0-alpha...1.3.0)
 

--- a/site/plans.html.jet
+++ b/site/plans.html.jet
@@ -55,7 +55,17 @@
 
                   <p class="plan-description">{{p.Description}}</p>
                   {{ if p.Interval }}
-                    <p class="plan-interval">{{i18n("shopping_info_plan_interval", map("Interval", p.Interval, "Count", p.IntervalCount))}}</p>
+                    {{interval := p.Interval}}
+                    {{if interval == "day"}}
+                      {{interval = i18n("interval_day", p.IntervalCount)}}
+                    {{else if interval == "month"}}
+                      {{interval = i18n("interval_month", p.IntervalCount)}}
+                    {{else if interval == "week"}}
+                      {{interval = i18n("interval_week", p.IntervalCount)}}
+                    {{else if interval == "year"}}
+                      {{interval = i18n("interval_year", p.IntervalCount)}}
+                    {{end}}
+                    <p class="plan-interval">{{i18n("shopping_info_plan_interval", map("Interval", interval, "Count", p.IntervalCount))}}</p>
                     {{ if p.TrialPeriodDays }}
                       <p class="plan-trial-period">{{i18n("shopping_info_trial_period", p.TrialPeriodDays)}}</p>
                     {{ end }}


### PR DESCRIPTION
This seems to be the only use of '.Interval' in the .jet files

ADO card: ☑️ [AB#9282](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9282)

## Description of work
The interval of a plan isn't translated into other languages from the plans.html page (viz "monat" vs "month")
![Screen Shot 2022-08-08 at 11 34 02 AM](https://user-images.githubusercontent.com/3870133/183315423-25596274-9e5a-490e-82a8-7180080219e0.png)

## Related PRs 
- #410 (already merged so translations will exist)

### Affected Clients
 - SVOD clients using languages other than English with recurring plans

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
