### PR TITLE
add trailing slash to tv season url path

### DIFF
--- a/kibble.json
+++ b/kibble.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "tvItem",
-      "urlPath": "/tv/:slug/:seasonNumber",
+      "urlPath": "/tv/:slug/:seasonNumber/",
       "templatePath": "templates/tv/detail.jet",
       "partialUrlPath": "/partials/tv/:showID/season/:seasonNumber.html",
       "partialTemplatePath": "templates/tv/partial.jet",


### PR DESCRIPTION
ADO card: ☑️ [AB#7318](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/7318)

I'm not clear on why this bug wasn't occurring when running a site locally but was occurring on staging.  Also not clear on why the tvItem urlPath didn't have a trailing slash because the other routes do.  But adding that trailing slash in seems to fix the issue.  Tested on staging-store-kibble clicking links to tv season pages and to specific episodes... both seem to work fine.

Credit goes to Louis for pointing me at the Lonely Planet repo where I spotted this trailing slash discrepancy.