### PR TITLE
AB#11072 GA refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Nav mobile top padding to meet design spec
 
+### Fixed
+- GA4 tracking of ecommerce data
+
 ## [1.9.1](https://github.com/shift72/core-template/compare/1.9.0...1.9.1)
 
 ### Changed

--- a/site/templates/application/google.jet
+++ b/site/templates/application/google.jet
@@ -15,12 +15,12 @@
     {{if hasPrefix(analyticsId,"G")}}
     {* Load GA4 code snippet and gtag function if G tracking code is provided, else use legacy UA code snippet *}
       <script>
-        window.dataLayer = window.dataLayer || [];
-        gtag = function(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '{{analyticsId}}', { 'debug_mode':true });
-
         function loadGA4() {
+          window.dataLayer = window.dataLayer || [];
+          window.gtag = function(){dataLayer.push(arguments);}
+          window.gtag('js', new Date());
+          window.gtag('config', '{{analyticsId}}');
+
           (function(d, googleId){var f = d.getElementsByTagName('script')[0];var s = d.createElement('script');
           s.src = 'https://www.googletagmanager.com/gtag/js?id=' + googleId;s.async = true;f.parentNode.insertBefore(s,f);
           }(document,'{{analyticsId}}'));
@@ -50,25 +50,28 @@
 
     var cookieConsentRequired = {{ isEnabled("frontend_cookie_consent") }};
 
+    function loadGoogleScripts() {
+      if(googleTagManagerEnabled) { 
+        loadGoogleTagManager(); 
+      }
+      if(googleAnalyticsEnabled) {
+        if(googleAnalyticsTrackingCode.startsWith("G")) {
+          loadGA4(); 
+        }
+        else {
+          loadGUA();
+        }
+      }
+    }
+
     document.addEventListener('s72loaded', function(event) {
       if(!cookieConsentRequired || event.detail.app.hasCookieConsent()) {
-        if(googleTagManagerEnabled) { 
-          loadGoogleTagManager(); 
-        }
-        if(googleAnalyticsEnabled) {
-          if(googleAnalyticsTrackingCode.startsWith("G")) {
-            loadGA4(); 
-          }
-          else {
-            loadGUA();
-          }
-        }
+        loadGoogleScripts();
       }
       else {
         // Listen for an 'accept' of the cookie consent, in which case load google tag manager
         event.detail.app.messagebus.subscribe('cookie-consent-set', function(event) {
-          if(googleTagManagerEnabled) { loadGoogleTagManager(); }
-          if(googleAnalyticsEnabled) {  loadGoogleAnalytics(); }
+          loadGoogleScripts();
         });
       }
     });

--- a/site/templates/application/google.jet
+++ b/site/templates/application/google.jet
@@ -1,48 +1,68 @@
 {{block googleScripts(tagManagerId=config("google_tag_manager_id"), analyticsId=config("google_analytics_id"))}}
   <!-- Google integration scripts -->
-  <script>
-    function loadGoogleTagManager() {
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-      var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-      j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','{{ tagManagerId }}')}
-
-    <!-- GA4 code snippet if G tracking code is provided, else use legacy UA code snippet -->
-    {{if hasPrefix(analyticsId,"G")}}
-      function loadGoogleAnalytics() {
-        (function(d, googleId){var f = d.getElementsByTagName('script')[0];var s = d.createElement('script');
-        s.src = 'https://www.googletagmanager.com/gtag/js?id=' + googleId;s.async = true;f.parentNode.insertBefore(s,f);
-        }(document,'{{analyticsId}}'));
-
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', '{{analyticsId}}');
-      }
-    {{else}}
-      function loadGoogleAnalytics() {
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', '{{analyticsId}}', 'auto');
-        ga('require', 'ecommerce');
-        ga('send', 'pageview');
-      }
+  
+    {{if len(tagManagerId) > 0}}
+    {* Load GTM code snippet if Tag Manager ID is provided *} 
+      <script>
+        function loadGoogleTagManager() {
+          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+          var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+          j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','{{ tagManagerId }}')};
+      </script>
     {{end}}
 
+    {{if hasPrefix(analyticsId,"G")}}
+    {* Load GA4 code snippet and gtag function if G tracking code is provided, else use legacy UA code snippet *}
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        gtag = function(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{analyticsId}}', { 'debug_mode':true });
+
+        function loadGA4() {
+          (function(d, googleId){var f = d.getElementsByTagName('script')[0];var s = d.createElement('script');
+          s.src = 'https://www.googletagmanager.com/gtag/js?id=' + googleId;s.async = true;f.parentNode.insertBefore(s,f);
+          }(document,'{{analyticsId}}'));
+        };
+      </script>
+    
+    {{else}}
+      <script>
+        function loadGUA() {
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+          ga('create', '{{analyticsId}}', 'auto');
+          ga('require', 'ecommerce');
+          ga('send', 'pageview');
+        }
+      </script>
+    {{end}}
+
+    <script>
     // Only load Google Tag Manager if a/ the frontend cookie consent isn't required or b/ they've agreed to the cookie consent
     var googleTagManagerEnabled = {{ (len(tagManagerId) > 0) ? "true" : "false" }};
     var googleAnalyticsEnabled = {{ (len(analyticsId) > 0) ? "true" : "false" }};
+    var googleAnalyticsTrackingCode = '{{analyticsId}}';
 
     var cookieConsentRequired = {{ isEnabled("frontend_cookie_consent") }};
 
     document.addEventListener('s72loaded', function(event) {
       if(!cookieConsentRequired || event.detail.app.hasCookieConsent()) {
-        if(googleTagManagerEnabled) { loadGoogleTagManager(); }
-        if(googleAnalyticsEnabled) {  loadGoogleAnalytics(); }
+        if(googleTagManagerEnabled) { 
+          loadGoogleTagManager(); 
+        }
+        if(googleAnalyticsEnabled) {
+          if(googleAnalyticsTrackingCode.startsWith("G")) {
+            loadGA4(); 
+          }
+          else {
+            loadGUA();
+          }
+        }
       }
       else {
         // Listen for an 'accept' of the cookie consent, in which case load google tag manager
@@ -52,7 +72,7 @@
         });
       }
     });
-  </script>
+    </script>
   <!-- End Google integration scripts -->
 {{end}}
 


### PR DESCRIPTION
ADO card: ☑️ [AB#11072](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11072)

## Description of work
Refactor how we initialise the google scripts / functions for collecting traffic and ecommerce data. The ecommerce data is sent via relish https://github.com/indiereign/shift72-web/pull/426
I've changed the logic slightly so it only loads GTM if theres a GTM code, and initialised the gtag function globally

## Edge cases/Caveats/Known issues
- May break clients existing setups with ecommerce data sent to GTM and forward on to UA, but this will be unsupported end of June anyway and clients should be upgrading to GA4

## Config settings/Toggles required for the feature to work
- Client needs google admin toggle for it to show the settings to set GA / GTM tracking codes, and have either of those setup.

## Related PRs 

### Any PRs which this PR depends on
https://github.com/indiereign/shift72-web/pull/426

### Affected Clients
 - All clients with GA settings enabled / ga codes set.

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
