### PR TITLE
AB#11366 fix select box on windows.

### DIFF
--- a/site/styles/_forms.scss
+++ b/site/styles/_forms.scss
@@ -101,7 +101,7 @@ s72-activatedevice-form,
 
   /* stylelint-disable-next-line */
   &:not(.StripeElement) {
-    background-color: transparent;
+    background-color: $body-bg-accent;
     border-color: rgba(var(--body-color-rgb), 0.6);
     color: var(--body-color);
     &:focus {


### PR DESCRIPTION
ADO card: ☑️ AB#11366

## Description of work
transparency was making white text on white background. we need to revert it back to using accent colour (https://github.com/shift72/core-template/commit/baacb58af4fc7656e1ade71ce4d28efe0612671e#diff-f2625d1be21270859db401ee99c897b5da278b1d7639153f87c1b2eba18a0525R104) which will keep it standard with the inputs and theme variables to work with light / dark theme. 

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
