### PR TITLE
add config to hide or change forgot password link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.9.1...HEAD)
 
+### Added
+- Configuration to change or remove the forgot password link
+
 ### Changed
 - Nav mobile top padding to meet design spec
 

--- a/site/signin.html.jet
+++ b/site/signin.html.jet
@@ -8,7 +8,10 @@
   <main id="main" class="page form-page">
     <div class="page-header">
       <h1>{{ i18n("signin_page_header") }}</h1>
-      <p><a href="{{ routeToPath("/forgotpassword.html") }}">{{ i18n("signin_page_forgotpassword")}}</a></p>
+      {{forgot_password_link := config("forgot_password_link")}}
+      {{if forgot_password_link != "hide"}}
+        <p><a href="{{ forgot_password_link == "" ? routeToPath("/forgotpassword.html") : forgot_password_link }}">{{ i18n("signin_page_forgotpassword")}}</a></p>
+      {{end}}
     </div>
     <div class="page-form">
       <div class="form-container">


### PR DESCRIPTION
ADO card: ☑️ [AB#11274](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11274)

## Description of work
Add a config that allows us to hide or change the forgot password link for SSO clients. Config can be set to either "hide" or a url to modify the forgotpassword link, otherwise it will keep the default path. Context: For new SSO with integrated IDP there will simply be the button or a redirect on the signin page so we can just hide it in those cases. For proxy shared accounts, client require to change the url to link off to their sites to change password (like on docedge https://vc.docedge.nz/signin.html) so we can edit the url for those clients also. 

Note: ive used one config to both hide or change the url. We separate these if its nicer - feature toggle for hide forgot password / config for forgot password link.

## Edge cases/Caveats/Known issues
- forgotpassword.html and resetpassword.html pages are still rendered
## Config settings/Toggles required for the feature to work
- User > Configs > forgot_password_link (public) - set to "hide" to hide the link or a url to link elsewhere

### Affected Clients
 - All clients who use Kibble - backward compatible

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
