### PR TITLE
Corrected Brazilian Portuguese shopping_complete_rental translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed translation for plan frequency in plans.html
 - Added Intl to polyfill to catch iOS devices.
 - Film detail page element switcher uses grid instead of flex with gap.
+- Fixed bad Portuguese translation.
 
 ## [1.3.0](https://github.com/shift72/core-template/compare/1.3.0-alpha...1.3.0)
 

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -689,7 +689,7 @@
     "other": "Seu cartão não é compatível."
   },
   "shopping_complete_rental": {
-    "other": "Successo!"
+    "other": "Sucesso!"
   },
   "shopping_complete_rental_period": {
     "one": "Agora você pode assistir quantas vezes quiser durante o próximo dia.",


### PR DESCRIPTION
ADO card: ☑️ [AB#9692](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9692)

Elab notes/AC: 📃 [Google Docs](https://docs.google.com)
- [ ] Has this been discussed with Delivery Team?

Designs: 
- 📱 [Mobile](http://www.zeplin.io/????)
- 💊 [Tablet](http://www.zeplin.io/????)
- 🖥 [Desktop](http://www.zeplin.io/????)

## Description of work
Fixed a typo in the Brazilian Portuguese translation shopping_complete_rental.

### Affected Clients
 - All clients who use Kibble

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
