### PR TITLE
Ab#8757 change polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 - Broken share modal styles.
+- Added Intl to polyfill to catch iOS devices.
 
 ## [1.3.0](https://github.com/shift72/core-template/compare/1.3.0-alpha...1.3.0)
 

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -45,11 +45,11 @@
       {{yield seo()}}
     {{end}}
 
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,fetch" defer></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=Intl%2Cdefault%2Cfetch" defer></script>
     <script src="{{CDN}}/s72.core.js" defer></script>
     <script src="{{CDN}}/s72.ui.js" defer></script>
 
-    <script src="/scripts/main.js" defer></script>    
+    <script src="/scripts/main.js" defer></script>
 
     <script src="{{CDN}}/s72.transactional.js" defer></script>
     <script src="https://js.stripe.com/v3/" defer></script>


### PR DESCRIPTION
ADO card: ☑️ [AB#8757](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/8757)

- [x] Has this been discussed with Delivery Team?

## Description of work
Pages don't render properly on iOS versions earlier than 13 because of a missing polyfill for Intl.PluralRules

Version 2.0 of the polyfill doesn't include (support?) specifically this object so upgrade to v3 seems to do it.

I've checked this works on an iOS simulator using versions 12.4, 14.5 and 15.5 of the operating system.

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
