### PR TITLE
live event purchase flow translations and css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.5.0...HEAD)
 
+### Added
+- Translations and CSS for live event purchase flow.
+
 ## [1.5.0](https://github.com/shift72/core-template/compare/1.4.0...1.5.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,12 @@
 ### Added
 - AB#9564 Live label to film detail page and carousel with translations.
 - AB#9361 Translations for live events, poster live availability status styling changes
+- Translations for live event purchase flow.
 
 ## [1.5.1](https://github.com/shift72/core-template/compare/1.5.0...1.5.1)
 
 ## Changed
 - Revert relish version to 1.3 from latest
-
-### Added
-- Translations and CSS for live event purchase flow.
 
 ## [1.5.0](https://github.com/shift72/core-template/compare/1.4.0...1.5.0)
 

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1530,5 +1530,26 @@
     "few": "مباشر: {{.Count}} أيام",
     "many": "مباشر: {{.Count}} أيام",
     "other": "مباشر: {{.Count}} أيام"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "البث المباشر"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "هذا حدث مباشر. يبدأ {{.Date}} . التاريخ."
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "يمكنك شراء تذكرة الآن ولكنك ستحتاج إلى المشاهدة أثناء البث المباشر."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "ستحتاج إلى المشاهدة أثناء البث المباشر."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "هذا حدث مباشر. ستحتاج إلى المشاهدة أثناء البث المباشر."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "ينتهي {{.Date}} . التاريخ."
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "لن تتمكن من مشاهدة البث بعد ذلك."
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1544,7 +1544,7 @@
     "other": "ستحتاج إلى المشاهدة أثناء البث المباشر."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "هذا الحدث مباشر حاليا. لا يمكنك إرجاعه."
+    "other": "هذا الحدث مباشر حاليا."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "ينتهي {{.Date}} . التاريخ."
@@ -1557,5 +1557,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "يبدأ {{.Date}} . التاريخ."
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "بدأت في {{.Date}} ."
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "لا يمكنك إرجاعه."
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1535,7 +1535,7 @@
     "other": "البث المباشر"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "هذا حدث مباشر. يبدأ {{.Date}} . التاريخ."
+    "other": "هذا حدث مباشر."
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "يمكنك شراء تذكرة الآن ولكنك ستحتاج إلى المشاهدة أثناء البث المباشر."
@@ -1544,7 +1544,7 @@
     "other": "ستحتاج إلى المشاهدة أثناء البث المباشر."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "هذا حدث مباشر. ستحتاج إلى المشاهدة أثناء البث المباشر."
+    "other": "هذا الحدث مباشر حاليا. لا يمكنك إرجاعه."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "ينتهي {{.Date}} . التاريخ."
@@ -1554,5 +1554,8 @@
   },
   "shopping_action_ticket": {
     "other": "احصل على تذكرة"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "يبدأ {{.Date}} . التاريخ."
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1551,5 +1551,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "لن تتمكن من مشاهدة البث بعد ذلك."
+  },
+  "shopping_action_ticket": {
+    "other": "احصل على تذكرة"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Després d'això, no podreu veure l'emissió."
+  },
+  "shopping_action_ticket": {
+    "other": "Aconsegueix el bitllet"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "EN DIRECTE: 1 DIA",
     "other": "EN DIRECTE: {{.Count}} DIES"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Transmissió en directe"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Aquest és un esdeveniment en directe. Comença la {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Ja pots comprar una entrada, però hauràs de mirar-la mentre la transmissió sigui en directe."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Haureu de mirar-lo mentre la transmissió sigui en directe."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Aquest és un esdeveniment en directe. Haureu de mirar-lo mentre la transmissió sigui en directe."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "El flux acaba {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Després d'això, no podreu veure l'emissió."
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1471,7 +1471,7 @@
     "other": "Transmissió en directe"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Aquest és un esdeveniment en directe. Comença la {{.Date}}. "
+    "other": "Aquest és un esdeveniment en directe. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Ja pots comprar una entrada, però hauràs de mirar-la mentre la transmissió sigui en directe."
@@ -1480,7 +1480,7 @@
     "other": "Haureu de mirar-lo mentre la transmissió sigui en directe."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Aquest és un esdeveniment en directe. Haureu de mirar-lo mentre la transmissió sigui en directe."
+    "other": "Aquest esdeveniment està actualment en directe. No pots rebobinar-lo."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "El flux acaba {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Aconsegueix el bitllet"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Comença la {{.Date}}. "
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1480,7 +1480,7 @@
     "other": "Haureu de mirar-lo mentre la transmissió sigui en directe."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Aquest esdeveniment està actualment en directe. No pots rebobinar-lo."
+    "other": "Aquest esdeveniment està actualment en directe. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "El flux acaba {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Comença la {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Va començar a {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "No pots rebobinar-lo."
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Du vil ikke være i stand til at se streamen efter det."
+  },
+  "shopping_action_ticket": {
+    "other": "Få billet"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "LIVE: 1 DAG",
     "other": "LIVE: {{.Count}} DAGE"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Live stream"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Dette er en Live Event. Stream starter {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Du kan købe en billet nu, men du bliver nødt til at se den, mens streamen er live."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Du skal se, mens streamen er live."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Dette er en Live Event. Du skal se, mens streamen er live."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Stream slutter {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Du vil ikke være i stand til at se streamen efter det."
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1471,7 +1471,7 @@
     "other": "Live stream"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Dette er en Live Event. Stream starter {{.Date}}. "
+    "other": "Dette er en Live Event. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Du kan købe en billet nu, men du bliver nødt til at se den, mens streamen er live."
@@ -1480,7 +1480,7 @@
     "other": "Du skal se, mens streamen er live."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Dette er en Live Event. Du skal se, mens streamen er live."
+    "other": "Denne begivenhed er i øjeblikket live. Du kan ikke spole den tilbage."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream slutter {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Få billet"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Stream starter {{.Date}}. "
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1480,7 +1480,7 @@
     "other": "Du skal se, mens streamen er live."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Denne begivenhed er i øjeblikket live. Du kan ikke spole den tilbage."
+    "other": "Denne begivenhed er i øjeblikket live. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream slutter {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Stream starter {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Det startede kl {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Du kan ikke spole den tilbage."
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1480,7 +1480,7 @@
     "other": "Sie müssen zuschauen, während der Stream live ist."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Diese Veranstaltung ist derzeit live. Sie können es nicht zurückspulen."
+    "other": "Diese Veranstaltung ist derzeit live. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream endet am {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Stream beginnt {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Es begann am {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Sie können es nicht zurückspulen."
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1471,7 +1471,7 @@
     "other": "Liveübertragung"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Dies ist ein Live-Event. Stream beginnt {{.Date}}. "
+    "other": "Dies ist ein Live-Event. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Sie können jetzt ein Ticket kaufen, aber Sie müssen zuschauen, während der Stream live ist."
@@ -1480,7 +1480,7 @@
     "other": "Sie müssen zuschauen, während der Stream live ist."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Dies ist ein Live-Event. Sie müssen zuschauen, während der Stream live ist."
+    "other": "Diese Veranstaltung ist derzeit live. Sie können es nicht zurückspulen."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream endet am {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Fahrkarte bekommen"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Stream beginnt {{.Date}}. "
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "LIVE: 1 TAG",
     "other": "LIVE: {{.Count}} TAGE"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Liveübertragung"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Dies ist ein Live-Event. Stream beginnt {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Sie können jetzt ein Ticket kaufen, aber Sie müssen zuschauen, während der Stream live ist."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Sie müssen zuschauen, während der Stream live ist."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Dies ist ein Live-Event. Sie müssen zuschauen, während der Stream live ist."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Stream endet am {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Danach können Sie den Stream nicht mehr ansehen."
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Danach können Sie den Stream nicht mehr ansehen."
+  },
+  "shopping_action_ticket": {
+    "other": "Fahrkarte bekommen"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "LIVE: 1 ΜΕΡΑ",
     "other": "LIVE: {{.Count}} ΗΜΕΡΕΣ"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Ζωντανή μετάδοση"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Αυτή είναι μια Ζωντανή Εκδήλωση. Έναρξη ροής {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Μπορείτε να αγοράσετε ένα εισιτήριο τώρα, αλλά θα πρέπει να το παρακολουθήσετε όσο είναι ζωντανή η ροή."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Θα χρειαστεί να παρακολουθήσετε ενώ η ροή είναι ζωντανή."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Αυτή είναι μια Ζωντανή Εκδήλωση. Θα χρειαστεί να παρακολουθήσετε ενώ η ροή είναι ζωντανή."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Λήξη ροής {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Δεν θα μπορείτε να παρακολουθήσετε τη ροή μετά από αυτό."
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1480,7 +1480,7 @@
     "other": "Θα χρειαστεί να παρακολουθήσετε ενώ η ροή είναι ζωντανή."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Αυτή η εκδήλωση είναι ζωντανή αυτήν τη στιγμή. Δεν μπορείτε να το επανατυλίξετε."
+    "other": "Αυτή η εκδήλωση είναι ζωντανή αυτήν τη στιγμή. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Λήξη ροής {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Έναρξη ροής {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Ξεκίνησε στις {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Δεν μπορείτε να το επανατυλίξετε."
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Δεν θα μπορείτε να παρακολουθήσετε τη ροή μετά από αυτό."
+  },
+  "shopping_action_ticket": {
+    "other": "Πάρτε εισιτήριο"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1471,7 +1471,7 @@
     "other": "Ζωντανή μετάδοση"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Αυτή είναι μια Ζωντανή Εκδήλωση. Έναρξη ροής {{.Date}}. "
+    "other": "Αυτή είναι μια Ζωντανή Εκδήλωση. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Μπορείτε να αγοράσετε ένα εισιτήριο τώρα, αλλά θα πρέπει να το παρακολουθήσετε όσο είναι ζωντανή η ροή."
@@ -1480,7 +1480,7 @@
     "other": "Θα χρειαστεί να παρακολουθήσετε ενώ η ροή είναι ζωντανή."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Αυτή είναι μια Ζωντανή Εκδήλωση. Θα χρειαστεί να παρακολουθήσετε ενώ η ροή είναι ζωντανή."
+    "other": "Αυτή η εκδήλωση είναι ζωντανή αυτήν τη στιγμή. Δεν μπορείτε να το επανατυλίξετε."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Λήξη ροής {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Πάρτε εισιτήριο"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Έναρξη ροής {{.Date}}. "
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "You won't be able to watch the stream after that."
+  },
+  "shopping_action_ticket": {
+    "other": "Get ticket"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "LIVE: 1 DAY",
     "other": "LIVE: {{.Count}} DAYS"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Live Stream"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "This is a Live Event. Stream starts {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "You can buy a ticket now but you will need to watch while the stream is live."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "You will need to watch while the stream is live."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "This is a Live Event. You will need to watch while the stream is live."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Stream ends {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "You won't be able to watch the stream after that."
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1480,7 +1480,7 @@
     "other": "You will need to watch while the stream is live."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "This event is currently live. You cannot rewind it."
+    "other": "This event is currently live. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream ends {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Stream starts {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "It started at {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "You cannot rewind it."
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1471,7 +1471,7 @@
     "other": "Live Stream"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "This is a Live Event. Stream starts {{.Date}}. "
+    "other": "This is a Live Event. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "You can buy a ticket now but you will need to watch while the stream is live."
@@ -1480,7 +1480,7 @@
     "other": "You will need to watch while the stream is live."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "This is a Live Event. You will need to watch while the stream is live."
+    "other": "This event is currently live. You cannot rewind it."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream ends {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Get ticket"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Stream starts {{.Date}}. "
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1475,7 +1475,7 @@
     "other": "Transmisión en vivo"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Este es un evento en vivo. La transmisión comienza {{.Date}}. "
+    "other": "Este es un evento en vivo. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Puede comprar un boleto ahora, pero deberá mirar mientras la transmisión está en vivo."
@@ -1484,7 +1484,7 @@
     "other": "Deberá mirar mientras la transmisión está en vivo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Este es un evento en vivo. Deberá mirar mientras la transmisión está en vivo."
+    "other": "Este evento está actualmente en vivo. No puedes rebobinarlo."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "La transmisión termina {{.Date}}. "
@@ -1494,5 +1494,8 @@
   },
   "shopping_action_ticket": {
     "other": "Obtener boleto"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "La transmisión comienza {{.Date}}. "
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1470,5 +1470,26 @@
   "live_label_days": {
     "one": "EN VIVO: 1 DÍA",
     "other": "EN VIVO: {{.Count}} DÍAS"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Transmisión en vivo"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Este es un evento en vivo. La transmisión comienza {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Puede comprar un boleto ahora, pero deberá mirar mientras la transmisión está en vivo."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Deberá mirar mientras la transmisión está en vivo."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Este es un evento en vivo. Deberá mirar mientras la transmisión está en vivo."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "La transmisión termina {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "No podrás ver la transmisión después de eso."
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1484,7 +1484,7 @@
     "other": "Deberá mirar mientras la transmisión está en vivo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Este evento está actualmente en vivo. No puedes rebobinarlo."
+    "other": "Este evento está actualmente en vivo. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "La transmisión termina {{.Date}}. "
@@ -1497,5 +1497,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "La transmisión comienza {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Comenzó en {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "No puedes rebobinarlo."
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1491,5 +1491,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "No podrás ver la transmisión después de eso."
+  },
+  "shopping_action_ticket": {
+    "other": "Obtener boleto"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1475,7 +1475,7 @@
     "other": "Transmisión en vivo"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Este es un evento en vivo. La transmisión comienza {{.Date}}. "
+    "other": "Este es un evento en vivo. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Puede comprar un boleto ahora, pero deberá mirar mientras la transmisión está en vivo."
@@ -1484,7 +1484,7 @@
     "other": "Deberá mirar mientras la transmisión está en vivo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Este es un evento en vivo. Deberá mirar mientras la transmisión está en vivo."
+    "other": "Este evento está actualmente en vivo. No puedes rebobinarlo."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "La transmisión termina {{.Date}}. "
@@ -1494,5 +1494,8 @@
   },
   "shopping_action_ticket": {
     "other": "Obtener boleto"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "La transmisión comienza {{.Date}}. "
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1470,5 +1470,26 @@
   "live_label_days": {
     "one": "EN VIVO: 1 DÍA",
     "other": "EN VIVO: {{.Count}} DÍAS"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Transmisión en vivo"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Este es un evento en vivo. La transmisión comienza {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Puede comprar un boleto ahora, pero deberá mirar mientras la transmisión está en vivo."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Deberá mirar mientras la transmisión está en vivo."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Este es un evento en vivo. Deberá mirar mientras la transmisión está en vivo."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "La transmisión termina {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "No podrás ver la transmisión después de eso."
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1484,7 +1484,7 @@
     "other": "Deberá mirar mientras la transmisión está en vivo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Este evento está actualmente en vivo. No puedes rebobinarlo."
+    "other": "Este evento está actualmente en vivo. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "La transmisión termina {{.Date}}. "
@@ -1497,5 +1497,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "La transmisión comienza {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Comenzó en {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "No puedes rebobinarlo."
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1491,5 +1491,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "No podrás ver la transmisión después de eso."
+  },
+  "shopping_action_ticket": {
+    "other": "Obtener boleto"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Pärast seda ei saa te otseülekannet vaadata."
+  },
+  "shopping_action_ticket": {
+    "other": "Hankige pilet"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1480,7 +1480,7 @@
     "other": "Peate vaatama otseülekannet."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "See sündmus on praegu otse-eetris. Te ei saa seda tagasi kerida."
+    "other": "See sündmus on praegu otse-eetris. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Voog lõpeb {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Voog algab {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "See algas kell {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Te ei saa seda tagasi kerida."
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "OTSE: 1 PÄEV",
     "other": "OTSE: {{.Count}} PÄEVAD"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Otseülekanne"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "See on otseülekanne. Voog algab {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Pileti saate osta kohe, kuid peate vaatama otseülekannet."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Peate vaatama otseülekannet."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "See on otseülekanne. Peate vaatama otseülekannet."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Voog lõpeb {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Pärast seda ei saa te otseülekannet vaadata."
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1471,7 +1471,7 @@
     "other": "Otseülekanne"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "See on otseülekanne. Voog algab {{.Date}}. "
+    "other": "See on otseülekanne. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Pileti saate osta kohe, kuid peate vaatama otseülekannet."
@@ -1480,7 +1480,7 @@
     "other": "Peate vaatama otseülekannet."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "See on otseülekanne. Peate vaatama otseülekannet."
+    "other": "See sündmus on praegu otse-eetris. Te ei saa seda tagasi kerida."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Voog lõpeb {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Hankige pilet"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Voog algab {{.Date}}. "
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Et voi katsoa striimiä sen jälkeen."
+  },
+  "shopping_action_ticket": {
+    "other": "Hanki lippu"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "LIVE: 1 PÄIVÄ",
     "other": "LIVE: {{.Count}} PÄIVÄT"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Suora lähetys"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Tämä on live-tapahtuma. Suoratoisto alkaa {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Voit ostaa lipun nyt, mutta sinun on katsottava suoratoiston aikana."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Sinun on katsottava suoratoiston aikana."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Tämä on live-tapahtuma. Sinun on katsottava suoratoiston aikana."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Lähetys päättyy {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Et voi katsoa striimiä sen jälkeen."
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1471,7 +1471,7 @@
     "other": "Suora lähetys"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Tämä on live-tapahtuma. Suoratoisto alkaa {{.Date}}. "
+    "other": "Tämä on live-tapahtuma. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Voit ostaa lipun nyt, mutta sinun on katsottava suoratoiston aikana."
@@ -1480,7 +1480,7 @@
     "other": "Sinun on katsottava suoratoiston aikana."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Tämä on live-tapahtuma. Sinun on katsottava suoratoiston aikana."
+    "other": "Tämä tapahtuma on tällä hetkellä live-tilassa. Et voi kelata sitä taaksepäin."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Lähetys päättyy {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Hanki lippu"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Suoratoisto alkaa {{.Date}}. "
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1480,7 +1480,7 @@
     "other": "Sinun on katsottava suoratoiston aikana."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Tämä tapahtuma on tällä hetkellä live-tilassa. Et voi kelata sitä taaksepäin."
+    "other": "Tämä tapahtuma on tällä hetkellä live-tilassa. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Lähetys päättyy {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Suoratoisto alkaa {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Se alkoi {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Et voi kelata sitä taaksepäin."
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1475,7 +1475,7 @@
     "other": "Direct"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Ceci est un événement en direct. Le flux commence {{.Date}}. "
+    "other": "Ceci est un événement en direct. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Vous pouvez acheter un billet maintenant, mais vous devrez regarder pendant que le flux est en direct."
@@ -1484,7 +1484,7 @@
     "other": "Vous devrez regarder pendant que le flux est en direct."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Ceci est un événement en direct. Vous devrez regarder pendant que le flux est en direct."
+    "other": "Cet événement est actuellement en direct. Vous ne pouvez pas le rembobiner."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Le flux se termine {{.Date}}. "
@@ -1494,5 +1494,8 @@
   },
   "shopping_action_ticket": {
     "other": "Obtenir un billet"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Le flux commence {{.Date}}. "
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1491,5 +1491,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Vous ne pourrez plus regarder le flux après cela."
+  },
+  "shopping_action_ticket": {
+    "other": "Obtenir un billet"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1484,7 +1484,7 @@
     "other": "Vous devrez regarder pendant que le flux est en direct."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Cet événement est actuellement en direct. Vous ne pouvez pas le rembobiner."
+    "other": "Cet événement est actuellement en direct. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Le flux se termine {{.Date}}. "
@@ -1497,5 +1497,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Le flux commence {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Cela a commencé à {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Vous ne pouvez pas le rembobiner."
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1470,5 +1470,26 @@
   "live_label_days": {
     "one": "EN DIRECT : 1 JOUR",
     "other": "EN DIRECT : {{.Count}} JOURS"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Direct"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Ceci est un événement en direct. Le flux commence {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Vous pouvez acheter un billet maintenant, mais vous devrez regarder pendant que le flux est en direct."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Vous devrez regarder pendant que le flux est en direct."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Ceci est un événement en direct. Vous devrez regarder pendant que le flux est en direct."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Le flux se termine {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Vous ne pourrez plus regarder le flux après cela."
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1473,7 +1473,7 @@
     "other": "Uživo prijenos"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Ovo je događaj uživo. Stream počinje {{.Date}}. "
+    "other": "Ovo je događaj uživo. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Ulaznicu možete kupiti sada, ali morat ćete gledati dok je prijenos uživo."
@@ -1482,7 +1482,7 @@
     "other": "Morat ćete gledati dok je prijenos uživo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Ovo je događaj uživo. Morat ćete gledati dok je prijenos uživo."
+    "other": "Ovaj događaj trenutno je uživo. Ne možete ga premotati unatrag."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream završava {{.Date}}. "
@@ -1492,5 +1492,8 @@
   },
   "shopping_action_ticket": {
     "other": "Uzmi kartu"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Stream počinje {{.Date}}. "
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1489,5 +1489,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Nakon toga nećete moći gledati prijenos."
+  },
+  "shopping_action_ticket": {
+    "other": "Uzmi kartu"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1468,5 +1468,26 @@
     "one": "UŽIVO: 1 DAN",
     "few": "UŽIVO: {{.Count}} DANE",
     "other": "UŽIVO: {{.Count}} DANE"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Uživo prijenos"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Ovo je događaj uživo. Stream počinje {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Ulaznicu možete kupiti sada, ali morat ćete gledati dok je prijenos uživo."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Morat ćete gledati dok je prijenos uživo."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Ovo je događaj uživo. Morat ćete gledati dok je prijenos uživo."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Stream završava {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Nakon toga nećete moći gledati prijenos."
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1482,7 +1482,7 @@
     "other": "Morat ćete gledati dok je prijenos uživo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Ovaj događaj trenutno je uživo. Ne možete ga premotati unatrag."
+    "other": "Ovaj događaj trenutno je uživo. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream završava {{.Date}}. "
@@ -1495,5 +1495,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Stream počinje {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Počelo je u {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Ne možete ga premotati unatrag."
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1480,7 +1480,7 @@
     "other": "A közvetítést élőben kell nézni."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Ez az esemény jelenleg élő. Nem tudod visszatekerni."
+    "other": "Ez az esemény jelenleg élő. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Az adatfolyam véget ér {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Az adatfolyam elindul {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "{{.Date}} -kor kezdődött. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Nem lehet visszatekerni."
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "ÉLŐ: 1 NAP",
     "other": "ÉLŐ: {{.Count}} NAPOK"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Élő adás"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Ez egy élő esemény. Az adatfolyam elindul {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Már most is vásárolhat jegyet, de a közvetítést élőben kell néznie."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "A közvetítést élőben kell nézni."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Ez egy élő esemény. A közvetítést élőben kell nézni."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Az adatfolyam véget ér {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Utána nem fogod tudni nézni a streamet."
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1471,7 +1471,7 @@
     "other": "Élő adás"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Ez egy élő esemény. Az adatfolyam elindul {{.Date}}. "
+    "other": "Ez egy élő esemény. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Már most is vásárolhat jegyet, de a közvetítést élőben kell néznie."
@@ -1480,7 +1480,7 @@
     "other": "A közvetítést élőben kell nézni."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Ez egy élő esemény. A közvetítést élőben kell nézni."
+    "other": "Ez az esemény jelenleg élő. Nem tudod visszatekerni."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Az adatfolyam véget ér {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Vegyél jegyet"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Az adatfolyam elindul {{.Date}}. "
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Utána nem fogod tudni nézni a streamet."
+  },
+  "shopping_action_ticket": {
+    "other": "Vegyél jegyet"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1491,5 +1491,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Non sarai in grado di guardare lo streaming dopo."
+  },
+  "shopping_action_ticket": {
+    "other": "Ottieni il biglietto"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1470,5 +1470,26 @@
   "live_label_days": {
     "one": "IN DIRETTA: 1 GIORNO",
     "other": "IN DIRETTA: {{.Count}} GIORNI"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Trasmissione in diretta"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Questo è un evento dal vivo. Lo streaming inizia {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Puoi acquistare un biglietto ora ma dovrai guardarlo mentre lo streaming è in diretta."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Dovrai guardare mentre lo streaming è in diretta."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Questo è un evento dal vivo. Dovrai guardare mentre lo streaming è in diretta."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Il flusso termina {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Non sarai in grado di guardare lo streaming dopo."
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1475,7 +1475,7 @@
     "other": "Trasmissione in diretta"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Questo è un evento dal vivo. Lo streaming inizia {{.Date}}. "
+    "other": "Questo è un evento dal vivo. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Puoi acquistare un biglietto ora ma dovrai guardarlo mentre lo streaming è in diretta."
@@ -1484,7 +1484,7 @@
     "other": "Dovrai guardare mentre lo streaming è in diretta."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Questo è un evento dal vivo. Dovrai guardare mentre lo streaming è in diretta."
+    "other": "Questo evento è attualmente in diretta. Non puoi riavvolgerlo."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Il flusso termina {{.Date}}. "
@@ -1494,5 +1494,8 @@
   },
   "shopping_action_ticket": {
     "other": "Ottieni il biglietto"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Il flusso inizia {{.Date}}. "
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1484,7 +1484,7 @@
     "other": "Dovrai guardare mentre lo streaming è in diretta."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Questo evento è attualmente in diretta. Non puoi riavvolgerlo."
+    "other": "Questo evento è attualmente in diretta. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Il flusso termina {{.Date}}. "
@@ -1497,5 +1497,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Il flusso inizia {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "È iniziato a {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Non puoi riavvolgerlo."
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1474,5 +1474,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "その後、ストリームを視聴することはできません。"
+  },
+  "shopping_action_ticket": {
+    "other": "チケットを入手"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1453,5 +1453,26 @@
   },
   "live_label_days": {
     "other": "ライブ: {{.Count}} 日"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "ライブ ストリーム"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "これはライブイベントです。ストリーム開始{{.Date}}。"
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "今すぐチケットを購入できますが、ストリームがライブである間に視聴する必要があります。"
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "ストリームがライブである間、視聴する必要があります。"
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "これはライブイベントです。ストリームがライブである間、視聴する必要があります。"
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "ストリームは{{.Date}}で終了します。"
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "その後、ストリームを視聴することはできません。"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1467,7 +1467,7 @@
     "other": "ストリームがライブである間、視聴する必要があります。"
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "このイベントは現在開催中です。巻き戻しはできません。"
+    "other": "このイベントは現在開催中です。"
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "ストリームは{{.Date}}で終了します。"
@@ -1480,5 +1480,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "ストリーム開始{{.Date}}。"
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "それは{{.Date}}に始まりました。"
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "巻き戻しはできません。"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1458,7 +1458,7 @@
     "other": "ライブ ストリーム"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "これはライブイベントです。ストリーム開始{{.Date}}。"
+    "other": "これはライブイベントです。"
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "今すぐチケットを購入できますが、ストリームがライブである間に視聴する必要があります。"
@@ -1467,7 +1467,7 @@
     "other": "ストリームがライブである間、視聴する必要があります。"
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "これはライブイベントです。ストリームがライブである間、視聴する必要があります。"
+    "other": "このイベントは現在開催中です。巻き戻しはできません。"
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "ストリームは{{.Date}}で終了します。"
@@ -1477,5 +1477,8 @@
   },
   "shopping_action_ticket": {
     "other": "チケットを入手"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "ストリーム開始{{.Date}}。"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1512,7 +1512,7 @@
     "other": "Turėsite žiūrėti, kol vyksta tiesioginė transliacija."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Šis įvykis šiuo metu vyksta tiesiogiai. Jūs negalite jo atsukti."
+    "other": "Šis įvykis šiuo metu vyksta tiesiogiai. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Srautas baigiasi {{.Date}}. "
@@ -1525,5 +1525,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Srautas prasideda {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Jis prasidėjo {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Jūs negalite jo atsukti."
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1519,5 +1519,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Po to srauto žiūrėti nebegalėsite."
+  },
+  "shopping_action_ticket": {
+    "other": "Gaukite bilietą"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1498,5 +1498,26 @@
     "few": "TIESIOGIAI: {{.Count}} DIENAS",
     "many": "TIESIOGIAI: {{.Count}} DIENAS",
     "other": "TIESIOGIAI: {{.Count}} DIENAS"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Tiesiogiai"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Tai tiesioginis įvykis. Srautas prasideda {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Galite nusipirkti bilietą dabar, bet turėsite žiūrėti, kol bus transliuojama tiesioginė transliacija."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Turėsite žiūrėti, kol vyksta tiesioginė transliacija."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Tai tiesioginis įvykis. Turėsite žiūrėti, kol vyksta tiesioginė transliacija."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Srautas baigiasi {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Po to srauto žiūrėti nebegalėsite."
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1503,7 +1503,7 @@
     "other": "Tiesiogiai"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Tai tiesioginis įvykis. Srautas prasideda {{.Date}}. "
+    "other": "Tai tiesioginis įvykis. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Galite nusipirkti bilietą dabar, bet turėsite žiūrėti, kol bus transliuojama tiesioginė transliacija."
@@ -1512,7 +1512,7 @@
     "other": "Turėsite žiūrėti, kol vyksta tiesioginė transliacija."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Tai tiesioginis įvykis. Turėsite žiūrėti, kol vyksta tiesioginė transliacija."
+    "other": "Šis įvykis šiuo metu vyksta tiesiogiai. Jūs negalite jo atsukti."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Srautas baigiasi {{.Date}}. "
@@ -1522,5 +1522,8 @@
   },
   "shopping_action_ticket": {
     "other": "Gaukite bilietą"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Srautas prasideda {{.Date}}. "
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "LIVE: 1 DAG",
     "other": "LIVE: {{.Count}} DAGEN"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Livestream"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Dit is een live-evenement. Stream start {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Je kunt nu een kaartje kopen, maar je moet kijken terwijl de stream live is."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Je moet kijken terwijl de stream live is."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Dit is een live-evenement. Je moet kijken terwijl de stream live is."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Stream eindigt {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Daarna kun je de stream niet meer bekijken."
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1480,7 +1480,7 @@
     "other": "Je moet kijken terwijl de stream live is."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Dit evenement is momenteel live. Je kunt het niet terugspoelen."
+    "other": "Dit evenement is momenteel live. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream eindigt {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Stream start {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Het begon om {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Je kunt het niet terugspoelen."
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1471,7 +1471,7 @@
     "other": "Livestream"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Dit is een live-evenement. Stream start {{.Date}}. "
+    "other": "Dit is een live-evenement. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Je kunt nu een kaartje kopen, maar je moet kijken terwijl de stream live is."
@@ -1480,7 +1480,7 @@
     "other": "Je moet kijken terwijl de stream live is."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Dit is een live-evenement. Je moet kijken terwijl de stream live is."
+    "other": "Dit evenement is momenteel live. Je kunt het niet terugspoelen."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Stream eindigt {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Koop een kaartje"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Stream start {{.Date}}. "
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Daarna kun je de stream niet meer bekijken."
+  },
+  "shopping_action_ticket": {
+    "other": "Koop een kaartje"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "LIVE: 1 DAG",
     "other": "LIVE: {{.Count}} DAGER"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Direktestrømming"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Dette er en Live Event. Strømmen starter {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Du kan kjøpe en billett nå, men du må se mens strømmen er direkte."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Du må se mens strømmen er direkte."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Dette er en Live Event. Du må se mens strømmen er direkte."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Strøm slutter {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Du vil ikke kunne se strømmen etter det."
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1480,7 +1480,7 @@
     "other": "Du må se mens strømmen er direkte."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Denne begivenheten er for øyeblikket live. Du kan ikke spole den tilbake."
+    "other": "Denne begivenheten er for øyeblikket live. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Strøm slutter {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Strømmen starter {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Det startet på {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Du kan ikke spole den tilbake."
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1471,7 +1471,7 @@
     "other": "Direktestrømming"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Dette er en Live Event. Strømmen starter {{.Date}}. "
+    "other": "Dette er en Live Event. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Du kan kjøpe en billett nå, men du må se mens strømmen er direkte."
@@ -1480,7 +1480,7 @@
     "other": "Du må se mens strømmen er direkte."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Dette er en Live Event. Du må se mens strømmen er direkte."
+    "other": "Denne begivenheten er for øyeblikket live. Du kan ikke spole den tilbake."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Strøm slutter {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Få billett"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Strømmen starter {{.Date}}. "
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Du vil ikke kunne se strømmen etter det."
+  },
+  "shopping_action_ticket": {
+    "other": "Få billett"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1543,5 +1543,26 @@
     "few": "NA ŻYWO: {{.Count}} DNI",
     "many": "NA ŻYWO: {{.Count}} DNI",
     "other": "NA ŻYWO: {{.Count}} DNI"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Transmisja na żywo"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "To jest wydarzenie na żywo. Strumień zaczyna się {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Możesz teraz kupić bilet, ale musisz oglądać, gdy transmisja jest na żywo."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Musisz oglądać transmisję na żywo."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "To jest wydarzenie na żywo. Musisz oglądać transmisję na żywo."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Transmisja kończy się {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Po tym nie będziesz mógł oglądać transmisji."
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1564,5 +1564,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Po tym nie będziesz mógł oglądać transmisji."
+  },
+  "shopping_action_ticket": {
+    "other": "Kup bilet"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1548,7 +1548,7 @@
     "other": "Transmisja na żywo"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "To jest wydarzenie na żywo. Strumień zaczyna się {{.Date}}. "
+    "other": "To jest wydarzenie na żywo. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Możesz teraz kupić bilet, ale musisz oglądać, gdy transmisja jest na żywo."
@@ -1557,7 +1557,7 @@
     "other": "Musisz oglądać transmisję na żywo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "To jest wydarzenie na żywo. Musisz oglądać transmisję na żywo."
+    "other": "To wydarzenie jest aktualnie na żywo. Nie możesz go cofnąć."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Transmisja kończy się {{.Date}}. "
@@ -1567,5 +1567,8 @@
   },
   "shopping_action_ticket": {
     "other": "Kup bilet"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Strumień zaczyna się {{.Date}}. "
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1557,7 +1557,7 @@
     "other": "Musisz oglądać transmisję na żywo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "To wydarzenie jest aktualnie na żywo. Nie możesz go cofnąć."
+    "other": "To wydarzenie jest aktualnie na żywo. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Transmisja kończy się {{.Date}}. "
@@ -1570,5 +1570,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Strumień zaczyna się {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Zaczęło się w {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Nie możesz go cofnąć."
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1470,5 +1470,26 @@
   "live_label_days": {
     "one": "AO VIVO: 1 DIA",
     "other": "AO VIVO: {{.Count}} DIAS"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Transmissão ao vivo"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Este é um evento ao vivo. O fluxo começa {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Você pode comprar um ingresso agora, mas precisará assistir enquanto a transmissão estiver ao vivo."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Você precisará assistir enquanto a transmissão estiver ao vivo."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Este é um evento ao vivo. Você precisará assistir enquanto a transmissão estiver ao vivo."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "O fluxo termina {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Você não poderá assistir à transmissão depois disso."
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1491,5 +1491,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Você não poderá assistir à transmissão depois disso."
+  },
+  "shopping_action_ticket": {
+    "other": "Obter bilhete"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1484,7 +1484,7 @@
     "other": "Você precisará assistir enquanto a transmissão estiver ao vivo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Este evento está atualmente ao vivo. Você não pode rebobinar."
+    "other": "Este evento está atualmente ao vivo. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "O fluxo termina {{.Date}}. "
@@ -1497,5 +1497,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "O fluxo começa {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Começou em {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Você não pode rebobinar."
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1475,7 +1475,7 @@
     "other": "Transmissão ao vivo"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Este é um evento ao vivo. O fluxo começa {{.Date}}. "
+    "other": "Este é um evento ao vivo. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Você pode comprar um ingresso agora, mas precisará assistir enquanto a transmissão estiver ao vivo."
@@ -1484,7 +1484,7 @@
     "other": "Você precisará assistir enquanto a transmissão estiver ao vivo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Este é um evento ao vivo. Você precisará assistir enquanto a transmissão estiver ao vivo."
+    "other": "Este evento está atualmente ao vivo. Você não pode rebobinar."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "O fluxo termina {{.Date}}. "
@@ -1494,5 +1494,8 @@
   },
   "shopping_action_ticket": {
     "other": "Obter bilhete"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "O fluxo começa {{.Date}}. "
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1470,5 +1470,26 @@
   "live_label_days": {
     "one": "AO VIVO: 1 DIA",
     "other": "AO VIVO: {{.Count}} DIAS"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Transmissão ao vivo"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Este é um evento ao vivo. O fluxo começa {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Você pode comprar um ingresso agora, mas precisará assistir enquanto a transmissão estiver ao vivo."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Você precisará assistir enquanto a transmissão estiver ao vivo."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Este é um evento ao vivo. Você precisará assistir enquanto a transmissão estiver ao vivo."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "O fluxo termina {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Você não poderá assistir à transmissão depois disso."
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1491,5 +1491,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Você não poderá assistir à transmissão depois disso."
+  },
+  "shopping_action_ticket": {
+    "other": "Obter bilhete"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1484,7 +1484,7 @@
     "other": "Você precisará assistir enquanto a transmissão estiver ao vivo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Este evento está atualmente ao vivo. Você não pode rebobinar."
+    "other": "Este evento está atualmente ao vivo. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "O fluxo termina {{.Date}}. "
@@ -1497,5 +1497,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "O fluxo começa {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Começou em {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Você não pode rebobinar."
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1475,7 +1475,7 @@
     "other": "Transmissão ao vivo"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Este é um evento ao vivo. O fluxo começa {{.Date}}. "
+    "other": "Este é um evento ao vivo. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Você pode comprar um ingresso agora, mas precisará assistir enquanto a transmissão estiver ao vivo."
@@ -1484,7 +1484,7 @@
     "other": "Você precisará assistir enquanto a transmissão estiver ao vivo."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Este é um evento ao vivo. Você precisará assistir enquanto a transmissão estiver ao vivo."
+    "other": "Este evento está atualmente ao vivo. Você não pode rebobinar."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "O fluxo termina {{.Date}}. "
@@ -1494,5 +1494,8 @@
   },
   "shopping_action_ticket": {
     "other": "Obter bilhete"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "O fluxo começa {{.Date}}. "
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1534,7 +1534,7 @@
     "other": "Вам нужно будет смотреть, пока трансляция идет в прямом эфире."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Это событие в настоящее время в прямом эфире. Вы не можете перемотать его назад."
+    "other": "Это событие в настоящее время в прямом эфире. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Поток заканчивается {{.Date}}. "
@@ -1547,5 +1547,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Поток начинается {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Это началось в {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Вы не можете перемотать его назад."
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1525,7 +1525,7 @@
     "other": "Прямая трансляция"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Это живое событие. Поток начинается {{.Date}}. "
+    "other": "Это живое событие. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Вы можете купить билет сейчас, но вам нужно будет смотреть, пока трансляция идет в прямом эфире."
@@ -1534,7 +1534,7 @@
     "other": "Вам нужно будет смотреть, пока трансляция идет в прямом эфире."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Это живое событие. Вам нужно будет смотреть, пока трансляция идет в прямом эфире."
+    "other": "Это событие в настоящее время в прямом эфире. Вы не можете перемотать его назад."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Поток заканчивается {{.Date}}. "
@@ -1544,5 +1544,8 @@
   },
   "shopping_action_ticket": {
     "other": "Получить билет"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Поток начинается {{.Date}}. "
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1520,5 +1520,26 @@
     "few": "ЖИТЬ: {{.Count}} ДНЕЙ",
     "many": "ЖИТЬ: {{.Count}} ДНЕЙ",
     "other": "ЖИТЬ: {{.Count}} ДНЕЙ"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Прямая трансляция"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Это живое событие. Поток начинается {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Вы можете купить билет сейчас, но вам нужно будет смотреть, пока трансляция идет в прямом эфире."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Вам нужно будет смотреть, пока трансляция идет в прямом эфире."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Это живое событие. Вам нужно будет смотреть, пока трансляция идет в прямом эфире."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Поток заканчивается {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "После этого вы не сможете смотреть трансляцию."
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1541,5 +1541,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "После этого вы не сможете смотреть трансляцию."
+  },
+  "shopping_action_ticket": {
+    "other": "Получить билет"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1496,7 +1496,7 @@
     "other": "Мораћете да гледате док је стрим уживо."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Овај догађај је тренутно уживо. Не можете га премотати."
+    "other": "Овај догађај је тренутно уживо. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Стрим се завршава {{.Date}}. "
@@ -1509,5 +1509,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Стрим почиње {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Почело је у {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Не можете га премотати."
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1503,5 +1503,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "После тога нећете моћи да гледате стрим."
+  },
+  "shopping_action_ticket": {
+    "other": "Узми карту"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1487,7 +1487,7 @@
     "other": "Ливе Стреам"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Ово је догађај уживо. Стрим почиње {{.Date}}. "
+    "other": "Ово је догађај уживо. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Можете купити карту сада, али ћете морати да гледате док је стрим уживо."
@@ -1496,7 +1496,7 @@
     "other": "Мораћете да гледате док је стрим уживо."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Ово је догађај уживо. Мораћете да гледате док је стрим уживо."
+    "other": "Овај догађај је тренутно уживо. Не можете га премотати."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Стрим се завршава {{.Date}}. "
@@ -1506,5 +1506,8 @@
   },
   "shopping_action_ticket": {
     "other": "Узми карту"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Стрим почиње {{.Date}}. "
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1482,5 +1482,26 @@
     "one": "УЖИВО: 1 ДАН",
     "few": "УЖИВО: {{.Count}} ДАНА",
     "other": "УЖИВО: {{.Count}} ДАНА"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Ливе Стреам"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Ово је догађај уживо. Стрим почиње {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Можете купити карту сада, али ћете морати да гледате док је стрим уживо."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Мораћете да гледате док је стрим уживо."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Ово је догађај уживо. Мораћете да гледате док је стрим уживо."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Стрим се завршава {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "После тога нећете моћи да гледате стрим."
   }
 }

--- a/site/styles/_shopping.scss
+++ b/site/styles/_shopping.scss
@@ -132,8 +132,7 @@
   }
 }
 
-.s72-shopping-info-meta,
-.s72-shopping-info-live-event {
+.s72-shopping-info-meta {
   margin: 0;
   padding: 10px 0 0;
 

--- a/site/styles/_shopping.scss
+++ b/site/styles/_shopping.scss
@@ -132,7 +132,8 @@
   }
 }
 
-.s72-shopping-info-meta {
+.s72-shopping-info-meta,
+.s72-shopping-info-live-event {
   margin: 0;
   padding: 10px 0 0;
 

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1487,5 +1487,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Bundan sonra yayını izleyemezsiniz."
+  },
+  "shopping_action_ticket": {
+    "other": "Bilet al"
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1480,7 +1480,7 @@
     "other": "Yayın canlıyken izlemeniz gerekecek."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Bu etkinlik şu anda yayında. Geri saramazsınız."
+    "other": "Bu etkinlik şu anda yayında. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Akış biter {{.Date}}. "
@@ -1493,5 +1493,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Akış başlar {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "{{.Date}} başladı. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Geri saramazsınız."
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1466,5 +1466,26 @@
   "live_label_days": {
     "one": "CANLI: 1 GÜN",
     "other": "CANLI: {{.Count}} GÜNLER"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Canlı yayın"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Bu Canlı Bir Etkinliktir. Akış başlar {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Şimdi bir bilet satın alabilirsiniz, ancak yayın canlıyken izlemeniz gerekecek."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Yayın canlıyken izlemeniz gerekecek."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Bu Canlı Bir Etkinliktir. Yayın canlıyken izlemeniz gerekecek."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Akış biter {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Bundan sonra yayını izleyemezsiniz."
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1471,7 +1471,7 @@
     "other": "Canlı yayın"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Bu Canlı Bir Etkinliktir. Akış başlar {{.Date}}. "
+    "other": "Bu Canlı Bir Etkinliktir. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Şimdi bir bilet satın alabilirsiniz, ancak yayın canlıyken izlemeniz gerekecek."
@@ -1480,7 +1480,7 @@
     "other": "Yayın canlıyken izlemeniz gerekecek."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Bu Canlı Bir Etkinliktir. Yayın canlıyken izlemeniz gerekecek."
+    "other": "Bu etkinlik şu anda yayında. Geri saramazsınız."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Akış biter {{.Date}}. "
@@ -1490,5 +1490,8 @@
   },
   "shopping_action_ticket": {
     "other": "Bilet al"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Akış başlar {{.Date}}. "
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1547,5 +1547,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "Після цього ви не зможете дивитися трансляцію."
+  },
+  "shopping_action_ticket": {
+    "other": "Отримати квиток"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1540,7 +1540,7 @@
     "other": "Вам потрібно буде дивитися, поки йде трансляція."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Ця подія зараз транслюється. Ви не можете перемотати його назад."
+    "other": "Ця подія зараз транслюється. "
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Потік закінчується {{.Date}}. "
@@ -1553,5 +1553,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "Початок потоку {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "Це почалося о {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "Ви не можете перемотати його назад."
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1526,5 +1526,26 @@
     "few": "НАЖИВО: {{.Count}} ДНІВ",
     "many": "НАЖИВО: {{.Count}} ДНІВ",
     "other": "НАЖИВО: {{.Count}} ДНІВ"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "Наживо"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "Це подія в прямому ефірі. Початок потоку {{.Date}}. "
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "Ви можете придбати квиток зараз, але вам потрібно буде дивитися, поки йде трансляція."
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "Вам потрібно буде дивитися, поки йде трансляція."
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "Це подія в прямому ефірі. Вам потрібно буде дивитися, поки йде трансляція."
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "Потік закінчується {{.Date}}. "
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "Після цього ви не зможете дивитися трансляцію."
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1531,7 +1531,7 @@
     "other": "Наживо"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "Це подія в прямому ефірі. Початок потоку {{.Date}}. "
+    "other": "Це подія в прямому ефірі. "
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "Ви можете придбати квиток зараз, але вам потрібно буде дивитися, поки йде трансляція."
@@ -1540,7 +1540,7 @@
     "other": "Вам потрібно буде дивитися, поки йде трансляція."
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "Це подія в прямому ефірі. Вам потрібно буде дивитися, поки йде трансляція."
+    "other": "Ця подія зараз транслюється. Ви не можете перемотати його назад."
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "Потік закінчується {{.Date}}. "
@@ -1550,5 +1550,8 @@
   },
   "shopping_action_ticket": {
     "other": "Отримати квиток"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "Початок потоку {{.Date}}. "
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1453,5 +1453,26 @@
   },
   "live_label_days": {
     "other": "直播：{{.Count}} 天"
+  },
+  "shopping_info_subtitle_live_event": {
+    "other": "現場直播"
+  },
+  "shopping_info_release_date_title_live_event": {
+    "other": "這是一個現場活動。流開始{{.Date}}。"
+  },
+  "shopping_info_release_date_explanation1_live_event_rent": {
+    "other": "您現在可以購買門票，但您需要在直播期間觀看。"
+  },
+  "shopping_info_release_date_explanation2_live_event_rent": {
+    "other": "您需要在直播時觀看。"
+  },
+  "shopping_info_release_date_explanation3_live_event_rent": {
+    "other": "這是一個現場活動。您需要在直播時觀看。"
+  },
+  "shopping_info_available_until_date_title_live_event": {
+    "other": "流結束{{.Date}}。"
+  },
+  "shopping_info_available_until_date_explanation_live_event_rent": {
+    "other": "之後您將無法觀看直播。"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1467,7 +1467,7 @@
     "other": "您需要在直播時觀看。"
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "此活動目前正在進行中。你不能倒帶。"
+    "other": "此活動目前正在進行中。"
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "流結束{{.Date}}。"
@@ -1480,5 +1480,11 @@
   },
   "shopping_info_release_date_title_live_event_start": {
     "other": "流開始{{.Date}}。"
+  },
+  "shopping_info_release_date_explanation4_live_event_rent": {
+    "other": "它始於{{.Date}}。"
+  },
+  "shopping_info_release_date_explanation5_live_event_rent": {
+    "other": "你不能倒帶。"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1458,7 +1458,7 @@
     "other": "現場直播"
   },
   "shopping_info_release_date_title_live_event": {
-    "other": "這是一個現場活動。流開始{{.Date}}。"
+    "other": "這是一個現場活動。"
   },
   "shopping_info_release_date_explanation1_live_event_rent": {
     "other": "您現在可以購買門票，但您需要在直播期間觀看。"
@@ -1467,7 +1467,7 @@
     "other": "您需要在直播時觀看。"
   },
   "shopping_info_release_date_explanation3_live_event_rent": {
-    "other": "這是一個現場活動。您需要在直播時觀看。"
+    "other": "此活動目前正在進行中。你不能倒帶。"
   },
   "shopping_info_available_until_date_title_live_event": {
     "other": "流結束{{.Date}}。"
@@ -1477,5 +1477,8 @@
   },
   "shopping_action_ticket": {
     "other": "取票"
+  },
+  "shopping_info_release_date_title_live_event_start": {
+    "other": "流開始{{.Date}}。"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1474,5 +1474,8 @@
   },
   "shopping_info_available_until_date_explanation_live_event_rent": {
     "other": "之後您將無法觀看直播。"
+  },
+  "shopping_action_ticket": {
+    "other": "取票"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#9743](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9743)

Elab notes/AC: 📃 [Google Docs](https://docs.google.com/document/d/1xVECgmuo5F5HxacMQQUDC3wXsbcCdOQyExJbL28B00Y/edit#heading=h.l6k7fw26aplf)

## Description of work
Adds translations and tiny bit of CSS for live event purchase flow.

## Related PRs 

### Any PRs dependent on this one
- https://github.com/indiereign/shift72-web/pull/350

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
