### PR TITLE
changed nav gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - AB#9564 Live label to film detail page and carousel with translations.
 - AB#9361 Translations for live events, poster live availability status styling changes
 
+### Changed
+- Increased nav height to make gradient larger.
+
 ## [1.5.1](https://github.com/shift72/core-template/compare/1.5.0...1.5.1)
 
 ## Changed

--- a/site/styles/_nav.scss
+++ b/site/styles/_nav.scss
@@ -3,7 +3,7 @@
   background-color: transparent;
   display: flex;
   flex-direction: column;
-  height: auto;
+  height: 190px;
   margin-left: auto;
   margin-right: auto;
   position: absolute;
@@ -11,6 +11,14 @@
   top: 0;
   width: 100%;
   z-index: 9;
+
+  @include media-breakpoint-up(sm) {
+    height: 240px;
+  }
+
+  @include media-breakpoint-up(lg) {
+    height: 358px;
+  }
 
   &.show {
     height: 100%;
@@ -117,7 +125,6 @@
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
-  height: 100%;
   padding: 10px 20px;
   position: relative;
   transition: background-color 0.25s ease-out;


### PR DESCRIPTION
ADO card: ☑️ [AB#9635](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9635)

Designs: 
- https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b/screen/6316b1d45d252d1682cdfdef

## Description of work
Made the nav taller so the gradient can also be taller.

## Edge cases/Caveats/Known issues
- Background images on light theme sites appear washed out.
![image](https://user-images.githubusercontent.com/10665859/190942644-631feaed-99bb-408a-a6ae-8673970e9ca9.png) ![image](https://user-images.githubusercontent.com/10665859/190942919-1b31ec58-6d95-4669-8472-9c0c59090d27.png)
- Background images on dark theme sites appear gloomy. 
![image](https://user-images.githubusercontent.com/10665859/190942759-a3b941b0-a06d-4e34-84a8-f821c713860f.png) 
![image](https://user-images.githubusercontent.com/10665859/190942859-36f7aa88-a4c5-4726-b4ac-9200af5f4caf.png)



### Affected Clients
 - All clients with background/carousel images.

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [x] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
