### PR TITLE
AB#11422 hide or modify my account from user menu via new config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Configuration to change or remove the forgot password link
+- Configuration to change or remove the my account link
 
 ### Changed
 - Nav mobile top padding to meet design spec

--- a/site/templates/application/nav/user_logged_in.jet
+++ b/site/templates/application/nav/user_logged_in.jet
@@ -31,9 +31,11 @@
             <a class="s72-dropdown-item" href="{{ routeToPath("/subscriptions.html") }}">{{i18n("nav_subscriptions")}}</a>
           </li>
         {{ end }}
+        {{if config("myaccount_disabled") != "true" }}
         <li>
           <a class="s72-dropdown-item" href="{{ routeToPath("/account.html") }}">{{i18n("nav_account")}}</a>
         </li>
+        {{end}}
         <li>
           <s72-sign-out class="s72-dropdown-item sign-out-desktop" >
             <a href="#" class="btn-sign-out btn-sign-out-desktop">{{i18n("nav_signout")}}</a>

--- a/site/templates/application/nav/user_logged_in.jet
+++ b/site/templates/application/nav/user_logged_in.jet
@@ -33,8 +33,17 @@
         {{ end }}
         {{my_account_link := config("my_account_link")}}
         {{if my_account_link != "hide"}}
+          {{href := my_account_link == "" ? routeToPath("/account.html") : my_account_link}}
           <li>
-            <a class="s72-dropdown-item" href="{{ my_account_link == "" ? routeToPath("/account.html") : my_account_link }}">{{i18n("nav_account")}}</a>
+            <a 
+              class="s72-dropdown-item" 
+              href="{{href}}"
+              {{if my_account_link != ""}}
+                target="_blank"
+              {{end}}
+            >
+              {{i18n("nav_account")}}
+            </a>
           </li>
         {{end}}
         <li>

--- a/site/templates/application/nav/user_logged_in.jet
+++ b/site/templates/application/nav/user_logged_in.jet
@@ -31,10 +31,11 @@
             <a class="s72-dropdown-item" href="{{ routeToPath("/subscriptions.html") }}">{{i18n("nav_subscriptions")}}</a>
           </li>
         {{ end }}
-        {{if config("myaccount_disabled") != "true" }}
-        <li>
-          <a class="s72-dropdown-item" href="{{ routeToPath("/account.html") }}">{{i18n("nav_account")}}</a>
-        </li>
+        {{my_account_link := config("my_account_link")}}
+        {{if my_account_link != "hide"}}
+          <li>
+            <a class="s72-dropdown-item" href="{{ my_account_link == "" ? routeToPath("/account.html") : my_account_link }}">{{i18n("nav_account")}}</a>
+          </li>
         {{end}}
         <li>
           <s72-sign-out class="s72-dropdown-item sign-out-desktop" >


### PR DESCRIPTION
ADO card: ☑️ [AB#11422](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11422)

## Description of work
Add a config that allows us to hide or change the "My Account" link in the user subnav for SSO clients. Config can be set to either "hide" or a url to modify the my account link, otherwise it will keep the default path. Context: For new SSO with integrated IDP accounts are managed on their side, meaning the My Account page will not work, name / password will need to be updated on the client side. For proxy shared accounts, client require to change the url to link off to their sites to change password (like on docedge https://vc.docedge.nz/signin.html) so we can edit the url for those clients also.

Note: ive used one config to both hide or change the url. We separate these if its nicer - feature toggle for hide forgot password / config for my account link.

## Edge cases/Caveats/Known issues
- myaccount page is still rendered on build, its just not linked to on the site anymore

## Config settings/Toggles required for the feature to work
- Users > Config > my_account_link (public) = hide or url. if left blank or not set then the default my account page will stay.

### Affected Clients
 - All clients who use Kibble

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
