### PR TITLE
AB#8701 Don't autoplay trailer when in carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - Inline cta buttons now grow when text is wider than button width.
 - TV season detail page layout now matches film detail page layout.
+- Trailer autoplay disabled for CTA buttons in homepage carousel.
 
 ### Fixed
 - Gap below page-collections consistent with sliders

--- a/site/templates/collection/carousel/item.jet
+++ b/site/templates/collection/carousel/item.jet
@@ -37,8 +37,8 @@
             {{end}}
 
             <s72-availability-label data-slug="{{item.Slug}}"></s72-availability-label>
-            
-            {{yield ctaButtons(itemType=item.ItemType) item.InnerItem}}
+
+            {{yield ctaButtons(itemType=item.ItemType, context="carousel") item.InnerItem}}
 
 
           </div>

--- a/site/templates/common/cta_buttons.jet
+++ b/site/templates/common/cta_buttons.jet
@@ -1,10 +1,11 @@
 {{import "./social-media-buttons.jet"}}
 
-{{block ctaButtons(itemType)}}
+{{block ctaButtons(itemType, context="item")}}
   {{isFilm := itemType == "film"}}
   {{isSeason := itemType == "tvseason"}}
   {{isEpisode := itemType == "tvepisode"}}
   {{isBundle := itemType == "bundle"}}
+  {{isCarousel := context == "carousel"}}
 
   {{slug := .Slug}}
   {{trailerURL := isBundle ? .PromoURL : (isFilm || isSeason) && len(.Trailers) > 0 ? .Trailers[0].URL : ""}}
@@ -15,9 +16,11 @@
   {{showTrailerButton := trailerURL != ""}}
   {{showWishlistButton := isFilm || isSeason || isEpisode}}
   {{showShareButton := isFilm || isSeason || isEpisode || isBundle}}
+  {{autoplay := !isCarousel}}
 
   {{showCtaButtons := showPricingButtons || showPlayButton || showCanBeWatchedButton || showTrailerButton || showWishlistButton || showShareButton}}
   {{showExtraButtons := showTrailerButton || showWishlistButton || showShareButton}}
+
 
   {{if showCtaButtons}}
     <div class="cta-buttons">
@@ -41,7 +44,7 @@
 
           {{if showTrailerButton}}
             {{dataLabel := i18n("play_trailer")}}
-            <s72-modal-player src="{{trailerURL}}" class="s72-btn-trailer" data-slug="{{slug}}" data-label="{{dataLabel}}" autoplay="querystring" layout="tooltip"></s72-modal-player>
+            <s72-modal-player src="{{trailerURL}}" class="s72-btn-trailer" data-slug="{{slug}}" data-label="{{dataLabel}}" {{if autoplay}}autoplay="querystring"{{end}} layout="tooltip"></s72-modal-player>
           {{end}}
 
           {{if showWishlistButton}}


### PR DESCRIPTION
ADO card: ☑️ [AB#8701](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/8701)

If a trailer button (inside a CTA buttons component) is rendered within the carousel, disable the autoplay if the querystring '?autoplay' is provided, to stop multiple modals with trailers opening up.

Alternatively a solution could lie in Relish, if the s72PlayerModal component looked for multiple such components and not respond to autoplay requests if there's more than one of them on the page. 🤷 

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
