### PR TITLE
mv award categories on detail page, adjust margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Translations for live event purchase flow.
 - Translations for credit card validation errors.
 - Translations for new card timing out error.
+- Award categories moved to above film description
 
 ### Fixed
 - Inline cta buttons now grow when text is wider than button width.

--- a/site/styles/_awards.scss
+++ b/site/styles/_awards.scss
@@ -4,16 +4,11 @@
   &.meta-awards-all {
     display: grid;
     gap: 30px 104px;
-    grid-auto-rows: 1fr;
-    margin-bottom: 51px;
-    margin-top: -14px;
+    margin-bottom: 0px;
+    margin-top: 20px;
 
     @include media-breakpoint-up(md) {
       grid-template-columns: repeat(2, minmax(0, 320px));
-    }
-
-    @include media-breakpoint-up(lg) {
-      margin-bottom: 52px;
     }
   }
 

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -61,6 +61,8 @@
             <br>
           {{end}}
 
+          {{yield awardNominations() film}}
+
           <div class="element-switcher-wrapper">
             <s72-element-switcher>
               {{if isEnabled("element_switcher_enabled")}}
@@ -150,7 +152,6 @@
             </s72-element-switcher>
             {{yield sponsor() film}}
           </div>
-          {{yield awardNominations() film}}
           {{if len(film.Bonuses) > 0 && !film.CustomFields.GetBool("hide_bonus_content", false)}}
             <section class="meta-detail-bonus-content" aria-label="{{i18n("meta_detail_bonus_title")}}">
               <h2>{{i18n("meta_detail_bonus_title")}}</h2>


### PR DESCRIPTION
ADO card: ☑️ [AB#10063](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/10063)

Designs: https://app.zeplin.io/project/5fdaa165fbacf584a2ce4f8b?seid=6343624823578b179d193e35

## Description of work
The designs changed again, have to move the awards back to where they were and adjust margin to designs.

### Affected Clients
 - All clients who use Kibble

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
