### PR TITLE
Use feature toggle to enable cloudsearch AB#9487

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - New keys for translations that were used by Relish and Core-template removing their overlapping usage
 - Add translation for `shopping_error_card_not_supported` and `shopping_error_processing_error`
 - Added support for carousel_play_speed and carousel_fade_time configs.
+- Added support to toggle on cloudsearch via Meta > cloudsearch feature toggle.
 
 ## Changed
 - Moved the carousel availability label above the CTA's.

--- a/site/search.html.jet
+++ b/site/search.html.jet
@@ -9,6 +9,8 @@
   <div class="page-header">
     <h1>{{ i18n("searchresults_page_header") }}</h1>
   </div>
-  <s72-searchresults search-param="q" partials-base-path="{{ routeToPath("/partials") }}" show-search-form="true" />
+  
+  {{cloudsearchEnabled := isEnabled("cloudsearch")}}
+  <s72-searchresults cloudsearch="{{cloudsearchEnabled}}" search-param="q" partials-base-path="{{ routeToPath("/partials") }}" show-search-form="true" />
 </main>
 {{end}}


### PR DESCRIPTION
ADO card: ☑️ [AB#9487](https://dev.azure.com/S72/SHIFT72/_workitems/edit/9487)

## Description of work
Allow us to enable cloud search via feature toggle rather than a custom jet file. I've run it up locally against https://www.maorinow.com/ to check the toggle works on / off.

## Config settings/Toggles required for the feature to work
Meta > Feature Toggles: cloudsearch


## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
