### PR TITLE
AB#9449 Correctly translate shopping_card_new_subscription

### DIFF
--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -950,7 +950,7 @@
     "other": "Opdater dit kreditkort. Understøttede kort er Visa, Mastercard og American Express."
   },
   "shopping_card_new_subscription": {
-    "other": "This card will saved and be charged regularly"
+    "other": "Dette kort vil blive opbevaret og opkrævet regelmæssigt"
   },
   "shopping_card_change": {
     "other": "Kreditkort ikke korrekt? <a href=\"{{.SubscriptionsURL}}\">Klik her for at opdatere dit kort.</a>"

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -968,7 +968,7 @@
     "other": "Atualize seu cartão de crédito. Os cartões suportados são Visa, Mastercard e American Express"
   },
   "shopping_card_new_subscription": {
-    "other": "This card will saved and be charged regularly"
+    "other": "Este cartão será salvo e cobrado regularmente"
   },
   "shopping_card_change": {
     "other": "O cartão de crédito não está correto? <a href=\"{{.SubscriptionsURL}}\"> Clique aqui para atualizar seu cartão. </a>"


### PR DESCRIPTION
ADO card: ☑️ [AB#9449](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9449)

2 languages have not had `shopping_card_new_subscription` translated