### PR TITLE
AB#10213 Element switcher wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Pricing buttons no longer get squashed in Firefox.
+- Spacing issues on small screens
 
 ## [1.6.0](https://github.com/shift72/core-template/compare/1.5.1...1.6.0)
 

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -416,9 +416,12 @@ s72-element-switcher,
 
 .element-switcher-wrapper {
   display: grid;
-  gap: 50px;
   grid-template-columns: auto auto;
   width: 100%;
+
+  @include media-breakpoint-up(lg) {
+    gap: 50px;
+  }
 
   .sponsor {
     display: none;


### PR DESCRIPTION
ADO card: ☑️ [AB#10213](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/10213)

As per card, the 50px gap is unnecessary at smaller widths.

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
