### PR TITLE
AB#9675 Fix issue with getting default language from kibble.json when…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.4.0...HEAD)
 
+### Added
+- Translations for discount errors
+
+## Changed
+- Spacing between components AB#9013 
+
+### Fixed
+- Default language now gets set either by site record or kibble.json depending on if DB translations are enabled AB#9675
+- Fixed incorrect Portuguese translation for shopping success
+
 ## [1.4.0](https://github.com/shift72/core-template/compare/1.3.0...1.4.0)
 
 ### Added
@@ -12,7 +22,6 @@
 - Added support for self-service CSS and brand images.
 - Added support for carousel_play_speed and carousel_fade_time configs.
 - Added support to toggle on cloudsearch via Meta > cloudsearch feature toggle.
-- Translations for discount errors
 
 ## Changed
 - Moved the carousel availability label above the CTA's.
@@ -26,7 +35,6 @@
 - Fixed translation for plan frequency in plans.html
 - Added Intl to polyfill to catch iOS devices.
 - Film detail page element switcher uses grid instead of flex with gap.
-- Fixed bad Portuguese translation.
 
 ## [1.3.0](https://github.com/shift72/core-template/compare/1.3.0-alpha...1.3.0)
 

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -52,10 +52,12 @@
     <script src="{{CDN}}/s72.transactional.js" defer></script>
     <script src="https://js.stripe.com/v3/" defer></script>
 
+    {* get default language from site record or kibble.json depening on if db translations is enabled *}  
+    {{ defaultLanguage := isEnabled("site_translations_api") ? site.DefaultLanguage : site.SiteConfig.DefaultLanguage }}
     <script>
       window.addEventListener('DOMContentLoaded', function(){
         s72.cfg(function(){ return s72.i18n.load('{{lang.Code}}', '/{{lang.DefinitionFilePath}}'); });
-        s72.cfg(function(){ return s72.i18n.href.setLanguages('{{site.SiteConfig.DefaultLanguage}}', '{{lang.Code}}'); });
+        s72.cfg(function(){ return s72.i18n.href.setLanguages('{{defaultLanguage}}', '{{lang.Code}}'); });
         s72.boot({
           config: {{ site.Config | json | raw }},
           toggles: {{ site.Toggles | json | raw }},


### PR DESCRIPTION
… db translations enabled

ADO card: ☑️ [AB#9675](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9675)

## Description of work
Add logic to check for database translations. if enabled get default language from site record, else grab it from kibble.json

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
