### PR TITLE
Add `theme.json.jet`: rudimentary checkout theming support

### DIFF
--- a/site/theme.json.jet
+++ b/site/theme.json.jet
@@ -1,0 +1,4 @@
+{
+  "primaryColor": {{isset(site.Config["theme_primary_color"]) ? json(site.Config["theme_primary_color"]) : "null" | raw }},
+  "mode": {{site.Config["theme_mode"] == "dark" ? "\"dark\"" : "\"light\"" | raw}}
+}


### PR DESCRIPTION
This is a temporary feature that can go away once we have a proper theming API.

## Config settings/Toggles required for the feature to work
 - theme_primary_color / theme_mode: these are temporary and should get checkout theming working

### Any PRs dependent on this one
-  The checkout theming support one

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Updated changelog (if applicable)
- [x] I promise NOT to document any new feature toggles/configurations in the appropriate documentation
