### PR TITLE
AB#9680 Missing translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added support for self-service CSS and brand images.
 - Added support for carousel_play_speed and carousel_fade_time configs.
 - Added support to toggle on cloudsearch via Meta > cloudsearch feature toggle.
+- Translations for discount errors
 
 ## Changed
 - Moved the carousel availability label above the CTA's.

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1464,5 +1464,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "انتهت جلسة التسوق ، يرجى المحاولة مرة أخرى."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "لا يمكنك استخدام الرمز الترويجي لهذا الشراء أو الاستئجار"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "هذا الرمز الترويجي غير صالح حتى الآن"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "لا يمكن تطبيق الرموز الترويجية على جلسات التسوق المجانية"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "لا يمكن تطبيق الرموز الترويجية بعد اكتمال عملية الشراء"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "لا يمكن تطبيق الرمز الترويجي ، يرجى المحاولة مرة أخرى"
+  },
+  "shopping_error_invalid_code": {
+    "other": "الرمز الترويجي غير صالح"
+  },
+  "shopping_error_missing_code": {
+    "other": "لم يتم تقديم رمز ترويجي"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "La sessió de compres ha caducat, torna-ho a provar."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "No podeu utilitzar un codi promocional per a aquesta compra o lloguer"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Aquest codi promocional encara no és vàlid"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Els codis promocionals no es poden aplicar a les sessions de compres gratuïtes"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Els codis promocionals no es poden aplicar un cop s'ha completat la compra"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "No s'ha pogut aplicar el codi promocional, torna-ho a provar"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Codi promocional no vàlid"
+  },
+  "shopping_error_missing_code": {
+    "other": "No s'ha proporcionat cap codi promocional"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Shopping-sessionen er udløbet, prøv venligst igen."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Du kan ikke bruge en kampagnekode til dette køb eller leje"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Denne kampagnekode er ikke gyldig endnu"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Kampagnekoder kan ikke anvendes til gratis shoppingsessioner"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Kampagnekoder kan ikke anvendes, når købet er gennemført"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Kampagnekoden kunne ikke anvendes. Prøv venligst igen"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Ugyldig kampagnekode"
+  },
+  "shopping_error_missing_code": {
+    "other": "Der blev ikke angivet nogen kampagnekode"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Einkaufssitzung abgelaufen, bitte versuchen Sie es erneut."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Sie können keinen Aktionscode für diesen Kauf oder diese Miete verwenden"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Dieser Promo-Code ist noch nicht gültig"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Promo-Codes können nicht auf kostenlose Shopping-Sessions angewendet werden"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Promo-Codes können nicht angewendet werden, nachdem der Kauf abgeschlossen ist"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Der Aktionscode konnte nicht angewendet werden, bitte versuchen Sie es erneut"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Ungültiger Promo-Code"
+  },
+  "shopping_error_missing_code": {
+    "other": "Es wurde kein Aktionscode angegeben"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Η περίοδος αγορών έληξε, δοκιμάστε ξανά."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Δεν μπορείτε να χρησιμοποιήσετε κωδικό προσφοράς για αυτήν την αγορά ή ενοικίαση"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Αυτός ο κωδικός προσφοράς δεν είναι ακόμη έγκυρος"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Οι κωδικοί προσφοράς δεν μπορούν να εφαρμοστούν σε δωρεάν συνεδρίες αγορών"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Οι κωδικοί προσφοράς δεν μπορούν να εφαρμοστούν μετά την ολοκλήρωση της αγοράς"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Δεν ήταν δυνατή η εφαρμογή του κωδικού προσφοράς, δοκιμάστε ξανά"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Μη έγκυρος κωδικός προσφοράς"
+  },
+  "shopping_error_missing_code": {
+    "other": "Δεν δόθηκε κωδικός προσφοράς"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Shopping session expired, please try again."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "You can not use a promo code for this purchase or rental"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "That promo code is not valid yet"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Promo codes cannot be applied to free shopping sessions"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Promo codes cannot be applied one the purchase is complete"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Promo code could not be applied, please try again"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Invalid promo code"
+  },
+  "shopping_error_missing_code": {
+    "other": "No promo code was provided"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1416,5 +1416,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "La sesión de compra expiró, inténtalo de nuevo."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "No puede usar un código de promoción para esta compra o alquiler"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Ese código de promoción aún no es válido"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Los códigos promocionales no se pueden aplicar a las sesiones de compras gratuitas."
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Los códigos de promoción no se pueden aplicar una vez que se completa la compra"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "No se pudo aplicar el código de promoción, inténtalo de nuevo"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Código de promoción no válido"
+  },
+  "shopping_error_missing_code": {
+    "other": "No se proporcionó ningún código de promoción"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1416,5 +1416,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "La sesión de compra expiró, inténtalo de nuevo."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "No puede usar un código de promoción para esta compra o alquiler"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Ese código de promoción aún no es válido"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Los códigos promocionales no se pueden aplicar a las sesiones de compras gratuitas."
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Los códigos de promoción no se pueden aplicar una vez que se completa la compra"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "No se pudo aplicar el código de promoción, inténtalo de nuevo"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Código de promoción no válido"
+  },
+  "shopping_error_missing_code": {
+    "other": "No se proporcionó ningún código de promoción"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Osteseanss aegus, proovige uuesti."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Selle ostu või rentimise jaoks ei saa te sooduskoodi kasutada"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "See sooduskood ei kehti veel"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Sooduskoode ei saa tasuta ostuseanssidele rakendada"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Kui ost on lõpetatud, ei saa sooduskoode rakendada"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Sooduskoodi ei saanud rakendada, proovige uuesti"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Kehtetu sooduskood"
+  },
+  "shopping_error_missing_code": {
+    "other": "Sooduskoodi ei antud"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Ostosistunto vanhentunut, yritä uudelleen."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Et voi käyttää tarjouskoodia tähän ostoon tai vuokraukseen"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Tämä tarjouskoodi ei ole vielä voimassa"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Tarjouskoodeja ei voi käyttää ilmaisissa ostosistunnoissa"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Tarjouskoodeja ei voi käyttää, kun osto on suoritettu"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Tarjouskoodia ei voitu käyttää. Yritä uudelleen"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Virheellinen tarjouskoodi"
+  },
+  "shopping_error_missing_code": {
+    "other": "Tarjouskoodia ei annettu"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1416,5 +1416,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "La session d'achat a expiré, veuillez réessayer."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Vous ne pouvez pas utiliser de code promo pour cet achat ou cette location"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Ce code promotionnel n'est pas encore valide"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Les codes promotionnels ne peuvent pas être appliqués aux séances d'achat gratuites"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Les codes promotionnels ne peuvent pas être appliqués une fois l'achat terminé"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Le code promotionnel n'a pas pu être appliqué, veuillez réessayer"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Code promotionnel invalide"
+  },
+  "shopping_error_missing_code": {
+    "other": "Aucun code promotionnel n'a été fourni"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1411,5 +1411,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Sesija kupnje je istekla, pokušajte ponovno."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Ne možete koristiti promotivni kod za ovu kupnju ili iznajmljivanje"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Taj promo kod još nije valjan"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Promotivni kodovi se ne mogu primijeniti na sesije besplatne kupnje"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Promotivni kodovi se ne mogu primijeniti nakon što je kupnja dovršena"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Promotivni kôd nije moguće primijeniti, pokušajte ponovno"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Nevažeći promotivni kod"
+  },
+  "shopping_error_missing_code": {
+    "other": "Nije dostavljen promotivni kod"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "A vásárlási munkamenet lejárt, próbálkozzon újra."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Nem használhat promóciós kódot ehhez a vásárláshoz vagy kölcsönzéshez"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Ez a promóciós kód még nem érvényes"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "A promóciós kódok nem alkalmazhatók ingyenes vásárlási alkalmakra"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "A promóciós kódok nem alkalmazhatók, ha a vásárlás befejeződött"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Nem sikerült alkalmazni a promóciós kódot, próbálkozzon újra"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Érvénytelen promóciós kód"
+  },
+  "shopping_error_missing_code": {
+    "other": "Nem adtak meg promóciós kódot"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1416,5 +1416,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Sessione di acquisto scaduta, riprova."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Non è possibile utilizzare un codice promozionale per questo acquisto o noleggio"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Quel codice promozionale non è ancora valido"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "I codici promozionali non possono essere applicati alle sessioni di acquisto gratuite"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "I codici promozionali non possono essere applicati una volta completato l'acquisto"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Impossibile applicare il codice promozionale, riprova"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Codice promozionale non valido"
+  },
+  "shopping_error_missing_code": {
+    "other": "Non è stato fornito alcun codice promozionale"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1402,5 +1402,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "ショッピング セッションの有効期限が切れました。もう一度お試しください。"
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "この購入またはレンタルにはプロモーション コードを使用できません"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "そのプロモーション コードはまだ有効ではありません"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "プロモーション コードは、無料のショッピング セッションには適用できません"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "購入が完了するとプロモーション コードを適用できません"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "プロモーション コードを適用できませんでした。もう一度お試しください"
+  },
+  "shopping_error_invalid_code": {
+    "other": "プロモーション コードが無効です"
+  },
+  "shopping_error_missing_code": {
+    "other": "プロモーション コードが提供されていません"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1438,5 +1438,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Apsipirkimo sesija baigėsi, bandykite dar kartą."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Šiam pirkimui ar nuomai negalite naudoti reklamos kredito kodo"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Šis reklamos kredito kodas dar negalioja"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Reklamos kredito kodai negali būti taikomi nemokamoms apsipirkimo sesijoms"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Kai pirkimas baigtas, reklamos kredito kodai negali būti taikomi"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Nepavyko pritaikyti reklamos kredito kodo, bandykite dar kartą"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Neteisingas reklamos kredito kodas"
+  },
+  "shopping_error_missing_code": {
+    "other": "Reklamos kodas nebuvo pateiktas"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Shopping-sessie is verlopen, probeer het opnieuw."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "U kunt geen promotiecode gebruiken voor deze aankoop of huur"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Die actiecode is nog niet geldig"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Promotiecodes kunnen niet worden toegepast op gratis winkelsessies"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Promotiecodes kunnen niet worden toegepast zodra de aankoop is voltooid"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Promotiecode kan niet worden toegepast, probeer het opnieuw"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Ongeldige promotiecode"
+  },
+  "shopping_error_missing_code": {
+    "other": "Er is geen promotiecode verstrekt"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Shoppingøkten er utløpt, prøv igjen."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Du kan ikke bruke en kampanjekode for dette kjøpet eller utleien"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Kampanjekoden er ikke gyldig ennå"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Kampanjekoder kan ikke brukes på gratis shoppingøkter"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Kampanjekoder kan ikke brukes etter at kjøpet er fullført"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Kampanjekoden kunne ikke brukes. Prøv igjen"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Ugyldig kampanjekode"
+  },
+  "shopping_error_missing_code": {
+    "other": "Ingen kampanjekode ble oppgitt"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1483,5 +1483,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Sesja zakupowa wygasła, spróbuj ponownie."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Nie możesz użyć kodu promocyjnego do tego zakupu lub wypożyczenia"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Ten kod promocyjny nie jest jeszcze ważny"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Kodów promocyjnych nie można zastosować do bezpłatnych sesji zakupowych"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Kodów promocyjnych nie można zastosować po zakończeniu zakupu"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Nie można zastosować kodu promocyjnego, spróbuj ponownie"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Nieprawidłowy kod promocyjny"
+  },
+  "shopping_error_missing_code": {
+    "other": "Nie podano kodu promocyjnego"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1416,5 +1416,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "A sessão de compras expirou. Tente novamente."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Você não pode usar um código promocional para esta compra ou aluguel"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Esse código promocional ainda não é válido"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Os códigos promocionais não podem ser aplicados a sessões de compras gratuitas"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Os códigos promocionais não podem ser aplicados depois que a compra for concluída"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Não foi possível aplicar o código promocional. Tente novamente"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Código promocional inválido"
+  },
+  "shopping_error_missing_code": {
+    "other": "Nenhum código promocional foi fornecido"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1416,5 +1416,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "A sessão de compras expirou. Tente novamente."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Você não pode usar um código promocional para esta compra ou aluguel"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Esse código promocional ainda não é válido"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Os códigos promocionais não podem ser aplicados a sessões de compras gratuitas"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Os códigos promocionais não podem ser aplicados depois que a compra for concluída"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Não foi possível aplicar o código promocional. Tente novamente"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Código promocional inválido"
+  },
+  "shopping_error_missing_code": {
+    "other": "Nenhum código promocional foi fornecido"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1460,5 +1460,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Сеанс покупки истек, попробуйте еще раз."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Вы не можете использовать промо-код для этой покупки или аренды"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Этот промокод еще не действителен"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Промокоды не могут быть применены к бесплатным сеансам покупок."
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Промокоды не могут быть применены после завершения покупки"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Не удалось применить промокод, попробуйте еще раз"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Недействительный промо-код"
+  },
+  "shopping_error_missing_code": {
+    "other": "Промокод не был предоставлен"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1425,5 +1425,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Сесија куповине је истекла, покушајте поново."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Не можете да користите промотивни код за ову куповину или изнајмљивање"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Тај промо код још увек није важећи"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Промотивни кодови се не могу применити на бесплатне сесије куповине"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Промо кодови се не могу применити након што је куповина завршена"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Није могуће применити промотивни код, покушајте поново"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Неважећи промо код"
+  },
+  "shopping_error_missing_code": {
+    "other": "Није наведен промотивни код"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1412,5 +1412,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Alışveriş oturumunun süresi doldu, lütfen tekrar deneyin."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Bu satın alma veya kiralama için promosyon kodu kullanamazsınız"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Bu promosyon kodu henüz geçerli değil"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Promosyon kodları ücretsiz alışveriş seanslarına uygulanamaz"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Promosyon kodları, satın alma işlemi tamamlandıktan sonra uygulanamaz"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Promosyon kodu uygulanamadı, lütfen tekrar deneyin"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Geçersiz reklam kodu"
+  },
+  "shopping_error_missing_code": {
+    "other": "Promosyon kodu sağlanmadı"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1466,5 +1466,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "Сеанс покупки закінчився, повторіть спробу."
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "Ви не можете використовувати промокод для цієї покупки або оренди"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "Цей промокод ще не дійсний"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "Промокоди не можуть бути застосовані до безкоштовних сеансів покупок"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "Промокоди не можна застосувати після завершення покупки"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "Не вдалося застосувати промокод, повторіть спробу"
+  },
+  "shopping_error_invalid_code": {
+    "other": "Недійсний промокод"
+  },
+  "shopping_error_missing_code": {
+    "other": "Промокод не надано"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1402,5 +1402,26 @@
   },
   "shopping_error_invalid_session_token": {
     "other": "購物會話已過期，請重試。"
+  },
+  "shopping_error_credit_discounts_not_allowed": {
+    "other": "您不能為此購買或租賃使用促銷代碼"
+  },
+  "shopping_error_discount_coming_soon": {
+    "other": "該促銷代碼無效"
+  },
+  "shopping_error_discount_not_allowed_on_free_session": {
+    "other": "促銷代碼不能應用於免費購物時段"
+  },
+  "shopping_error_discount_not_allowed_on_processing_session": {
+    "other": "購買完成後無法使用促銷代碼"
+  },
+  "shopping_error_discount_redemption_failed": {
+    "other": "無法應用促銷代碼，請重試"
+  },
+  "shopping_error_invalid_code": {
+    "other": "促銷代碼無效"
+  },
+  "shopping_error_missing_code": {
+    "other": "未提供促銷代碼"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#9680](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9680)

## Description of work
Some error messages returned by the discounts API don't have translations. Once we've agreed upon these I'll add them to Curzon.

### Affected Clients
 - All clients who use Kibble and have discounts enabled

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
