### PR TITLE
Hid live event button for logged out users

### DIFF
--- a/site/templates/items/meta_item.jet
+++ b/site/templates/items/meta_item.jet
@@ -84,10 +84,12 @@
                 <s72-pricing-buttons data-slug="{{item.Slug}}" class="pricing-buttons-fit" title="{{item.Title}}"></s72-pricing-buttons>
               {{end}}
 
-              {{if len(canBeWatchedLink) > 0}}
-                <can-be-watched-button data-slug="{{item.InnerItem.Slug}}" data-url="{{canBeWatchedLink}}" data-label="{{canBeWatchedText | i18n}}"></can-be-watched-button>
-              {{end}}
-
+              <s72-user-known>
+                {{if len(canBeWatchedLink) > 0}}
+                  <can-be-watched-button data-slug="{{item.InnerItem.Slug}}" data-url="{{canBeWatchedLink}}" data-label="{{canBeWatchedText | i18n}}"></can-be-watched-button>
+                {{end}}
+              </s72-user-known>
+              
               {{if len(externalPurchaseButtonLink) > 0}}
                 <external-purchase-button data-slug="{{item.InnerItem.Slug}}" data-url="{{externalPurchaseButtonLink}}" data-label="{{externalPurchaseButtonText | i18n}}"></external-purchase-button>
               {{end}}

--- a/site/templates/items/meta_item.jet
+++ b/site/templates/items/meta_item.jet
@@ -84,11 +84,11 @@
                 <s72-pricing-buttons data-slug="{{item.Slug}}" class="pricing-buttons-fit" title="{{item.Title}}"></s72-pricing-buttons>
               {{end}}
 
-              <s72-user-known>
                 {{if len(canBeWatchedLink) > 0}}
-                  <can-be-watched-button data-slug="{{item.InnerItem.Slug}}" data-url="{{canBeWatchedLink}}" data-label="{{canBeWatchedText | i18n}}"></can-be-watched-button>
+                  <s72-user-known>
+                    <can-be-watched-button data-slug="{{item.InnerItem.Slug}}" data-url="{{canBeWatchedLink}}" data-label="{{canBeWatchedText | i18n}}"></can-be-watched-button>
+                  </s72-user-known>
                 {{end}}
-              </s72-user-known>
               
               {{if len(externalPurchaseButtonLink) > 0}}
                 <external-purchase-button data-slug="{{item.InnerItem.Slug}}" data-url="{{externalPurchaseButtonLink}}" data-label="{{externalPurchaseButtonText | i18n}}"></external-purchase-button>


### PR DESCRIPTION
## Description of work
The can-be-watched-button is visible to logged out users if the film is flagged as available to watch (Such as if the film is in a free plan and the disable_anonymous_watch_now toggle is not enabled). We're limiting this to only logged in users.

### Affected Clients
 - All clients who use Kibble

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
