### PR TITLE
create css vars for button styles, flex position the oauth signin but…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 - Configuration to change or remove the forgot password link
 - Configuration to change or remove the my account link
+- Styling for SSO buttons
+- CSS variables for change default button colors
 
 ### Changed
 - Nav mobile top padding to meet design spec

--- a/site/styles/_buttons.scss
+++ b/site/styles/_buttons.scss
@@ -41,6 +41,25 @@
     font-size: 16px;
   }
 }
+// OAuth
+.s72-oauth-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 10px;
+
+  .btn-sso {
+    background-color: var(--signin-sso-btn-background-color);
+    color: var(--signin-sso-btn-text-color);
+    &:hover,
+    &:focus {
+      background-color: var(--signin-sso-btn-background-hover-color);
+      color: var(--signin-sso-btn-text-hover-color);
+    }
+  }
+}
 
 .s72-btn.s72-btn-block {
   @extend .btn-block;

--- a/site/styles/_buttons.scss
+++ b/site/styles/_buttons.scss
@@ -43,11 +43,11 @@
 }
 // OAuth
 .s72-oauth-buttons {
-  display: flex;
   align-items: center;
-  justify-content: center;
+  display: flex;
   flex-direction: column;
   gap: 20px;
+  justify-content: center;
   margin-top: 10px;
 
   .btn-sso {

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -85,11 +85,22 @@
   --signin-background-hover: var(--hover-background);
   --signin-background-lg: transparent;
   --signin-background-hover-lg: transparent;
-
   --signout-background: rgba(var(--body-color-rgb), 0.1);
   --signout-background-hover: rgba(var(--body-color-rgb), 0.2);
   --signout-text-color: var(--body-color);
   --signout-text-color-hover: var(--body-color);
+
+  // Buttons
+  --button-text-color: var(--body-bg);
+  --button-text-color-hover: var(--body-bg);
+  --button-background: var(--primary);
+  --button-background-hover: var(--secondary);
+  --trailer-button-text-color: var(--body-color);
+  --mobile-nav-link-color: var(--body-color);
+  --signin-sso-btn-text-color: var(--button-text-color);
+  --signin-sso-btn-text-hover-color: var(--button-text-color-hover);
+  --signin-sso-btn-background-color: var(--button-background);
+  --signin-sso-btn-background-hover-color: var(--button-background-hover);
 
   --carousel-height: 75vh;
   --carousel-height-sm: 75vh;
@@ -251,12 +262,12 @@ $navbar-dark-color: var(--body-color) !default;
 $navbar-dark-hover-color: #fd4766 !default;
 
 // Buttons
-$button-text-color: var(--body-bg) !default;
-$button-text-color-hover: var(--body-bg) !default;
-$button-background: var(--primary) !default;
-$button-background-hover: var(--secondary) !default;
-$trailer-button-text-color: var(--body-color) !default;
-$mobile-nav-link-color: var(--body-color) !default;
+$button-text-color: var(--button-text-color) !default;
+$button-text-color-hover: var(--button-text-color-hover) !default;
+$button-background: var(--button-background) !default;
+$button-background-hover: var(--button-background-hover) !default;
+$trailer-button-text-color: var(--trailer-button-text-color) !default;
+$mobile-nav-link-color: var(--mobile-nav-link-color) !default;
 
 $signup-text-color: $button-text-color !default;
 $signup-text-color-hover: $button-text-color-hover !default;


### PR DESCRIPTION
…tons

ADO card: ☑️ [AB#11406](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11406)

## Description of work
Style the SSO buttons with default btn styles but also have css vars if they need to be changed in the shared template. Also brought default button styles in as css variables, as its currently a mission to style buttons in shared template. To test this PR you can run core template locally against staging-store-kibble.shift72.com or dl.locarnofestival.ch.


### Affected Clients
 - All clients who use Kibble

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
