### PR TITLE
fixed episode container issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Pricing buttons no longer get squashed in Firefox.
 - Spacing issues on small screens
+- Fixed episode description container issue.
 
 ## [1.6.0](https://github.com/shift72/core-template/compare/1.5.1...1.6.0)
 

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -161,8 +161,8 @@
     animation: fadein 2s;
     display: block;
     flex-shrink: 0;
-    margin-right: 20px;
     margin-bottom: 20px;
+    margin-right: 20px;
     width: 110px;
 
     @include media-breakpoint-up(xs) {
@@ -183,9 +183,9 @@
   }
 
   .poster-wrapper .sponsor {
-      @include media-breakpoint-up(lg) {
-        display: none;
-      }
+    @include media-breakpoint-up(lg) {
+      display: none;
+    }
   }
 
   .meta-detail-content {

--- a/site/templates/tv/detail.jet
+++ b/site/templates/tv/detail.jet
@@ -81,9 +81,7 @@
               <h2>{{i18n("meta_detail_episodes_title")}}</h2>
               {{yield list(itemsPerRow=4, itemLayout="portrait") content}}
                 {{range episode := tvseason.Episodes}}
-                  <div class="sub-item">
-                    {{yield subItem(item=episode)}}
-                  </div>
+                  {{yield subItem(item=episode)}}
                 {{end}}
               {{end}}
             </div>


### PR DESCRIPTION
ADO card: ☑️ [AB#10630](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/10630)

## Description of work
Removed extra/unwanted container around episodes from tv detail jet so content no longer gets squashed.

Also ran the CSS linter.


## Checklist
- [x] CI tests are passing Github actions (inc. linting)
- [x] Key areas of the feature outlined for context and testing
- [x] Have checked this at multiple screen resolutions and range of browsers
- [x] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [x] Updated changelog (if applicable)
- [x] I promise to document any new feature toggles/configurations in the appropriate documentation
