### PR TITLE
AB#11220 fix border radius 50%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.8.0...HEAD)
 
+### Fixed
+- Border radius for longer width buttons
+
 
 ## [1.8.0](https://github.com/shift72/core-template/compare/1.7.0...1.8.0)
 

--- a/site/styles/_buttons.scss
+++ b/site/styles/_buttons.scss
@@ -228,7 +228,7 @@ s72-userwishlist-button {
   > * {
     &:hover {
       background-color: var(--hover-background);
-      border-radius: 50%;
+      border-radius: 999em;
     }
   }
 

--- a/site/styles/_nav.scss
+++ b/site/styles/_nav.scss
@@ -370,7 +370,7 @@
   .btn-search-close {
     background: transparent;
     border: 0;
-    border-radius: 50%;
+    border-radius: 999em;
     color: var(--body-color);
     font-size: 24px;
     line-height: 0;


### PR DESCRIPTION
ADO card: ☑️ [AB#11220](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11220)

found a couple of cases of border-radius: 50% which works fine with square buttons but goes oval if you have custom button widths. tested both fixes locally. 