### PR TITLE
Update checkout embed, and some dev mode niceties in application.jet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 
 ### Changed
+- Update the checkout embed to suit latest version, and to pass through urls
+- Add flags in `application.jet` to switch on local dev options for relish and
+  checkout.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ This template supports the following features:
 
 ## Running local content
 
-To use a local version of relish, update [application.jet](site/templates/application/application.jet) to set the CDN to: `{{CDN := "//localhost:3000"}}`.
+To use a local version of relish or checkout, update the flags at the top of
+[application.jet](site/templates/application/application.jet)

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -62,7 +62,7 @@
 
     {* get default language from site record or kibble.json depening on if db translations is enabled *}
     {{ defaultLanguage := isEnabled("site_translations_api") ? site.DefaultLanguage : site.SiteConfig.DefaultLanguage }}
-    <script defer>
+    <script>
       window.addEventListener('DOMContentLoaded', function(){
         s72.cfg(function(){ return s72.i18n.load('{{lang.Code}}', '/{{lang.DefinitionFilePath}}'); });
         s72.cfg(function(){ return s72.i18n.href.setLanguages('{{defaultLanguage}}', '{{lang.Code}}'); });

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -5,14 +5,17 @@
 {{import "./pixel.jet"}}
 {{import "./footer/footer.jet" }}
 
-{{CDN := "//cdn.shift72.com/1.4"}}
-{*{CDN := "//localhost:3000"}*}
+{{useLocalDevRelish := false}}
+{{useLocalDevCheckout := false}}
+
+{{CDN := useLocalDevRelish ? "//localhost:3000" : "//cdn.shift72.com/1.4"}}
 
 {{CSSFileURL := site.SiteBrand.GetLink("css", "")}}
 {*{CSSFileURL := "/styles/local.css"}*}
 
-{{checkoutDevMode := false}}
-{{useCheckout := site.Toggles["use_checkout"] || checkoutDevMode}}
+{{useCheckout := site.Toggles["use_checkout"] || useLocalDevCheckout}}
+{{checkoutDevServer := "http://localhost:4072"}}
+{{checkoutScriptUrl := useLocalDevCheckout ? checkoutDevServer + "/s72.checkout.js" : "/checkout/s72.checkout.js"}}
 
 <!DOCTYPE html>
 <html lang="{{lang.Code}}">
@@ -55,18 +58,11 @@
 
     <script src="{{CDN}}/s72.transactional.js" defer></script>
 
-    {{if checkoutDevMode}}
-      <script>window.S72_CHECKOUT_OVERRIDE_URL = 'http://localhost:4072'</script>
-      <script src="http://localhost:4072/s72.checkout.js" defer></script> 
-    {{else if useCheckout}}
-      <script src="/checkout/s72.checkout.js" defer></script>
-    {{end}}
-
     <script src="https://js.stripe.com/v3/" defer></script>
 
-    {* get default language from site record or kibble.json depening on if db translations is enabled *}  
+    {* get default language from site record or kibble.json depening on if db translations is enabled *}
     {{ defaultLanguage := isEnabled("site_translations_api") ? site.DefaultLanguage : site.SiteConfig.DefaultLanguage }}
-    <script>
+    <script defer>
       window.addEventListener('DOMContentLoaded', function(){
         s72.cfg(function(){ return s72.i18n.load('{{lang.Code}}', '/{{lang.DefinitionFilePath}}'); });
         s72.cfg(function(){ return s72.i18n.href.setLanguages('{{defaultLanguage}}', '{{lang.Code}}'); });
@@ -77,6 +73,22 @@
         });
       });
     </script>
+
+    {{if useCheckout}}
+      <script src="{{checkoutScriptUrl}}" defer></script>
+      <script>
+        window.Shift72CheckoutOptions = {
+          baseUrl: window.location.origin,
+          {{if useLocalDevCheckout}}checkoutDevServerUrl: '{{checkoutDevServer}}',{{end}}
+          links: {
+            library: '{{routeToPath("/library.html")}}',
+            termsAndConditions: '{{routeToPath("/page/terms-and-conditions/")}}',
+            deviceCompatibility: '{{routeToPath("/page/help/")}}',
+            help: '{{routeToPath("/page/help/")}}'
+          }
+        };
+      </script>
+    {{end}}
 
     <script type="text/javascript" src="/scripts/swiper.min.js"></script>
   </head>


### PR DESCRIPTION
ADO card: ☑️ [AB#11872](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Core%20team/Stories/?workitem=11872)

## Description of work

 - Tidies up the checkout embed. Adds flags for local dev checkout and relish rather than commenting/uncommenting nonsense
 - Use the new Shift72CheckoutOptions object
 - Pass through some helpful URLs that should have the right language codes baked into them.


## Config settings/Toggles required for the feature to work
- It's behind the checkout toggle so shouldn't affect non-checkout sites

### Any PRs which this PR depends on
- https://github.com/indiereign/shift72-checkout/pull/40

### Affected Clients
- Testing sites using checkout

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
