### PR TITLE
Ab#9272 remove flex gap usage from film detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Broken share modal styles.
 - Fixed translation for plan frequency in plans.html
 - Added Intl to polyfill to catch iOS devices.
+- Film detail page element switcher uses grid instead of flex with gap.
 
 ## [1.3.0](https://github.com/shift72/core-template/compare/1.3.0-alpha...1.3.0)
 

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -376,16 +376,18 @@ s72-element-switcher,
 }
 
 .element-switcher-wrapper {
-  display: flex;
+  display: grid;
   gap: 50px;
-  justify-content: space-between;
+  grid-template-columns: auto auto;
   width: 100%;
 
   .sponsor {
     display: none;
     padding-top: 10px;
+
     @include media-breakpoint-up(lg) {
       display: block;
+      margin-left: auto;
     }
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#9272](https://dev.azure.com/S72/SHIFT72/_workitems/edit/9272)

Elab notes/AC: 📃 [Google Docs](https://docs.google.com)
- [x] Has this been discussed with Delivery Team?

## Description of work
Replaced flex-gap usage on film detail page with grid-gap as flex-gap is not supported on Safari iOS <14.5.

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
