### PR TITLE
 AB#11677 config to disable letterboxd share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.9.5...HEAD)
 ### Added
 - Facebook / meta pixel support
+- Ability to disable letterboxd share
 
 ## [1.9.5](https://github.com/shift72/core-template/compare/1.9.4...1.9.5)
 ### Changed

--- a/site/templates/common/cta_buttons.jet
+++ b/site/templates/common/cta_buttons.jet
@@ -62,7 +62,7 @@
           {{end}}
 
           {{if showShareButton}}
-            {{letterboxdID := isFilm && !isEnabled("disable_letterboxd_share") ? .Refs.LetterboxdID : ""}}
+            {{letterboxdID := isFilm && config("show_letterboxd_share", "true") == "true" ? .Refs.LetterboxdID : ""}}
             {{shareURL := site.SiteConfig.SiteURL + routeToSlug(slug)}}
             {{yield socialMediaButtons(url=shareURL, letterboxdID=letterboxdID)}}
           {{end}}

--- a/site/templates/common/cta_buttons.jet
+++ b/site/templates/common/cta_buttons.jet
@@ -62,7 +62,7 @@
           {{end}}
 
           {{if showShareButton}}
-            {{letterboxdID := isFilm ? .Refs.LetterboxdID : ""}}
+            {{letterboxdID := isFilm && !isEnabled("disable_letterboxd_share") ? .Refs.LetterboxdID : ""}}
             {{shareURL := site.SiteConfig.SiteURL + routeToSlug(slug)}}
             {{yield socialMediaButtons(url=shareURL, letterboxdID=letterboxdID)}}
           {{end}}


### PR DESCRIPTION
ADO card: ☑️ [AB#11677](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11677)

## Description of work
Feature toggle to not show the letterboxd option in the share modal.

## Config settings/Toggles required for the feature to work
- User > config: show_letterboxd_share (public)

### Affected Clients
 - All clients who use Kibble


## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
