### PR TITLE
clean up branding

### DIFF
--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "En col·laboració amb"

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "i samarbejde med"

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "in einer Beziehung mit"

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "in partnership with"

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "koostöös"

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -6,10 +6,10 @@
     "other": "Powered by"
   },
   "powered_by_name": {
-    "other": "ScreenPlus"
+    "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "in partnership with"

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "u suradnji s"

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "in partnership with"

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "in partnership with"

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -6,10 +6,10 @@
     "other": "Powered by"
   },
   "powered_by_name": {
-    "other": "ScreenPlus"
+    "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "in partnership with"

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "in partnership with"

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -6,7 +6,7 @@
     "other": "Distribuído por"
   },
   "powered_by_name": {
-    "other": "ScreenPlus"
+    "other": "Shift72"
   },
   "powered_by_url": {
     "other": "https://www.shift72.com"

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -9,7 +9,7 @@
     "other": "Shift72"
   },
   "powered_by_url": {
-    "other": "https://www.screenplus.com"
+    "other": "https://www.shift72.com"
   },
   "in_partnership_with": {
     "other": "у партнерстві з"


### PR DESCRIPTION
Make the default footer branding consistent to be Shift72 / www.shift72.com

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
