### PR TITLE
carousel play speed and fade time config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add translations for intervals without counts
 - New keys for translations that were used by Relish and Core-template removing their overlapping usage
 - Add translation for `shopping_error_card_not_supported`
+- Added support for carousel_play_speed and carousel_fade_time configs.
 
 ## Changed
 - Moved the carousel availability label above the CTA's.

--- a/site/templates/collection/carousel/carousel.jet
+++ b/site/templates/collection/carousel/carousel.jet
@@ -8,8 +8,11 @@
 	{{end}}
 	{{items := .Items[0:maxSlides]}}
 
+	{{playSpeed := config("carousel_play_speed")}}
+	{{fadeTime := config("carousel_fade_time")}}
+
 	{{if len(items) > 0}}
-		<s72-carousel>
+		<s72-carousel play-speed="{{playSpeed}}" fade-time="{{fadeTime}}">
 			<section class="page-collection page-collection-carousel" aria-label="{{i18n("wcag_aria_label_carousel")}}">
 				<h2 class="sr-only">{{i18n("wcag_carousel_h2")}}</h2>
 


### PR DESCRIPTION
ADO card: ☑️ [AB#9140](https://dev.azure.com/S72/SHIFT72/_workitems/edit/9140)

## Description of work
Added support for carousel play speed and fade time configs.

## Config settings/Toggles required for the feature to work
- carousel_play_speed (default is 4000).
- carousel_fade_time (default is 700).

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
