### PR TITLE
AB#10996 Add styles for the relish auth selector

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1653,5 +1653,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "أعد محاولة التحقق من صحة البريد الإلكتروني"
+  },
+  "auth_selector_info": {
+    "other": "مطلوب حساب لشراء هذا المحتوى."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "عضوا فعلا؟ تسجيل الدخول"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "إنشاء حساب"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "أو"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Torna a provar la validació del correu electrònic"
+  },
+  "auth_selector_info": {
+    "other": "Es necessita un compte per comprar aquest contingut."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Ja ets membre? Inicia sessió"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Crear compte"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "o"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Prøv e-mailvalidering igen"
+  },
+  "auth_selector_info": {
+    "other": "En konto er nødvendig for at købe dette indhold."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "allerede medlem? Log ind"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Opret konto"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "eller"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "E-Mail-Validierung erneut versuchen"
+  },
+  "auth_selector_info": {
+    "other": "Zum Kauf dieser Inhalte ist ein Konto erforderlich."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Schon ein Mitglied? anmelden"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Benutzerkonto erstellen"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "oder"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Δοκιμάστε ξανά την επικύρωση μέσω email"
+  },
+  "auth_selector_info": {
+    "other": "Απαιτείται λογαριασμός για την αγορά αυτού του περιεχομένου."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Ήδη μέλος; Συνδεθείτε"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Δημιουργήστε λογαριασμό"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "ή"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Retry email validation"
+  },
+  "auth_selector_info": {
+    "other": "An account is needed to purchase this content."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Already a member? Sign in"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Create account"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "or"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1593,5 +1593,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Vuelva a intentar la validación de correo electrónico"
+  },
+  "auth_selector_info": {
+    "other": "Se necesita una cuenta para comprar este contenido."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "¿Ya eres usuario? Iniciar sesión"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Crear una cuenta"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "o"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1593,5 +1593,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Vuelva a intentar la validación de correo electrónico"
+  },
+  "auth_selector_info": {
+    "other": "Se necesita una cuenta para comprar este contenido."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "¿Ya eres usuario? Iniciar sesión"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Crear una cuenta"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "o"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Proovige meili kinnitamist uuesti"
+  },
+  "auth_selector_info": {
+    "other": "Selle sisu ostmiseks on vaja kontot."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Oled juba liige? Logi sisse"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Loo konto"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "või"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Yritä sähköpostin vahvistusta uudelleen"
+  },
+  "auth_selector_info": {
+    "other": "Tämän sisällön ostamiseen tarvitaan tili."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "joko olet jäsen? Kirjaudu sisään"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Luo tili"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "tai"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1593,5 +1593,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Réessayez la validation de l'e-mail"
+  },
+  "auth_selector_info": {
+    "other": "Un compte est nécessaire pour acheter ce contenu."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Déjà membre? S'identifier"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Créer un compte"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "ou"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1591,5 +1591,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Ponovi provjeru valjanosti e-pošte"
+  },
+  "auth_selector_info": {
+    "other": "Za kupnju ovog sadržaja potreban je račun."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "već si član? Prijaviti se"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Napravi račun"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "ili"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Próbálja újra az e-mail érvényesítést"
+  },
+  "auth_selector_info": {
+    "other": "A tartalom megvásárlásához fiók szükséges."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Már tag? Bejelentkezés"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Fiók létrehozása"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "vagy"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1592,6 +1592,18 @@
     "other": "Si è verificato un errore sconosciuto durante la creazione del tuo account. Prova ad aggiornare la pagina o a contattare l'amministratore del sito."
   },
   "signup_form_error_email_verification_link_text": {
-    "other": "Riprova la convalida dell'email"
+    "other": "Riprova la convalida dell'e-mail"
+  },
+  "auth_selector_info": {
+    "other": "È necessario un account per acquistare questo contenuto."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "sei già un membro? Registrazione"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Creare un account"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "O"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1576,5 +1576,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "メールの検証を再試行する"
+  },
+  "auth_selector_info": {
+    "other": "このコンテンツを購入するにはアカウントが必要です。"
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "すでにメンバーですか？ログイン"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "アカウントを作成する"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "また"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1621,5 +1621,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Bandykite patvirtinti el. paštu dar kartą"
+  },
+  "auth_selector_info": {
+    "other": "Norint įsigyti šį turinį, reikalinga paskyra."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Jau narys? Prisijungti"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Sukurti paskyrą"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "arba"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Probeer de e-mailvalidatie opnieuw"
+  },
+  "auth_selector_info": {
+    "other": "Er is een account nodig om deze inhoud te kopen."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Al lid? Aanmelden"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Account aanmaken"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "of"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1540,7 +1540,7 @@
     "other": "Besøk oss på Letterboxd"
   },
   "validate_email_about": {
-    "other": "For å opprette en konto må vi først bekrefte e-postadressen din. Skriv inn e-postadressen din, så sender vi en invitasjon til kontoregistrering."
+    "other": "For å opprette en konto må vi først bekrefte e-postadressen din. Skriv inn e-postadressen din, så sender vi en invitasjon til å registrere deg."
   },
   "validate_email_success": {
     "other": "En bekreftelses-e-post er sendt til {{.Email}} . Vennligst sjekk e-posten din og følg instruksjonene for kontooppretting."
@@ -1585,9 +1585,21 @@
     "other": "Det oppstod en ukjent feil under validering av e-postadressen din. Prøv å oppdatere siden eller kontakt nettstedadministratoren din."
   },
   "signup_form_error_generic": {
-    "other": "Det oppsto en ukjent feil under opprettelsen av kontoen din. Prøv å oppdatere siden eller kontakt nettstedadministratoren din."
+    "other": "Det oppstod en ukjent feil under opprettelsen av kontoen din. Prøv å oppdatere siden eller kontakt nettstedadministratoren din."
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Prøv e-postvalidering på nytt"
+  },
+  "auth_selector_info": {
+    "other": "En konto er nødvendig for å kjøpe dette innholdet."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Allerede medlem? Logg inn"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Opprett konto"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "eller"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1666,5 +1666,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Ponów weryfikację adresu e-mail"
+  },
+  "auth_selector_info": {
+    "other": "Do zakupu tej zawartości potrzebne jest konto."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Jesteś już członkiem? Zalogować się"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Utwórz konto"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "Lub"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1593,5 +1593,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Repetir a validação de e-mail"
+  },
+  "auth_selector_info": {
+    "other": "É necessária uma conta para comprar este conteúdo."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "já é um membro? Entrar"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Criar uma conta"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "ou"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1593,5 +1593,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Repetir a validação de e-mail"
+  },
+  "auth_selector_info": {
+    "other": "É necessária uma conta para comprar este conteúdo."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "já é um membro? Entrar"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Criar uma conta"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "ou"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1643,5 +1643,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Повторить проверку электронной почты"
+  },
+  "auth_selector_info": {
+    "other": "Для покупки этого контента необходима учетная запись."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Уже вступил? Войти"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Зарегистрироваться"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "или"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1605,5 +1605,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Поновите проверу е-поште"
+  },
+  "auth_selector_info": {
+    "other": "За куповину овог садржаја потребан је налог."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Већ сте члан? Пријавите се"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Региструј се"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "или"
   }
 }

--- a/site/styles/_forms.scss
+++ b/site/styles/_forms.scss
@@ -116,12 +116,12 @@ s72-activatedevice-form,
   &.s72-form-control-readonly,
   &.s72-form-control-readonly:focus {
     border: 0;
-    cursor: not-allowed;
     color: rgba(var(--body-color-rgb), 0.5);
+    cursor: not-allowed;
     outline: none;
 
     /* Make sure all text based inputs have the right padding */
-    &input:not([type=submit]):not([type=file]) {
+    &input:not([type='submit']):not([type='file']) {
       padding: 0.375rem 0.75rem;
     }
   }

--- a/site/styles/_shift72.scss
+++ b/site/styles/_shift72.scss
@@ -114,6 +114,39 @@
   }
 }
 
+.s72-auth-selector {
+  padding-bottom: 10px;
+
+  p {
+    text-align: center;
+  }
+
+  .s72-auth-selector-buttons {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    & > * {
+        width: 80%;
+    }
+  }
+
+  .s72-or-divider {
+    display: flex;
+    padding: 0 10px;
+    margin: 16px 0;
+    width: 75%;
+
+    hr {
+      flex: 1;
+    }
+
+    div {
+      padding: 0 10px;
+    }
+  }
+}
+
 .s72-combined-auth-email {
   @extend .alert;
   @extend .alert-secondary;

--- a/site/styles/_shift72.scss
+++ b/site/styles/_shift72.scss
@@ -122,19 +122,19 @@
   }
 
   .s72-auth-selector-buttons {
+    align-items: center;
     display: flex;
     flex-direction: column;
-    align-items: center;
 
-    & > * {
-        width: 80%;
+    > * {
+      width: 80%;
     }
   }
 
   .s72-or-divider {
     display: flex;
-    padding: 0 10px;
     margin: 16px 0;
+    padding: 0 10px;
     width: 75%;
 
     hr {

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1589,5 +1589,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "E-posta doğrulamasını yeniden dene"
+  },
+  "auth_selector_info": {
+    "other": "Bu içeriği satın almak için bir hesap gereklidir."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Zaten bir üye misiniz? Kayıt olmak"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Hesap oluşturmak"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "veya"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1649,5 +1649,17 @@
   },
   "signup_form_error_email_verification_link_text": {
     "other": "Повторіть перевірку електронної пошти"
+  },
+  "auth_selector_info": {
+    "other": "Щоб придбати цей вміст, потрібен обліковий запис."
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "Вже учасник? Увійти"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "Створити акаунт"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "або"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1572,9 +1572,21 @@
     "other": "驗證您的電子郵件地址時出現未知錯誤。嘗試刷新頁面或聯繫您的站點管理員。"
   },
   "signup_form_error_generic": {
-    "other": "創建您的帳戶時出現未知錯誤。嘗試刷新頁面或聯繫您的站點管理員。"
+    "other": "創建您的帳戶時出現未知錯誤。嘗試刷新頁面或聯繫您的網站管理員。"
   },
   "signup_form_error_email_verification_link_text": {
     "other": "重試電子郵件驗證"
+  },
+  "auth_selector_info": {
+    "other": "購買此內容需要一個帳戶。"
+  },
+  "auth_selector_sign_in_button_text": {
+    "other": "已經是會員？登入"
+  },
+  "auth_selector_sign_up_button_text": {
+    "other": "創建賬戶"
+  },
+  "auth_selector_or_divider_text": {
+    "other": "或者"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#10996](https://dev.azure.com/S72/SHIFT72/_workitems/edit/10996)

This PR is part of xxxx Relish PR to add in support for showing a UI to clients with the `validate_email` feature toggle enabled that will bypass the shopping modal sign in flow since it does not support verifying email addresses for sign up.
