### PR TITLE
AB#10786 fix runtime showing as 0m for 1 hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Links to specific episodes from collections (inc homepage carousel).
+- 60 mins runtime now shows as 1h 0m.
 
 ## [1.7.0](https://github.com/shift72/core-template/compare/1.6.0...1.7.0)
 

--- a/site/templates/items/tagline.jet
+++ b/site/templates/items/tagline.jet
@@ -17,7 +17,7 @@
 
     {{if isset(.Runtime)}}
       {{yield item(class="runtime") content}}
-        {{if .Runtime > 60}}
+        {{if .Runtime > 59}}
           {{.Runtime.Hours()}}{{i18n("runtime_hours")}}
         {{end}}
         {{.Runtime.Minutes()}}{{i18n("runtime_minutes")}}


### PR DESCRIPTION
ADO card: ☑️ [AB#10786](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/10786)

## Description of work
Setting runtime to 60 mins shows as 0m on frontend, this fix ensures if 60 mins is entered, then it will show the hour. 

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
