### PR TITLE
fixed broken tv detail page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Translations for credit card expiry validation.
 
 ### Fixed
-- Inline cta buttons now grow when text is wider than button width
+- Inline cta buttons now grow when text is wider than button width.
+- TV season detail page layout now matches film detail page layout.
 
 ### Fixed
 - Gap below page-collections consistent with sliders

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -23,12 +23,15 @@
     </div>
     <div class="container">
       <div class="meta-detail-main">
-        {{if config("default_image_type") == "portrait"}}
-          <div class="poster poster-portrait">
-            <s72-image src="{{tvseason.Images.Classification}}" alt="" class="classification-image">
-            <s72-image src="{{tvseason.Images.Portrait}}" alt="{{tvseason.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
-          </div>
-        {{end}}
+        <div class="poster-wrapper">
+          {{if config("default_image_type") == "portrait"}}
+            <div class="poster poster-portrait">
+              <s72-image src="{{tvseason.Images.Classification}}" alt="" class="classification-image">
+              <s72-image src="{{tvseason.Images.Portrait}}" alt="{{tvseason.Title}}" class="poster poster-image poster-image-portrait"></s72-image>
+            </div>
+          {{end}}
+        </div>
+
         <div class="meta-detail-content">
           <h1>{{tvseason.GetTitle(i18n)}}</h1>
           <div class="meta-detail-tagline-and-classification">


### PR DESCRIPTION
ADO card: ☑️ [AB#9938](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9938)

## Description of work
Added poster wrapper element on tv detail page to un-break the layout and match the film detail page layout.

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
