### PR TITLE
Support aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Pricing buttons no longer get squashed in Firefox.
 - Spacing issues on small screens
+- Images not taking up space before being loaded in
 
 ## [1.6.0](https://github.com/shift72/core-template/compare/1.5.1...1.6.0)
 

--- a/site/styles/_poster.scss
+++ b/site/styles/_poster.scss
@@ -41,4 +41,12 @@
   max-width: 100%;
   position: relative;
   width: 100%;
+
+  &-portrait {
+    aspect-ratio: var(--image-ratio-poster-portrait);
+  }
+
+  &-landscape {
+    aspect-ratio: var(--image-ratio-poster-landscape);
+  }
 }

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -136,6 +136,9 @@
   --subtitle-2-style-font-size: 14px;
   --caption-1-style-font-size: 16px;
   --overline-style-font-size: 14px;
+
+  --image-ratio-poster-portrait: 4 / 6;
+  --image-ratio-poster-landscape: 6 / 4;
 }
 
 // Bootstrap 4 overrides START


### PR DESCRIPTION
ADO card: ☑️ [AB#10172](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/10172)

## Description of work
This card reduces layout shift on image load, which is considered bad.

This change is good for SEO, but also looks nicer, and helps dev things that rely on correct height calculations on page load (This personally has caused issues for me working on the floating donate button, and working on slider image lazy load in)

### Affected Clients
 - Safest just to roll this out with template upgrade/new clients and update image ratio css var if they use custom images

## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] If there are designs for this work are they noted here and in the ADO card 
- [x] Design review
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
