### PR TITLE
release-1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [Unreleased](https://github.com/shift72/core-template/compare/1.3.0...HEAD)
+## [Unreleased](https://github.com/shift72/core-template/compare/1.4.0...HEAD)
+
+## [1.4.0](https://github.com/shift72/core-template/compare/1.3.0...1.4.0)
 
 ### Added
 - Add new variables to change the font sizes and letter spacing of headings, subtitles, body text, etc.

--- a/kibble.json
+++ b/kibble.json
@@ -185,5 +185,5 @@
       "pageSize": 0
     }
   ],
-  "coreTemplateVersion": "1.3.0"
+  "coreTemplateVersion": "1.4.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shift72/core-template",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shift72/core-template",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-buble": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shift72/core-template",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Shift72 core template",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## [1.4.0](https://github.com/shift72/core-template/compare/1.3.0...1.4.0)

### Added
- Add new variables to change the font sizes and letter spacing of headings, subtitles, body text, etc.
- Add translations for intervals without counts
- New keys for translations that were used by Relish and Core-template removing their overlapping usage
- Add translation for `shopping_error_card_not_supported`, `shopping_error_processing_error` and `shopping_error_invalid_session_token`
- Added support for self-service CSS and brand images.
- Added support for carousel_play_speed and carousel_fade_time configs.
- Added support to toggle on cloudsearch via Meta > cloudsearch feature toggle.

## Changed
- Moved the carousel availability label above the CTA's.
- The site url in kibble.json now points to [tvoddemo.shift72.com](https://tvoddemo.shift72.com).
- Full width background image and gradient on meta detail pages
- Various links and buttons now use new colour variables.
- Translations refer to "CVC" rather than "CVV" at payment stage

### Fixed
- Broken share modal styles.
- Fixed translation for plan frequency in plans.html
- Added Intl to polyfill to catch iOS devices.
- Film detail page element switcher uses grid instead of flex with gap.