### PR TITLE
Ab#9805 buttons are not dynamic so text overruns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - AB#9361 Translations for live events, poster live availability status styling changes
 
 ### Fixed
-- inline cta buttons now grow when text is wider than button width
+- Inline cta buttons now grow when text is wider than button width
 
 ## [1.5.1](https://github.com/shift72/core-template/compare/1.5.0...1.5.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - AB#9564 Live label to film detail page and carousel with translations.
 - AB#9361 Translations for live events, poster live availability status styling changes
 
+### Fixed
+- inline cta buttons now grow when text is wider than button width
+
 ## [1.5.1](https://github.com/shift72/core-template/compare/1.5.0...1.5.1)
 
 ## Changed
@@ -17,7 +20,7 @@
 - Translations for discount errors
 
 ## Changed
-- Spacing between components AB#9013 
+- Spacing between components AB#9013
 
 ### Fixed
 - Default language now gets set either by site record or kibble.json depending on if DB translations are enabled AB#9675

--- a/site/styles/_availability-tags.scss
+++ b/site/styles/_availability-tags.scss
@@ -64,16 +64,16 @@ s72-availability-label {
   }
 
   .availability-bg.live {
-    color: var(--body-color, rgb(255, 255, 255));
     background-color: rgba(var(--body-bg-rgb, 0, 0, 0), 0.7);
+    color: var(--body-color, rgb(255, 255, 255));
   }
 
   s72-availability-status {
-    .availability-livenow:before {
+    .availability-livenow::before {
       @include s72-icon-live;
-      margin-right: 6px;
-      font-size: 8px;
       color: var(--live-red);
+      font-size: 8px;
+      margin-right: 6px;
     }
   }
 }

--- a/site/styles/_cta-buttons.scss
+++ b/site/styles/_cta-buttons.scss
@@ -1,4 +1,16 @@
 /* stylelint-disable selector-max-compound-selectors, max-nesting-depth */
+@mixin text-cta-btn-inline {
+  margin: 0;
+  padding: 6px 12px;
+  width: 100%;
+  white-space: nowrap;
+
+  @include media-breakpoint-up(xs) {
+    width: 140px;
+    min-width: fit-content;
+  }
+}
+
 .cta-buttons {
   display: grid;
   gap: 16px;
@@ -121,12 +133,7 @@
     }
 
     .s72-btn {
-      white-space: nowrap;
-      width: 100%;
-
-      @include media-breakpoint-up(xs) {
-        width: auto;
-      }
+      @include text-cta-btn-inline;
 
       &:nth-child(2) {
         margin: 0; // RELISH OVERRIDE.
@@ -136,10 +143,7 @@
 
   s72-play-button {
     .s72-btn-play {
-      margin: 0;
-      min-width: 140px;
-      padding: 6px 12px;
-      width: 100%;
+      @include text-cta-btn-inline;
     }
 
     .s72-btn-play-icon {
@@ -152,9 +156,7 @@
   }
 
   .s72-btn-can-be-watched {
-    min-width: 140px;
-    padding: 6px 12px;
-    width: 100%;
+    @include text-cta-btn-inline;
 
     .padder {
       display: none;

--- a/site/styles/_cta-buttons.scss
+++ b/site/styles/_cta-buttons.scss
@@ -2,12 +2,12 @@
 @mixin text-cta-btn-inline {
   margin: 0;
   padding: 6px 12px;
-  width: 100%;
   white-space: nowrap;
+  width: 100%;
 
   @include media-breakpoint-up(xs) {
-    width: 140px;
     min-width: fit-content;
+    width: 140px;
   }
 }
 

--- a/site/styles/_cta-buttons.scss
+++ b/site/styles/_cta-buttons.scss
@@ -1,5 +1,5 @@
 /* stylelint-disable selector-max-compound-selectors, max-nesting-depth */
-@mixin text-cta-btn-inline {
+@mixin text-cta-btn {
   margin: 0;
   padding: 6px 12px;
   white-space: nowrap;
@@ -133,7 +133,7 @@
     }
 
     .s72-btn {
-      @include text-cta-btn-inline;
+      @include text-cta-btn;
 
       &:nth-child(2) {
         margin: 0; // RELISH OVERRIDE.
@@ -143,7 +143,7 @@
 
   s72-play-button {
     .s72-btn-play {
-      @include text-cta-btn-inline;
+      @include text-cta-btn;
     }
 
     .s72-btn-play-icon {
@@ -156,7 +156,7 @@
   }
 
   .s72-btn-can-be-watched {
-    @include text-cta-btn-inline;
+    @include text-cta-btn;
 
     .padder {
       display: none;


### PR DESCRIPTION
ADO card: ☑️ [AB#9805](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9805)

## Description of work
- Made it so inline cta buttons now grow when text is wider than button width
- Applies to pricing button, play button, and can be watched button.

### before
![image](https://user-images.githubusercontent.com/32156362/190547977-7f9595f8-f765-4cdd-8f15-789e8addfdd2.png)

## after
![image](https://user-images.githubusercontent.com/32156362/190548253-b19691c9-7dad-4038-ba6a-a0f7d40bc1cc.png)

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
