### PR TITLE
Ab#11453 token trampoline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.9.3...HEAD)
+- Added page for signing users in across domains
 
 ## [1.9.3](https://github.com/shift72/core-template/compare/1.9.2...1.9.3)
 ### Added

--- a/site/authpass.html.jet
+++ b/site/authpass.html.jet
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <script type="text/javascript">
+    let [key, val] = window.location.hash.slice(1).split("=");
+    if (key === "token") {
+      fetch("/services/users/detail/users", {
+        headers: {
+          'X-Auth-Token': val
+        }
+      }).then(res => res.json()).then(res => {
+        localStorage.setItem("shift72.user", JSON.stringify(res.account.users[0]));
+        localStorage.setItem("shift72.authToken", JSON.stringify(val));
+      }).finally(() => {
+        window.location.href = "about:blank";
+      });
+    }
+  </script>
+</head>
+
+</html>


### PR DESCRIPTION
ADO card: ☑️ [AB#11453](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11453)

Elab notes/AC: 📃 [Google Docs](https://docs.google.com/document/d/1z8rWGsEWWkk4jDiIzpVA399_zEM5WVoMRiLqkbBFFsA/edit)
- [x] Has this been discussed with Delivery Team?

Designs: 
- 📱 [Mobile](https://cdn.dribbble.com/users/58639/screenshots/3788063/936.jpg)
- 💊 [Tablet](https://cdn.dribbble.com/users/58639/screenshots/3788063/936.jpg)
- 🖥 [Desktop](https://cdn.dribbble.com/users/58639/screenshots/3788063/936.jpg)

## Description of work
A trampoline for bouncing auth tokens from Ferve into our site from a different domain. Creates a new page that can be embedded in the background with an iframe, which can pass the auth token in via hash segment of the url, which then gets added to local storage for the domain of the Shift site.

## Edge cases/Caveats/Known issues
- Sitelock blocks it, for testing this can be bypassed by manually navigating to authpass.html once in the browser and entering site lock before testing it from another domain.

## Config settings/Toggles required for the feature to work
- N/A

## Related PRs 

### Any PRs which this PR depends on
- Nah

### Any PRs dependent on this one
- Nuh uh

### Affected Clients
 - Anyone who integrates with Ferve could benefit from this once Ferve know about it. MIFF/Docedge etc

## Checklist
- [x] Wear cowboy hat 🤠 
