### PR TITLE
proof of concept

### DIFF
--- a/kibble.json
+++ b/kibble.json
@@ -1,113 +1,13 @@
 {
   "name": "core-template",
   "version": "0.0.1",
-  "siteUrl": "https://tvoddemo.shift72.com",
+  "siteUrl": "https://staging-letterboxd.shift72.com",
   "builderVersion": "0.17.0",
   "defaultLanguage": "en",
   "languages": {
-    "ar": {
-      "code": "ar_LB",
-      "name": "عربى"
-    },
-    "ca": {
-      "code": "ca_ES",
-      "name": "Català"
-    },
-    "da": {
-      "code": "da_DK",
-      "name": "Dansk"
-    },
-    "de": {
-      "code": "de_DE",
-      "name": "Deutsch"
-    },
-    "et": {
-      "code": "et_ET",
-      "name": "Eestlane"
-    },
-    "el": {
-      "code": "el_EL",
-      "name": "Ελληνικά"
-    },
     "en": {
       "code": "en_AU",
       "name": "English"
-    },
-    "es": {
-      "code": "es_ES",
-      "name": "Español"
-    },
-    "es-mx": {
-      "code": "es_MX",
-      "name": "Español"
-    },
-    "fi": {
-      "code": "fi_FI",
-      "name": "Suomi"
-    },
-    "fr": {
-      "code": "fr_FR",
-      "name": "Français"
-    },
-    "hr": {
-      "code": "hr_HR",
-      "name": "Hrvatski"
-    },
-    "hu": {
-      "code": "hu_HU",
-      "name": "Magyar"
-    },
-    "it": {
-      "code": "it_IT",
-      "name": "Italiano"
-    },
-    "ja": {
-      "code": "ja_JP",
-      "name": "日本語"
-    },
-    "lt": {
-      "code": "lt_LT",
-      "name": "Lietuvių Kalba"
-    },
-    "nl": {
-      "code": "nl_BE",
-      "name": "Nederlands"
-    },
-    "no": {
-      "code": "no_NO",
-      "name": "Norsk"
-    },
-    "pl": {
-      "code": "pl_PL",
-      "name": "Polski"
-    },
-    "pt": {
-      "code": "pt_PT",
-      "name": "Português"
-    },
-    "pt-br": {
-      "code": "pt_BR",
-      "name": "Português do Brasil"
-    },
-    "ru": {
-      "code": "ru_RU",
-      "name": "Pусский"
-    },
-    "sr": {
-      "code": "sr_SR",
-      "name": "Српски"
-    },
-    "tr": {
-      "code": "tr_TR",
-      "name": "Türk"
-    },
-    "uk": {
-      "code": "uk_UA",
-      "name": "Український"
-    },
-    "zh-tw": {
-      "code": "zh_TW",
-      "name": "中文"
     }
   },
   "siteRootPath": "site",
@@ -125,69 +25,6 @@
       "partialUrlPath": "/partials/film/:filmID.html",
       "partialTemplatePath": "templates/film/partial.jet",
       "datasource": "Film",
-      "pageSize": 0
-    },
-    {
-      "name": "filmIndex",
-      "urlPath": "/film/",
-      "templatePath": "404.html.jet",
-      "datasource": "FilmIndex",
-      "pageSize": 0
-    },
-    {
-      "name": "tvItem",
-      "urlPath": "/tv/:slug/:seasonNumber/",
-      "templatePath": "templates/tv/detail.jet",
-      "partialUrlPath": "/partials/tv/:showID/season/:seasonNumber.html",
-      "partialTemplatePath": "templates/tv/partial.jet",
-      "datasource": "TVSeason",
-      "pageSize": 0
-    },
-    {
-      "name": "tvEpisode",
-      "urlPath": "/tv/:slug/:seasonNumber/#episode-:episodeNumber",
-      "datasource": "TVEpisode",
-      "pageSize": 0
-    },
-    {
-      "name": "pageItem",
-      "urlPath": "/page/:slug/",
-      "templatePath": "templates/page/:type.jet",
-      "partialUrlPath": "/partials/page/:pageID.html",
-      "partialTemplatePath": "templates/page/partial.jet",
-      "datasource": "Page",
-      "pageSize": 0
-    },
-    {
-      "name": "pageIndex",
-      "urlPath": "/page/",
-      "templatePath": "404.html.jet",
-      "datasource": "PageIndex",
-      "pageSize": 0
-    },
-    {
-      "name": "bundleItem",
-      "urlPath": "/bundle/:slug/",
-      "templatePath": "templates/bundle/item.jet",
-      "partialUrlPath": "/partials/bundle/:bundleID.html",
-      "partialTemplatePath": "templates/bundle/partial.jet",
-      "datasource": "Bundle",
-      "pageSize": 0
-    },
-    {
-      "name": "bundleIndex",
-      "urlPath": "/bundle/",
-      "templatePath": "404.html.jet",
-      "datasource": "BundleIndex",
-      "pageSize": 0
-    },
-    {
-      "name": "collectionItem",
-      "urlPath": "/collection/:slug/",
-      "templatePath": "templates/collection/item.jet",
-      "partialUrlPath": "/partials/collection/:collectionID.html",
-      "partialTemplatePath": "templates/collection/partial.jet",
-      "datasource": "Collection",
       "pageSize": 0
     }
   ],

--- a/site/iframe.html.jet
+++ b/site/iframe.html.jet
@@ -1,0 +1,17 @@
+{* THIS FILE IS HERE TO SIMULATE LETTERBOXD'S MODAL *}
+
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+
+  <body>
+    <iframe
+      id="s72-purchase-iframe"
+      title="Shift72 Purchase Iframe"
+      width="600"
+      height="2000"
+      src="/purchase.html?slug=/film/3257"
+    ></iframe>
+  </body>
+</html>

--- a/site/purchase.html.jet
+++ b/site/purchase.html.jet
@@ -1,8 +1,5 @@
-{{import "./head/font.jet" }}
-{{import "./head/seo.jet" }}
-{{import "./nav/nav.jet"}}
-{{import "./google.jet" }}
-{{import "./footer/footer.jet" }}
+{{import "./templates/application/head/font.jet" }}
+{{import "./templates/application/head/seo.jet" }}
 
 {{CDN := "//cdn.shift72.com/1.3"}}
 {{CDN := "//localhost:3000"}}
@@ -11,7 +8,7 @@
 {*{CSSFileURL := "/styles/local.css"}*}
 
 <!DOCTYPE html>
-<html lang="{{lang.Code}}">
+<html lang={{lang.Code}}>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -68,24 +65,8 @@
 
     <script type="text/javascript" src="/scripts/swiper.min.js"></script>
   </head>
+
   <body>
-
-    <h2 class="sr-only">{{i18n("wcag_skip_links_header")}}</h2>
-    <a class="skip-link" href="#main">{{i18n("wcag_skip_links_content")}}</a>
-
-    <s72-cookie-consent></s72-cookie-consent>
-
-    {{yield googleTagManagerNoScript()}}
-
-    {{block navigation()}}
-      {{yield nav() }}
-    {{end}}
-
-    {{yield body()}}
-
-    {{yield footer()}}
-
-    {{yield googleScripts()}}
-    <s72-donate-button></s72-donate-button>
+    <s72-shopping-iframe></s72-shopping-iframe>
   </body>
 </html>


### PR DESCRIPTION
ADO card: ☑️ [AB#11086](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11086)

This is just proof of concept for the Letterboxd iframe purchase flow.  Not intended to be merged.

Relish draft PR is [here](https://github.com/indiereign/shift72-web/pull/412).

What I've done:
- Gutted languages and routes from kibble.json for faster build times while testing... this is not necessary for the iframe solution, however it is something we may want to consider doing if the client has no interest in supporting pages outside the iframe purchase flow.
- Added purchase.jet.  This jet contains the prototype s72-shopping-iframe Relish component to show the purchase flow without needing a modal.  It also has complete html markup including head and body tags unlike every other jet... this is because application.jet (which other jets normally extend) includes the nav and footer etc which we don't want in purchase.jet.
- Added iframe.jet.  This jet is just here for testing.  It contains an iframe element which targets purchase.jet to simulate how Letterboxd might use purchase.jet.