### PR TITLE
shopping_error_stripe_invalid_number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - AB#9564 Live label to film detail page and carousel with translations.
 - AB#9361 Translations for live events, poster live availability status styling changes
 - Translations for live event purchase flow.
-- Translations for credit card expiry validation.
+- Translations for credit card validation errors.
 
 ### Fixed
 - Inline cta buttons now grow when text is wider than button width

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1569,5 +1569,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "انقضت سنة انتهاء صلاحية بطاقتك."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "رقم بطاقتك غير صالح."
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "L'any de caducitat de la vostra targeta és del passat."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "El vostre número de targeta no és vàlid."
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Dit korts udløbsår er i fortiden."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Dit kortnummer er ugyldigt."
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Das Ablaufjahr Ihrer Karte liegt in der Vergangenheit."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Ihre Kartennummer ist ungültig."
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Το έτος λήξης της κάρτας σας είναι παρελθόν."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Ο αριθμός της κάρτας σας δεν είναι έγκυρος."
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Your card's expiration year is in the past."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Your card number is invalid."
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1509,5 +1509,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "El año de vencimiento de su tarjeta está en el pasado."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Su número de tarjeta no es válido."
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1509,5 +1509,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "El año de vencimiento de su tarjeta está en el pasado."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Su número de tarjeta no es válido."
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Teie kaardi aegumisaasta on möödas."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Teie kaardi number on kehtetu."
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Korttisi vanhentumisvuosi on mennyt."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Korttisi numero on virheellinen."
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1509,5 +1509,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "L'année d'expiration de votre carte est dans le passé."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Votre numéro de carte est invalide."
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1507,5 +1507,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Godina isteka vaše kartice je u prošlosti."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Broj vaše kartice je nevažeći."
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "A kártya lejárati éve már a múltban van."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "A kártyaszám érvénytelen."
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1509,5 +1509,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "L'anno di scadenza della tua carta è nel passato."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Il numero della tua carta non è valido."
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1492,5 +1492,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "カードの有効期限が過ぎています。"
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "カード番号が無効です。"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1537,5 +1537,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Jūsų kortelės galiojimo laikas yra praeityje."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Jūsų kortelės numeris neteisingas."
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Het vervaljaar van uw kaart is in het verleden."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Uw kaartnummer is ongeldig."
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Kortets utløpsår er i fortiden."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Kortnummeret ditt er ugyldig."
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1582,5 +1582,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Rok ważności Twojej karty już minął."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Numer Twojej karty jest nieprawidłowy."
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1509,5 +1509,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "O ano de validade do seu cartão está no passado."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "O número do seu cartão é inválido."
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1509,5 +1509,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "O ano de validade do seu cartão está no passado."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "O número do seu cartão é inválido."
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1559,5 +1559,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Срок действия вашей карты истек."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Номер вашей карты недействителен."
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1521,5 +1521,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Година истека ваше картице је у прошлости."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Број ваше картице је неважећи."
   }
 }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1505,5 +1505,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Kartınızın son kullanma yılı geçmişte kaldı."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Kart numaranız geçersiz."
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1565,5 +1565,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "Рік закінчення терміну дії вашої картки минув."
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "Номер вашої картки недійсний."
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1492,5 +1492,8 @@
   },
   "shopping_error_stripe_invalid_expiry_year_past": {
     "other": "您的卡的到期年份已過去。"
+  },
+  "shopping_error_stripe_invalid_number": {
+    "other": "您的卡號無效。"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#9935](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/9935)

## Description of work
More credit card validation error translations.


## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
