### PR TITLE
fix bundle page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - AB#9564 Live label to film detail page and carousel with translations.
 - AB#9361 Translations for live events, poster live availability status styling changes
 
+### Fixed
+- Bundle page style regression
+
 ## [1.5.1](https://github.com/shift72/core-template/compare/1.5.0...1.5.1)
 
 ## Changed
@@ -17,7 +20,7 @@
 - Translations for discount errors
 
 ## Changed
-- Spacing between components AB#9013 
+- Spacing between components AB#9013
 
 ### Fixed
 - Default language now gets set either by site record or kibble.json depending on if DB translations are enabled AB#9675

--- a/site/styles/_availability-tags.scss
+++ b/site/styles/_availability-tags.scss
@@ -64,16 +64,16 @@ s72-availability-label {
   }
 
   .availability-bg.live {
-    color: var(--body-color, rgb(255, 255, 255));
     background-color: rgba(var(--body-bg-rgb, 0, 0, 0), 0.7);
+    color: var(--body-color, rgb(255, 255, 255));
   }
 
   s72-availability-status {
-    .availability-livenow:before {
+    .availability-livenow::before {
       @include s72-icon-live;
-      margin-right: 6px;
-      font-size: 8px;
       color: var(--live-red);
+      font-size: 8px;
+      margin-right: 6px;
     }
   }
 }

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -186,11 +186,6 @@
       grid-row: 2;
     }
   }
-
-  .page-collection-list {
-    grid-column-end: -1;
-    grid-row: 3;
-  }
 }
 
 s72-element-switcher,

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -188,8 +188,8 @@
   }
 
   .page-collection-list {
-    grid-row: 3;
     grid-column-end: -1;
+    grid-row: 3;
   }
 }
 

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -186,6 +186,11 @@
       grid-row: 2;
     }
   }
+
+  .page-collection-list {
+    grid-row: 3;
+    grid-column-end: -1;
+  }
 }
 
 s72-element-switcher,

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -374,7 +374,9 @@ s72-element-switcher,
   }
 
   .page-collection-list {
-    padding: 0;
+    @include media-breakpoint-up(md) {
+      padding: 0;
+    }
 
     .page-collection-list-title {
       margin-bottom: 10px;

--- a/site/templates/bundle/item.jet
+++ b/site/templates/bundle/item.jet
@@ -31,9 +31,8 @@
 
           {{yield bundleSynopsis(class="meta-detail-synopsis", synopsis=bundle.Description)}}
         </div>
-
-        {{yield bundleList(items=bundle.Items)}}
       </div>
     </div>
+    {{yield bundleList(items=bundle.Items)}}
   </main>
 {{end}}


### PR DESCRIPTION
ADO card: ☑️ [AB#9825](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9825)

Noticed yesterday a bundle page style regression, just want to add a fix

Bundle page should look like:
https://staging-event.shift72.com/bundle/the-matrix-trilogy/

Currently looks like:
https://staging-store-kibble.shift72.com/bundle/super-bundle/