### PR TITLE
S72 Checkout local dev support

### DIFF
--- a/kibble.json
+++ b/kibble.json
@@ -117,6 +117,9 @@
       "js"
     ]
   },
+  "proxy": [
+    "^/checkout/"
+  ],
   "routes": [
     {
       "name": "filmItem",

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -56,9 +56,9 @@
 
     {{if checkoutDevMode}}
       <script>window.S72_CHECKOUT_OVERRIDE_URL = 'http://localhost:4072'</script>
-      <script src="http://localhost:4072/s72.checkout.js"></script> 
+      <script src="http://localhost:4072/s72.checkout.js" defer></script> 
     {{else if useCheckout}}
-      <script src="/checkout/s72.checkout.js" async></script>
+      <script src="/checkout/s72.checkout.js" defer></script>
     {{end}}
 
     <script src="https://js.stripe.com/v3/" defer></script>

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -50,6 +50,13 @@
     <script src="/scripts/main.js" defer></script>
 
     <script src="{{CDN}}/s72.transactional.js" defer></script>
+
+    {* S72 Checkout: eventually this will be hosted somewhere like /checkout/s72.checkout.js *}
+    <script src="http://localhost:4072/s72.checkout.js" defer></script>
+
+    {* Enable local dev on the checkout app. This is used by Relish when starting the checkout to point it at the dev server *}
+    <script>window.S72_CHECKOUT_OVERRIDE_URL = 'http://localhost:4072'</script>
+
     <script src="https://js.stripe.com/v3/" defer></script>
 
     {* get default language from site record or kibble.json depening on if db translations is enabled *}  

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -10,6 +10,9 @@
 {{CSSFileURL := site.SiteBrand.GetLink("css", "")}}
 {*{CSSFileURL := "/styles/local.css"}*}
 
+{{checkoutDevMode := false}}
+{{useCheckout := site.Toggles["use_checkout"] || checkoutDevMode}}
+
 <!DOCTYPE html>
 <html lang="{{lang.Code}}">
   <head>
@@ -51,11 +54,12 @@
 
     <script src="{{CDN}}/s72.transactional.js" defer></script>
 
-    {* S72 Checkout: eventually this will be hosted somewhere like /checkout/s72.checkout.js *}
-    <script src="http://localhost:4072/s72.checkout.js" defer></script>
-
-    {* Enable local dev on the checkout app. This is used by Relish when starting the checkout to point it at the dev server *}
-    <script>window.S72_CHECKOUT_OVERRIDE_URL = 'http://localhost:4072'</script>
+    {{if checkoutDevMode}}
+      <script>window.S72_CHECKOUT_OVERRIDE_URL = 'http://localhost:4072'</script>
+      <script src="http://localhost:4072/s72.checkout.js"></script> 
+    {{else if useCheckout}}
+      <script src="/checkout/s72.checkout.js" async></script>
+    {{end}}
 
     <script src="https://js.stripe.com/v3/" defer></script>
 


### PR DESCRIPTION
Support for using the Shift72 Checkout.

If toggled on (users > use_checkout) it will slip in a script tag for the checkout launcher. There's a change in relish that will show the checkout rather than new purchase flow if this toggle is on.

To support local dev, I've added a `checkoutDevMode` variable at the top of application.jet. 

### See also 
- https://github.com/indiereign/shift72-web/pull/434

### Affected Clients
 - Hopefully nobody, behind a feature toggle
 
## Checklist
- [x] <img width="22" src="https://github.com/shift72/core-template/assets/98778140/3293ad04-771e-47da-94e6-38ba77e8a75a" style="vertical-align:middle">

