### PR TITLE
Ab#9668 credit card validation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - AB#9564 Live label to film detail page and carousel with translations.
 - AB#9361 Translations for live events, poster live availability status styling changes
 - Translations for live event purchase flow.
+- Translations for credit card expiry validation.
 
 ### Fixed
 - Inline cta buttons now grow when text is wider than button width

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1563,5 +1563,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "لا يمكنك إرجاعه."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "تاريخ انتهاء صلاحية بطاقتك في الماضي."
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1566,5 +1566,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "تاريخ انتهاء صلاحية بطاقتك في الماضي."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "انقضت سنة انتهاء صلاحية بطاقتك."
   }
 }

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1567,7 +1567,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "تاريخ انتهاء صلاحية بطاقتك في الماضي."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "انقضت سنة انتهاء صلاحية بطاقتك."
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La data de caducitat de la vostra targeta és del passat."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "L'any de caducitat de la vostra targeta és del passat."
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "No pots rebobinar-lo."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "La data de caducitat de la vostra targeta és del passat."
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La data de caducitat de la vostra targeta és del passat."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "L'any de caducitat de la vostra targeta és del passat."
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Dit korts udløbsdato ligger i fortiden."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Dit korts udløbsår er i fortiden."
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Du kan ikke spole den tilbage."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Dit korts udløbsdato ligger i fortiden."
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Dit korts udløbsdato ligger i fortiden."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Dit korts udløbsår er i fortiden."
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Das Ablaufdatum Ihrer Karte liegt in der Vergangenheit."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Das Ablaufjahr Ihrer Karte liegt in der Vergangenheit."
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Sie können es nicht zurückspulen."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Das Ablaufdatum Ihrer Karte liegt in der Vergangenheit."
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Das Ablaufdatum Ihrer Karte liegt in der Vergangenheit."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Das Ablaufjahr Ihrer Karte liegt in der Vergangenheit."
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Δεν μπορείτε να το επανατυλίξετε."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Η ημερομηνία λήξης της κάρτας σας είναι παρελθόν."
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Η ημερομηνία λήξης της κάρτας σας είναι παρελθόν."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Το έτος λήξης της κάρτας σας είναι παρελθόν."
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Η ημερομηνία λήξης της κάρτας σας είναι παρελθόν."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Το έτος λήξης της κάρτας σας είναι παρελθόν."
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "You cannot rewind it."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Your card's expiration date is in the past."
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Your card's expiration date is in the past."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Your card's expiration year is in the past."
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Your card's expiration date is in the past."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Your card's expiration year is in the past."
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1503,5 +1503,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "No puedes rebobinarlo."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "La fecha de vencimiento de su tarjeta ya pasó."
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1507,7 +1507,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La fecha de vencimiento de su tarjeta ya pasó."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "El año de vencimiento de su tarjeta está en el pasado."
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1506,5 +1506,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La fecha de vencimiento de su tarjeta ya pasó."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "El año de vencimiento de su tarjeta está en el pasado."
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1503,5 +1503,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "No puedes rebobinarlo."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "La fecha de vencimiento de su tarjeta ya pasó."
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1507,7 +1507,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La fecha de vencimiento de su tarjeta ya pasó."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "El año de vencimiento de su tarjeta está en el pasado."
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1506,5 +1506,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La fecha de vencimiento de su tarjeta ya pasó."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "El año de vencimiento de su tarjeta está en el pasado."
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Teie kaardi aegumiskuupäev on minevik."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Teie kaardi aegumisaasta on möödas."
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Te ei saa seda tagasi kerida."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Teie kaardi aegumiskuupäev on minevik."
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Teie kaardi aegumiskuupäev on minevik."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Teie kaardi aegumisaasta on möödas."
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Korttisi viimeinen voimassaolopäivä on mennyt."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Korttisi vanhentumisvuosi on mennyt."
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Et voi kelata sitä taaksepäin."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Korttisi viimeinen voimassaolopäivä on mennyt."
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Korttisi viimeinen voimassaolopäivä on mennyt."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Korttisi vanhentumisvuosi on mennyt."
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1507,7 +1507,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La date d'expiration de votre carte est dans le passé."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "L'année d'expiration de votre carte est dans le passé."
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1506,5 +1506,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La date d'expiration de votre carte est dans le passé."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "L'année d'expiration de votre carte est dans le passé."
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1503,5 +1503,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Vous ne pouvez pas le rembobiner."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "La date d'expiration de votre carte est dans le passé."
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1501,5 +1501,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Ne možete ga premotati unatrag."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Datum isteka vaše kartice je u prošlosti."
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1504,5 +1504,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Datum isteka vaše kartice je u prošlosti."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Godina isteka vaše kartice je u prošlosti."
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1505,7 +1505,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Datum isteka vaše kartice je u prošlosti."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Godina isteka vaše kartice je u prošlosti."
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Kártyája lejárati dátuma a múltban van."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "A kártya lejárati éve már a múltban van."
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Kártyája lejárati dátuma a múltban van."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "A kártya lejárati éve már a múltban van."
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Nem lehet visszatekerni."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Kártyája lejárati dátuma a múltban van."
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1506,5 +1506,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La data di scadenza della tua carta è nel passato."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "L'anno di scadenza della tua carta è nel passato."
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1507,7 +1507,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "La data di scadenza della tua carta è nel passato."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "L'anno di scadenza della tua carta è nel passato."
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1503,5 +1503,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Non puoi riavvolgerlo."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "La data di scadenza della tua carta è nel passato."
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1486,5 +1486,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "巻き戻しはできません。"
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "カードの有効期限が過ぎています。"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1489,5 +1489,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "カードの有効期限が過ぎています。"
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "カードの有効期限が過ぎています。"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1490,7 +1490,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "カードの有効期限が過ぎています。"
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "カードの有効期限が過ぎています。"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1534,5 +1534,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Jūsų kortelės galiojimo laikas yra praeityje."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Jūsų kortelės galiojimo laikas yra praeityje."
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1535,7 +1535,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Jūsų kortelės galiojimo laikas yra praeityje."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Jūsų kortelės galiojimo laikas yra praeityje."
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1531,5 +1531,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Jūs negalite jo atsukti."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Jūsų kortelės galiojimo laikas yra praeityje."
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "De vervaldatum van uw kaart ligt in het verleden."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Het vervaljaar van uw kaart is in het verleden."
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "De vervaldatum van uw kaart ligt in het verleden."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Het vervaljaar van uw kaart is in het verleden."
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Je kunt het niet terugspoelen."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "De vervaldatum van uw kaart ligt in het verleden."
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Kortets utløpsdato er i fortiden."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Kortets utløpsår er i fortiden."
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Kortets utløpsdato er i fortiden."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Kortets utløpsår er i fortiden."
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Du kan ikke spole den tilbake."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Kortets utløpsdato er i fortiden."
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1576,5 +1576,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Nie możesz go cofnąć."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Data ważności Twojej karty już minęła."
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1580,7 +1580,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Data ważności Twojej karty już minęła."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Rok ważności Twojej karty już minął."
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1579,5 +1579,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Data ważności Twojej karty już minęła."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Rok ważności Twojej karty już minął."
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1503,5 +1503,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Você não pode rebobinar."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "A data de validade do seu cartão está no passado."
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1507,7 +1507,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "A data de validade do seu cartão está no passado."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "O ano de validade do seu cartão está no passado."
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1506,5 +1506,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "A data de validade do seu cartão está no passado."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "O ano de validade do seu cartão está no passado."
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1503,5 +1503,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Você não pode rebobinar."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "A data de validade do seu cartão está no passado."
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1507,7 +1507,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "A data de validade do seu cartão está no passado."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "O ano de validade do seu cartão está no passado."
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1506,5 +1506,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "A data de validade do seu cartão está no passado."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "O ano de validade do seu cartão está no passado."
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1553,5 +1553,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Вы не можете перемотать его назад."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Срок действия вашей карты истек."
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1557,7 +1557,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Срок действия вашей карты истек."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Срок действия вашей карты истек."
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1556,5 +1556,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Срок действия вашей карты истек."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Срок действия вашей карты истек."
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1519,7 +1519,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Датум истека ваше картице је у прошлости."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Година истека ваше картице је у прошлости."
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1515,5 +1515,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Не можете га премотати."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Датум истека ваше картице је у прошлости."
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1518,5 +1518,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Датум истека ваше картице је у прошлости."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Година истека ваше картице је у прошлости."
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1499,5 +1499,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Geri saramazsınız."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Kartınızın son kullanma tarihi geçmişte."
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1502,5 +1502,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Kartınızın son kullanma tarihi geçmişte."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Kartınızın son kullanma yılı geçmişte kaldı."
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1503,7 +1503,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Kartınızın son kullanma tarihi geçmişte."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Kartınızın son kullanma yılı geçmişte kaldı."
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1559,5 +1559,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "Ви не можете перемотати його назад."
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "Термін дії вашої картки минув."
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1562,5 +1562,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Термін дії вашої картки минув."
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "Рік закінчення терміну дії вашої картки минув."
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1563,7 +1563,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "Термін дії вашої картки минув."
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Рік закінчення терміну дії вашої картки минув."
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1486,5 +1486,8 @@
   },
   "shopping_info_release_date_explanation5_live_event_rent": {
     "other": "你不能倒帶。"
+  },
+  "shopping_error_stripe_invalid_expiry_month_past": {
+    "other": "您卡的過期日期已過。"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1489,5 +1489,8 @@
   },
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "您卡的過期日期已過。"
+  },
+  "shopping_error_stripe_invalid_expiry_year_pastt": {
+    "other": "您的卡的到期年份已過去。"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1490,7 +1490,7 @@
   "shopping_error_stripe_invalid_expiry_month_past": {
     "other": "您卡的過期日期已過。"
   },
-  "shopping_error_stripe_invalid_expiry_year_pastt": {
+  "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "您的卡的到期年份已過去。"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#9668](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9668)

## Description of work
Added translations for credit card expiry date validations.

## Related PRs 

### Any PRs dependent on this one
- https://github.com/indiereign/shift72-web/pull/352

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
