### PR TITLE
pages to handle user self deletion story

### DIFF
--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1725,5 +1725,38 @@
   },
   "pricing_from": {
     "other": "شاهد من"
+  },
+  "confirm_delete_header": {
+    "other": "تأكيد الحذف"
+  },
+  "confirm_delete_message": {
+    "other": "هذا الإجراء دائم ولا يمكن التراجع عنه! بعد حذف حسابك، سيتم تسجيل خروجك على الفور ولن تتمكن من الوصول إلى مشترياتك بعد الآن."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "تم حذف الحساب!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "لقد تم حذف حسابك بنجاح."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "حذف"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "حذف الحساب"
+  },
+  "confirm_delete_error_generic": {
+    "other": "لم نتمكن من حذف حسابك. الرجاء معاودة المحاولة في وقت لاحق."
+  },
+  "account_form_request_delete": {
+    "other": "حذف الحساب"
+  },
+  "account_form_request_delete_message": {
+    "other": "سيتم إرسال بريد إلكتروني إليك لتأكيد حذف حسابك."
+  },
+  "account_form_account_delete_failed": {
+    "other": "حدث خطأ ما أثناء محاولة إرسال بريد إلكتروني لحذف الحساب، يرجى المحاولة مرة أخرى لاحقًا."
+  },
+  "account_form_request_delete_button": {
+    "other": "طلب الحذف"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Mira des de"
+  },
+  "confirm_delete_header": {
+    "other": "Confirmeu la supressió"
+  },
+  "confirm_delete_message": {
+    "other": "Aquesta acció és permanent i no es pot desfer! Després d'eliminar el vostre compte, es tancarà la sessió immediatament i ja no podreu accedir a les vostres compres."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Compte suprimit!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "El vostre compte s'ha suprimit correctament."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "esborrant"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Esborrar compte"
+  },
+  "confirm_delete_error_generic": {
+    "other": "No hem pogut suprimir el vostre compte. Siusplau, intenta-ho més tard."
+  },
+  "account_form_request_delete": {
+    "other": "Esborrar compte"
+  },
+  "account_form_request_delete_message": {
+    "other": "Se us enviarà un correu electrònic per confirmar la supressió del vostre compte."
+  },
+  "account_form_account_delete_failed": {
+    "other": "S'ha produït un error en intentar enviar un correu electrònic d'eliminació del compte. Torneu-ho a provar més tard."
+  },
+  "account_form_request_delete_button": {
+    "other": "Sol·licita la supressió"
   }
 }

--- a/site/confirmdelete.html.jet
+++ b/site/confirmdelete.html.jet
@@ -5,7 +5,7 @@
 {{end}}
 
 {{block body()}}
-  <main id="main" class="container page confirm-delete-page">
+  <main id="main" class="container page delete-confirm-page">
     <div class="page-header text-center">
       <h1>{{ i18n("confirm_delete_header") }}</h1>
     </div>

--- a/site/confirmdelete.html.jet
+++ b/site/confirmdelete.html.jet
@@ -9,8 +9,9 @@
     <div class="page-header text-center">
       <h1>{{ i18n("confirm_delete_header") }}</h1>
     </div>
-    <div class="d-flex">
-      <s72-confirm-delete-form />
+    <s72-confirm-delete-form />
+    <div class="page-content">
+      <p>{{ i18n("confirm_delete_message") }}</p>
     </div>
   </main>
 {{end}}

--- a/site/confirmdelete.html.jet
+++ b/site/confirmdelete.html.jet
@@ -1,0 +1,16 @@
+{{extends "templates/application/application.jet"}}
+
+{{block head()}}
+  {{yield seo(title=i18n("confirm_delete_header"), index=false)}}
+{{end}}
+
+{{block body()}}
+  <main id="main" class="container page form-page">
+    <div class="page-header text-center">
+      <h1>{{ i18n("confirm_delete_header") }}</h1>
+    </div>
+    <div class="d-flex">
+      <s72-confirm-delete-form />
+    </div>
+  </main>
+{{end}}

--- a/site/confirmdelete.html.jet
+++ b/site/confirmdelete.html.jet
@@ -5,13 +5,13 @@
 {{end}}
 
 {{block body()}}
-  <main id="main" class="container page form-page">
+  <main id="main" class="container page confirm-delete-page">
     <div class="page-header text-center">
       <h1>{{ i18n("confirm_delete_header") }}</h1>
     </div>
-    <s72-confirm-delete-form />
     <div class="page-content">
       <p>{{ i18n("confirm_delete_message") }}</p>
+      <s72-confirm-delete-form />
     </div>
   </main>
 {{end}}

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Se fra"
+  },
+  "confirm_delete_header": {
+    "other": "Bekræft sletning"
+  },
+  "confirm_delete_message": {
+    "other": "Denne handling er permanent og kan ikke fortrydes! Efter sletning af din konto bliver du logget ud med det samme og vil ikke længere kunne få adgang til dine køb."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Konto slettet!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Din konto er blevet slettet."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "sletter"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Slet konto"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Vi kunne ikke slette din konto. Prøv igen senere."
+  },
+  "account_form_request_delete": {
+    "other": "Slet konto"
+  },
+  "account_form_request_delete_message": {
+    "other": "En e-mail vil blive sendt til dig for at bekræfte sletningen af din konto."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Noget gik galt under forsøget på at sende en e-mail til sletning af konto. Prøv venligst igen senere."
+  },
+  "account_form_request_delete_button": {
+    "other": "Anmod om sletning"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Schauen Sie ab"
+  },
+  "confirm_delete_header": {
+    "other": "Löschung bestätigen"
+  },
+  "confirm_delete_message": {
+    "other": "Diese Aktion ist dauerhaft und kann nicht rückgängig gemacht werden! Nach der Löschung Ihres Kontos werden Sie sofort abgemeldet und haben keinen Zugriff mehr auf Ihre Einkäufe."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Konto gelöscht!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Ihr Konto wurde erfolgreich gelöscht."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "löschen"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Konto löschen"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Wir konnten Ihr Konto nicht löschen. Bitte versuchen Sie es später noch einmal."
+  },
+  "account_form_request_delete": {
+    "other": "Konto löschen"
+  },
+  "account_form_request_delete_message": {
+    "other": "Sie erhalten eine E-Mail zur Bestätigung der Löschung Ihres Kontos."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Beim Versuch, eine E-Mail zur Kontolöschung zu senden, ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal."
+  },
+  "account_form_request_delete_button": {
+    "other": "Löschung beantragen"
   }
 }

--- a/site/deleteresult.html.jet
+++ b/site/deleteresult.html.jet
@@ -5,7 +5,7 @@
 {{end}}
 
 {{block body()}}
-  <main id="main" class="page verify-email-page">
+  <main id="main" class="page delete-result-page">
     <div class="page-header">
       <h1>{{ i18n("confirm_delete_success_page_header") }}</h1>
     </div>

--- a/site/deleteresult.html.jet
+++ b/site/deleteresult.html.jet
@@ -1,0 +1,16 @@
+{{extends "templates/application/application.jet"}}
+
+{{block head()}}
+  {{yield seo(title=i18n("confirm_delete_result_page_header"), index=false)}}
+{{end}}
+
+{{block body()}}
+  <main id="main" class="page verify-email-page">
+    <div class="page-header">
+      <h1>{{ i18n("confirm_delete_success_page_header") }}</h1>
+    </div>
+    <div class="page-content">
+      <p>{{ i18n("confirm_delete_success_page_message") }}</p>
+    </div>
+  </main>
+{{end}}

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Παρακολουθήστε από"
+  },
+  "confirm_delete_header": {
+    "other": "Επιβεβαίωση Διαγραφής"
+  },
+  "confirm_delete_message": {
+    "other": "Αυτή η ενέργεια είναι μόνιμη και δεν μπορεί να αναιρεθεί! Μετά τη διαγραφή του λογαριασμού σας θα αποσυνδεθείτε αμέσως και δεν θα έχετε πλέον πρόσβαση στις αγορές σας."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Ο λογαριασμός διαγράφηκε!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Ο λογαριασμός σας διαγράφηκε επιτυχώς."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "διαγραφή"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Διαγραφή λογαριασμού"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Δεν ήταν δυνατή η διαγραφή του λογαριασμού σας. Παρακαλώ δοκιμάστε ξανά αργότερα."
+  },
+  "account_form_request_delete": {
+    "other": "Διαγραφή λογαριασμού"
+  },
+  "account_form_request_delete_message": {
+    "other": "Θα σας σταλεί ένα email για να επιβεβαιώσετε τη διαγραφή του λογαριασμού σας."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Παρουσιάστηκε κάποιο πρόβλημα κατά την προσπάθεια αποστολής ενός μηνύματος ηλεκτρονικού ταχυδρομείου για τη διαγραφή λογαριασμού. Δοκιμάστε ξανά αργότερα."
+  },
+  "account_form_request_delete_button": {
+    "other": "Αίτημα διαγραφής"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Watch from"
+  },
+  "confirm_delete_header": {
+    "other": "Confirm Deletion"
+  },
+  "confirm_delete_message": {
+    "other": "This action is permanent and cannot be undone! After deleting your account you will be logged out immediately and will not be able to access your purchases any more."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Account Deleted!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Your account has been successfully deleted."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "deleting"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Delete Account"
+  },
+  "confirm_delete_error_generic": {
+    "other": "We were unable to delete your account. Please try again later."
+  },
+  "account_form_request_delete": {
+    "other": "Delete Account"
+  },
+  "account_form_request_delete_message": {
+    "other": "An email will be sent to you to confirm your account deletion."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Something went wrong while trying to send an account deletion email, please try again later."
+  },
+  "account_form_request_delete_button": {
+    "other": "Request deletion"
   }
 }

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1665,5 +1665,38 @@
   },
   "pricing_from": {
     "other": "Mirar desde"
+  },
+  "confirm_delete_header": {
+    "other": "Confirmar la eliminación"
+  },
+  "confirm_delete_message": {
+    "other": "¡Esta acción es permanente y no se puede deshacer! Después de eliminar su cuenta, se cerrará su sesión inmediatamente y ya no podrá acceder a sus compras."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "¡Cuenta borrada!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Su cuenta ha sido eliminada exitosamente."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "eliminando"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Borrar cuenta"
+  },
+  "confirm_delete_error_generic": {
+    "other": "No pudimos eliminar su cuenta. Por favor, inténtelo de nuevo más tarde."
+  },
+  "account_form_request_delete": {
+    "other": "Borrar cuenta"
+  },
+  "account_form_request_delete_message": {
+    "other": "Se le enviará un correo electrónico para confirmar la eliminación de su cuenta."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Algo salió mal al intentar enviar un correo electrónico de eliminación de cuenta. Vuelve a intentarlo más tarde."
+  },
+  "account_form_request_delete_button": {
+    "other": "Solicitar eliminación"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1665,5 +1665,38 @@
   },
   "pricing_from": {
     "other": "Mirar desde"
+  },
+  "confirm_delete_header": {
+    "other": "Confirmar la eliminación"
+  },
+  "confirm_delete_message": {
+    "other": "¡Esta acción es permanente y no se puede deshacer! Después de eliminar su cuenta, se cerrará su sesión inmediatamente y ya no podrá acceder a sus compras."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "¡Cuenta borrada!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Su cuenta ha sido eliminada exitosamente."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "eliminando"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Borrar cuenta"
+  },
+  "confirm_delete_error_generic": {
+    "other": "No pudimos eliminar su cuenta. Por favor, inténtelo de nuevo más tarde."
+  },
+  "account_form_request_delete": {
+    "other": "Borrar cuenta"
+  },
+  "account_form_request_delete_message": {
+    "other": "Se le enviará un correo electrónico para confirmar la eliminación de su cuenta."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Algo salió mal al intentar enviar un correo electrónico de eliminación de cuenta. Vuelve a intentarlo más tarde."
+  },
+  "account_form_request_delete_button": {
+    "other": "Solicitar eliminación"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Vaata alates"
+  },
+  "confirm_delete_header": {
+    "other": "Kinnitage kustutamine"
+  },
+  "confirm_delete_message": {
+    "other": "See toiming on püsiv ja seda ei saa tagasi võtta! Pärast konto kustutamist logitakse teid kohe välja ja te ei pääse enam oma ostudele juurde."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Konto kustutatud!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Teie konto on edukalt kustutatud."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "kustutamine"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Kustuta konto"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Me ei saanud teie kontot kustutada. Palun proovi hiljem uuesti."
+  },
+  "account_form_request_delete": {
+    "other": "Kustuta konto"
+  },
+  "account_form_request_delete_message": {
+    "other": "Konto kustutamise kinnitamiseks saadetakse teile e-kiri."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Konto kustutamise meili saatmisel läks midagi valesti. Proovige hiljem uuesti."
+  },
+  "account_form_request_delete_button": {
+    "other": "Taotle kustutamist"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Katso alkaen"
+  },
+  "confirm_delete_header": {
+    "other": "Vahvista poisto"
+  },
+  "confirm_delete_message": {
+    "other": "Tämä toiminto on pysyvä, eikä sitä voi kumota! Tilin poistamisen jälkeen kirjaudut ulos välittömästi etkä voi enää käyttää ostoksia."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Tili poistettu!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Tilisi on poistettu onnistuneesti."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "poistamalla"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Poista tili"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Emme voineet poistaa tiliäsi. Yritä uudelleen myöhemmin."
+  },
+  "account_form_request_delete": {
+    "other": "Poista tili"
+  },
+  "account_form_request_delete_message": {
+    "other": "Sinulle lähetetään sähköposti, jossa vahvistetaan tilisi poistaminen."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Jotain meni pieleen lähetettäessä tilin poistoviestiä. Yritä myöhemmin uudelleen."
+  },
+  "account_form_request_delete_button": {
+    "other": "Pyydä poistamista"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1665,5 +1665,38 @@
   },
   "pricing_from": {
     "other": "Regarder depuis"
+  },
+  "confirm_delete_header": {
+    "other": "Confirmer la suppression"
+  },
+  "confirm_delete_message": {
+    "other": "Cette action est permanente et ne peut être annulée ! Après avoir supprimé votre compte, vous serez immédiatement déconnecté et ne pourrez plus accéder à vos achats."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Compte supprimé !"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Votre compte a été supprimé avec succès."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "suppression"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Supprimer le compte"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Nous n'avons pas pu supprimer votre compte. Veuillez réessayer plus tard."
+  },
+  "account_form_request_delete": {
+    "other": "Supprimer le compte"
+  },
+  "account_form_request_delete_message": {
+    "other": "Un email vous sera envoyé pour confirmer la suppression de votre compte."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Une erreur s'est produite lors de la tentative d'envoi d'un e-mail de suppression de compte. Veuillez réessayer plus tard."
+  },
+  "account_form_request_delete_button": {
+    "other": "Demander la suppression"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1663,5 +1663,38 @@
   },
   "pricing_from": {
     "other": "Gledajte iz"
+  },
+  "confirm_delete_header": {
+    "other": "Potvrdite brisanje"
+  },
+  "confirm_delete_message": {
+    "other": "Ova radnja je trajna i ne može se poništiti! Nakon brisanja računa odmah ćete biti odjavljeni i više nećete moći pristupiti svojim kupnjama."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Račun izbrisan!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Vaš račun je uspješno izbrisan."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "brisanje"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Izbriši račun"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Nismo uspjeli izbrisati vaš račun. Molimo pokušajte ponovo kasnije."
+  },
+  "account_form_request_delete": {
+    "other": "Izbriši račun"
+  },
+  "account_form_request_delete_message": {
+    "other": "Poslat ćemo vam e-poruku da potvrdite brisanje računa."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Nešto nije u redu prilikom pokušaja slanja e-pošte za brisanje računa, pokušajte ponovno kasnije."
+  },
+  "account_form_request_delete_button": {
+    "other": "Zahtjev za brisanje"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Nézd innen"
+  },
+  "confirm_delete_header": {
+    "other": "A törlés megerősítésére"
+  },
+  "confirm_delete_message": {
+    "other": "Ez a művelet végleges, és nem vonható vissza! Fiókja törlése után azonnal kijelentkezik, és többé nem fog tudni hozzáférni vásárlásaihoz."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Fiók törölve!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Fiókját sikeresen töröltük."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "törlése"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Fiók törlése"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Nem tudtuk törölni a fiókját. Kérlek, próbáld újra később."
+  },
+  "account_form_request_delete": {
+    "other": "Fiók törlése"
+  },
+  "account_form_request_delete_message": {
+    "other": "A fiók törlésének megerősítése érdekében e-mailt küldünk Önnek."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Hiba történt a fióktörlési e-mail küldésekor. Kérjük, próbálja újra később."
+  },
+  "account_form_request_delete_button": {
+    "other": "Törlés kérése"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1665,5 +1665,38 @@
   },
   "pricing_from": {
     "other": "Guarda da"
+  },
+  "confirm_delete_header": {
+    "other": "Confermare la cancellazione"
+  },
+  "confirm_delete_message": {
+    "other": "Questa azione è permanente e non può essere annullata! Dopo aver eliminato il tuo account verrai disconnesso immediatamente e non potrai più accedere ai tuoi acquisti."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Account cancellato!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Il tuo account è stato eliminato con successo."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "eliminazione"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Eliminare l'account"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Non siamo riusciti a eliminare il tuo account. Per favore riprova più tardi."
+  },
+  "account_form_request_delete": {
+    "other": "Eliminare l'account"
+  },
+  "account_form_request_delete_message": {
+    "other": "Ti verrà inviata un'email per confermare la cancellazione del tuo account."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Qualcosa è andato storto durante il tentativo di inviare un'e-mail di cancellazione dell'account, riprova più tardi."
+  },
+  "account_form_request_delete_button": {
+    "other": "Richiedi la cancellazione"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1648,5 +1648,38 @@
   },
   "pricing_from": {
     "other": "から見る"
+  },
+  "confirm_delete_header": {
+    "other": "削除の確認"
+  },
+  "confirm_delete_message": {
+    "other": "このアクションは永続的なものであり、元に戻すことはできません。アカウントを削除するとすぐにログアウトされ、購入したものにアクセスできなくなります。"
+  },
+  "confirm_delete_success_page_header": {
+    "other": "アカウントが削除されました!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "アカウントは正常に削除されました。"
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "削除する"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "アカウントを削除する"
+  },
+  "confirm_delete_error_generic": {
+    "other": "アカウントを削除できませんでした。後でもう一度試してください。"
+  },
+  "account_form_request_delete": {
+    "other": "アカウントを削除する"
+  },
+  "account_form_request_delete_message": {
+    "other": "アカウントの削除を確認する電子メールが送信されます。"
+  },
+  "account_form_account_delete_failed": {
+    "other": "アカウント削除メールの送信中に問題が発生しました。しばらくしてからもう一度お試しください。"
+  },
+  "account_form_request_delete_button": {
+    "other": "削除依頼"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1693,5 +1693,38 @@
   },
   "pricing_from": {
     "other": "Žiūrėti iš"
+  },
+  "confirm_delete_header": {
+    "other": "Patvirtinkite ištrynimą"
+  },
+  "confirm_delete_message": {
+    "other": "Šis veiksmas yra nuolatinis ir jo negalima anuliuoti! Ištrynę paskyrą būsite iš karto atsijungę ir nebegalėsite pasiekti savo pirkinių."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Paskyra ištrinta!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Jūsų paskyra sėkmingai ištrinta."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "ištrynimas"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Ištrinti paskyrą"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Nepavyko ištrinti jūsų paskyros. Pabandykite dar kartą vėliau."
+  },
+  "account_form_request_delete": {
+    "other": "Ištrinti paskyrą"
+  },
+  "account_form_request_delete_message": {
+    "other": "Jums bus išsiųstas el. laiškas, patvirtinantis paskyros ištrynimą."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Bandant išsiųsti paskyros ištrynimo el. laišką, kažkas nepavyko. Vėliau bandykite dar kartą."
+  },
+  "account_form_request_delete_button": {
+    "other": "Prašyti ištrinti"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Kijk vanaf"
+  },
+  "confirm_delete_header": {
+    "other": "Bevestig verwijdering"
+  },
+  "confirm_delete_message": {
+    "other": "Deze actie is permanent en kan niet ongedaan worden gemaakt! Nadat u uw account heeft verwijderd, wordt u onmiddellijk uitgelogd en heeft u geen toegang meer tot uw aankopen."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Account verwijderd!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Uw account is succesvol verwijderd."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "verwijderen"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Account verwijderen"
+  },
+  "confirm_delete_error_generic": {
+    "other": "We konden uw account niet verwijderen. Probeer het later opnieuw."
+  },
+  "account_form_request_delete": {
+    "other": "Account verwijderen"
+  },
+  "account_form_request_delete_message": {
+    "other": "Er wordt een e-mail naar u verzonden om de verwijdering van uw account te bevestigen."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Er is iets misgegaan bij het verzenden van een e-mail voor het verwijderen van een account. Probeer het later opnieuw."
+  },
+  "account_form_request_delete_button": {
+    "other": "Verwijdering aanvragen"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Se fra"
+  },
+  "confirm_delete_header": {
+    "other": "Bekreft sletting"
+  },
+  "confirm_delete_message": {
+    "other": "Denne handlingen er permanent og kan ikke angres! Etter å ha slettet kontoen din vil du bli logget ut umiddelbart og vil ikke ha tilgang til kjøpene dine lenger."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Konto slettet!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Kontoen din er slettet."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "sletter"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Slett konto"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Vi kunne ikke slette kontoen din. Prøv igjen senere."
+  },
+  "account_form_request_delete": {
+    "other": "Slett konto"
+  },
+  "account_form_request_delete_message": {
+    "other": "En e-post vil bli sendt til deg for å bekrefte slettingen av kontoen din."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Noe gikk galt under forsøk på å sende en e-post for sletting av kontoen. Prøv igjen senere."
+  },
+  "account_form_request_delete_button": {
+    "other": "Be om sletting"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1738,5 +1738,38 @@
   },
   "pricing_from": {
     "other": "Oglądaj od"
+  },
+  "confirm_delete_header": {
+    "other": "Potwierdź usunięcie"
+  },
+  "confirm_delete_message": {
+    "other": "Ta czynność jest trwała i nie można jej cofnąć! Po usunięciu konta zostaniesz natychmiast wylogowany i nie będziesz mieć już dostępu do swoich zakupów."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Konto usunięte!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Twoje konto zostało pomyślnie usunięte."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "usuwanie"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Usuń konto"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Nie udało nam się usunąć Twojego konta. Spróbuj ponownie później."
+  },
+  "account_form_request_delete": {
+    "other": "Usuń konto"
+  },
+  "account_form_request_delete_message": {
+    "other": "Zostanie wysłana do Ciebie wiadomość e-mail z potwierdzeniem usunięcia konta."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Coś poszło nie tak podczas próby wysłania wiadomości e-mail o usunięciu konta. Spróbuj ponownie później."
+  },
+  "account_form_request_delete_button": {
+    "other": "Poproś o usunięcie"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1665,5 +1665,38 @@
   },
   "pricing_from": {
     "other": "Assista à partir"
+  },
+  "confirm_delete_header": {
+    "other": "Confirmar exclusão"
+  },
+  "confirm_delete_message": {
+    "other": "Esta ação é permanente e não pode ser desfeita! Após excluir sua conta você será desconectado imediatamente e não poderá mais acessar suas compras."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Conta excluída!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Sua conta foi excluída com sucesso."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "excluindo"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Deletar conta"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Não foi possível excluir sua conta. Por favor, tente novamente mais tarde."
+  },
+  "account_form_request_delete": {
+    "other": "Deletar conta"
+  },
+  "account_form_request_delete_message": {
+    "other": "Um e-mail será enviado a você para confirmar a exclusão da sua conta."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Algo deu errado ao tentar enviar um e-mail de exclusão de conta. Tente novamente mais tarde."
+  },
+  "account_form_request_delete_button": {
+    "other": "Solicitar exclusão"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1665,5 +1665,38 @@
   },
   "pricing_from": {
     "other": "Assista à partir"
+  },
+  "confirm_delete_header": {
+    "other": "Confirmar exclusão"
+  },
+  "confirm_delete_message": {
+    "other": "Esta ação é permanente e não pode ser desfeita! Após excluir sua conta você será desconectado imediatamente e não poderá mais acessar suas compras."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Conta excluída!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Sua conta foi excluída com sucesso."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "excluindo"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Deletar conta"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Não foi possível excluir sua conta. Por favor, tente novamente mais tarde."
+  },
+  "account_form_request_delete": {
+    "other": "Deletar conta"
+  },
+  "account_form_request_delete_message": {
+    "other": "Um e-mail será enviado a você para confirmar a exclusão da sua conta."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Algo deu errado ao tentar enviar um e-mail de exclusão de conta. Tente novamente mais tarde."
+  },
+  "account_form_request_delete_button": {
+    "other": "Solicitar exclusão"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1715,5 +1715,38 @@
   },
   "pricing_from": {
     "other": "Смотреть из"
+  },
+  "confirm_delete_header": {
+    "other": "Подтвердить удаление"
+  },
+  "confirm_delete_message": {
+    "other": "Это действие является постоянным и не может быть отменено! После удаления учетной записи вы сразу же выйдете из системы и больше не сможете получить доступ к своим покупкам."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Аккаунт удален!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Ваша учетная запись успешно удалена."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "удаление"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Удалить аккаунт"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Нам не удалось удалить вашу учетную запись. Пожалуйста, повторите попытку позже."
+  },
+  "account_form_request_delete": {
+    "other": "Удалить аккаунт"
+  },
+  "account_form_request_delete_message": {
+    "other": "Вам будет отправлено электронное письмо для подтверждения удаления вашей учетной записи."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Что-то пошло не так при попытке отправить электронное письмо об удалении аккаунта. Повторите попытку позже."
+  },
+  "account_form_request_delete_button": {
+    "other": "Запросить удаление"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1677,5 +1677,38 @@
   },
   "pricing_from": {
     "other": "Гледајте из"
+  },
+  "confirm_delete_header": {
+    "other": "Потврдите брисање"
+  },
+  "confirm_delete_message": {
+    "other": "Ова радња је трајна и не може се поништити! Након брисања налога, одмах ћете бити одјављени и више нећете моћи да приступите својим куповинама."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Налог је избрисан!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Ваш налог је успешно избрисан."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "брисање"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Обрисати налог"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Нисмо могли да избришемо ваш налог. Покушајте поново касније."
+  },
+  "account_form_request_delete": {
+    "other": "Обрисати налог"
+  },
+  "account_form_request_delete_message": {
+    "other": "Биће вам послата е-порука да потврдите брисање вашег налога."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Нешто је пошло наопако при покушају слања е-поруке за брисање налога, покушајте поново касније."
+  },
+  "account_form_request_delete_button": {
+    "other": "Захтевај брисање"
   }
 }

--- a/site/styles/_forms.scss
+++ b/site/styles/_forms.scss
@@ -11,6 +11,7 @@ s72-resetpassword-form,
 s72-acceptinvite-form,
 s72-useraccount-form,
 s72-activatedevice-form,
+s72-confirm-delete-form,
 .form-container {
   display: block;
   margin: 0 auto;

--- a/site/styles/_pages.scss
+++ b/site/styles/_pages.scss
@@ -45,7 +45,8 @@
 .devices-page,
 .plans-page,
 .carousel-len-0,
-.verify-email-page {
+.verify-email-page,
+.delete-result-page {
   padding-top: var(--page-padding-top);
   @include media-breakpoint-up(md) {
     padding: var(--page-padding-top-md) 0 0 0;
@@ -286,7 +287,8 @@
   @include heading-4-style;
 }
 
-.verify-email-page {
+.verify-email-page,
+.delete-result-page {
   @include media-breakpoint-up(xl) {
     padding: var(--page-padding-top-lg) 0 0 0;
   }

--- a/site/styles/_pages.scss
+++ b/site/styles/_pages.scss
@@ -308,3 +308,29 @@
     }
   }
 }
+
+.confirm-delete-page {
+  @include media-breakpoint-up(xl) {
+    padding: var(--page-padding-top-lg) 0 0 0;
+  }
+
+  .page-header {
+    h1 {
+      text-align: center;
+    }
+  }
+
+  .page-content {
+    padding: 0 20px;
+    @include media-breakpoint-up(lg) {
+      padding: 0 50px;
+    }
+
+    p {
+      max-width: 400px;
+      width: 100%;
+      text-align: center;
+      margin: 0 auto 16px auto;
+    }
+  }
+}

--- a/site/styles/_pages.scss
+++ b/site/styles/_pages.scss
@@ -309,7 +309,7 @@
   }
 }
 
-.confirm-delete-page {
+.delete-confirm-page {
   @include media-breakpoint-up(xl) {
     padding: var(--page-padding-top-lg) 0 0 0;
   }

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1661,5 +1661,38 @@
   },
   "pricing_from": {
     "other": "Şuradan izle:"
+  },
+  "confirm_delete_header": {
+    "other": "Silmeyi onayla"
+  },
+  "confirm_delete_message": {
+    "other": "Bu eylem kalıcıdır ve geri alınamaz! Hesabınızı sildikten sonra hemen çıkış yapacaksınız ve artık satın alma işlemlerinize erişemeyeceksiniz."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Hesap Silindi!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Hesabınız başarıyla silindi."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "siliniyor"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Hesabı sil"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Hesabınızı silemedik. Lütfen daha sonra tekrar deneyiniz."
+  },
+  "account_form_request_delete": {
+    "other": "Hesabı sil"
+  },
+  "account_form_request_delete_message": {
+    "other": "Hesabınızın silinmesini onaylamak için size bir e-posta gönderilecektir."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Hesap silme e-postası gönderilmeye çalışılırken bir şeyler ters gitti. Lütfen daha sonra tekrar deneyin."
+  },
+  "account_form_request_delete_button": {
+    "other": "Silme isteği"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1721,5 +1721,38 @@
   },
   "pricing_from": {
     "other": "Дивитися з"
+  },
+  "confirm_delete_header": {
+    "other": "Підтвердити видалення"
+  },
+  "confirm_delete_message": {
+    "other": "Ця дія є постійною і не може бути скасована! Після видалення облікового запису ви негайно вийдете з системи та більше не зможете отримати доступ до своїх покупок."
+  },
+  "confirm_delete_success_page_header": {
+    "other": "Обліковий запис видалено!"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "Ваш обліковий запис успішно видалено."
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "видалення"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "Видалити аккаунт"
+  },
+  "confirm_delete_error_generic": {
+    "other": "Нам не вдалося видалити ваш обліковий запис. Будь-ласка спробуйте пізніше."
+  },
+  "account_form_request_delete": {
+    "other": "Видалити аккаунт"
+  },
+  "account_form_request_delete_message": {
+    "other": "Вам буде надіслано електронний лист для підтвердження видалення вашого облікового запису."
+  },
+  "account_form_account_delete_failed": {
+    "other": "Під час спроби надіслати електронний лист про видалення облікового запису сталася помилка. Повторіть спробу пізніше."
+  },
+  "account_form_request_delete_button": {
+    "other": "Запит на видалення"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1648,5 +1648,38 @@
   },
   "pricing_from": {
     "other": "觀看來自"
+  },
+  "confirm_delete_header": {
+    "other": "確認刪除"
+  },
+  "confirm_delete_message": {
+    "other": "此操作是永久性的且無法撤消！刪除您的帳戶後，您將立即登出，並且無法再存取您的購買內容。"
+  },
+  "confirm_delete_success_page_header": {
+    "other": "帳戶已刪除！"
+  },
+  "confirm_delete_success_page_message": {
+    "other": "您的帳戶已成功刪除。"
+  },
+  "confirm_delete_submit_button_text_in_progress": {
+    "other": "刪除"
+  },
+  "confirm_delete_submit_button_text": {
+    "other": "刪除帳戶"
+  },
+  "confirm_delete_error_generic": {
+    "other": "我們無法刪除您的帳戶。請稍後再試。"
+  },
+  "account_form_request_delete": {
+    "other": "刪除帳戶"
+  },
+  "account_form_request_delete_message": {
+    "other": "我們將向您發送一封電子郵件，以確認您的帳戶刪除。"
+  },
+  "account_form_account_delete_failed": {
+    "other": "嘗試傳送帳戶刪除電子郵件時出現問題，請稍後重試。"
+  },
+  "account_form_request_delete_button": {
+    "other": "請求刪除"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#11812](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/11812)

## Description of work
Adds in a page that will let a user confirm their account deletion, which they will be directed to from an email, and then a page to put them on after this has been triggered. I haven't really handled error cases... I also don't know how to do the translation stuff so still a bit of work to do here. 

## Config settings/Toggles required for the feature to work
- Users -> Feature toggle -> user_deletion set to is enabled for the apis to work.

## Related PRs 
https://github.com/indiereign/shift72-web/pull/442
https://github.com/indiereign/shift72-users/pull/416
https://github.com/indiereign/shift72-users/pull/412

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
