### PR TITLE
Ab#12169 add carousel focus from tv / film objects to position carousel image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Added
 
+- Support for applying carousel image focus area if set
+
 ### Changed
+
 - Hid can-be-watched button on the film page for logged out users
 
 ### Fixed
@@ -16,7 +19,6 @@
 - Hid can-be-watched button for logged out users
 
 ### Fixed
-
 
 ## [1.9.13](https://github.com/shift72/core-template/compare/1.9.12...1.9.13)
 

--- a/kibble.json
+++ b/kibble.json
@@ -2,7 +2,7 @@
   "name": "core-template",
   "version": "0.0.1",
   "siteUrl": "https://tvoddemo.shift72.com",
-  "builderVersion": "0.17.1",
+  "builderVersion": "0.17.5",
   "defaultLanguage": "en",
   "languages": {
     "ar": {
@@ -112,14 +112,9 @@
   },
   "siteRootPath": "site",
   "liveReload": {
-    "ignoredPaths": [
-      "styles",
-      "js"
-    ]
+    "ignoredPaths": ["styles", "js"]
   },
-  "proxy": [
-    "^/checkout/"
-  ],
+  "proxy": ["^/checkout/"],
   "routes": [
     {
       "name": "filmItem",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss-cli": "^9.0.1",
     "rollup": "^2.23.0",
     "rollup-plugin-terser": "^6.1.0",
-    "s72-kibble": "^0.17.1",
+    "s72-kibble": "^0.17.5",
     "sass": "^1.36.0"
   },
   "devDependencies": {

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -52,6 +52,15 @@ s72-carousel {
       object-position: var(--carousel-image-object-position-lg);
     }
   }
+  .carousel-position-left {
+    object-position: left;
+  }
+  .carousel-position-right {
+    object-position: right;
+  }
+  .carousel-position-center {
+    object-position: center;
+  }
 }
 
 .s72-carousel-item {

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -51,15 +51,15 @@ s72-carousel {
     @include media-breakpoint-up(lg) {
       object-position: var(--carousel-image-object-position-lg);
     }
-  }
-  .carousel-focus-left {
-    object-position: left;
-  }
-  .carousel-focus-right {
-    object-position: right;
-  }
-  .carousel-focus-center {
-    object-position: center;
+    &.left {
+      object-position: left;
+    }
+    &.right {
+      object-position: right;
+    }
+    &.center {
+      object-position: center;
+    }
   }
 }
 

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -51,13 +51,13 @@ s72-carousel {
     @include media-breakpoint-up(lg) {
       object-position: var(--carousel-image-object-position-lg);
     }
-    &.left {
+    &.focus-left {
       object-position: left;
     }
-    &.right {
+    &.focus-right {
       object-position: right;
     }
-    &.center {
+    &.focus-center {
       object-position: center;
     }
   }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -52,13 +52,13 @@ s72-carousel {
       object-position: var(--carousel-image-object-position-lg);
     }
   }
-  .carousel-position-left {
+  .carousel-focus-left {
     object-position: left;
   }
-  .carousel-position-right {
+  .carousel-focus-right {
     object-position: right;
   }
-  .carousel-position-center {
+  .carousel-focus-center {
     object-position: center;
   }
 }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -39,7 +39,7 @@ s72-carousel {
   top: 0;
   width: 100%;
 
-  img {
+  .carousel-item-image {
     height: 100%;
     object-fit: cover;
     object-position: var(--carousel-image-object-position);

--- a/site/styles/_pages.scss
+++ b/site/styles/_pages.scss
@@ -308,11 +308,11 @@
     }
 
     p {
-      width: auto;
-      max-width: 400px;
-      text-align: center;
       margin-left: auto;
       margin-right: auto;
+      max-width: 400px;
+      text-align: center;
+      width: auto;
     }
   }
 }

--- a/site/templates/collection/carousel/item/image.jet
+++ b/site/templates/collection/carousel/item/image.jet
@@ -1,7 +1,14 @@
 {{block carouselItemImage()}}
   {{if isset(.Images["Carousel"])}}
-    {* If carousel focus is set for film (film infos metadata) or tv season (tv seasons metadata) then it will set a class accordingly to position the carousel image *}
-    {{carouselFocusClass := (isset(.InnerItem["CarouselFocus"]) && .InnerItem["CarouselFocus"] != "" ) ? "carousel-focus-" + .InnerItem["CarouselFocus"] : ""}}
+    {* If carousel focus is set for film (film infos metadata) or tv season (tv seasons metadata) or custom fields for Pages / Bundles then it will set a class accordingly to position the carousel image *}
+      {{carouselFocus = ""}}
+      {{if isset(.InnerItem["CarouselFocus"]) && .InnerItem["CarouselFocus"] != "" }}
+        {{carouselFocus = .InnerItem["CarouselFocus"]}}
+      {{end}}
+      {{ if .InnerItem.CustomFields.GetString("carousel_focus", "") != ""}}
+        {{carouselFocus = .InnerItem.CustomFields.GetString("carousel_focus", "")}}
+      {{end}}
+    {{carouselFocusClass := (carouselFocus != "" ) ? "carousel-focus-" + carouselFocus : ""}}
     <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{carouselFocusClass}}"></s72-image>
   {{end}}
 {{end}}

--- a/site/templates/collection/carousel/item/image.jet
+++ b/site/templates/collection/carousel/item/image.jet
@@ -1,6 +1,16 @@
 {{block carouselItemImage()}}
   {{if isset(.Images["Carousel"])}}
     {* If carousel focus is set for film (film infos metadata) or tv season (tv seasons metadata) or custom fields for Pages / Bundles then it will set a class accordingly to position the carousel image *}
-    <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{.GetCarouselImageFocusArea()}}"></s72-image>
+    {{focusClass = ""}}
+    {{if .GetCarouselImageFocusArea() != ""}}
+      {{if .GetCarouselImageFocusArea() == "left"}}
+        {{focusClass = "focus-left"}}
+      {{else if .GetCarouselImageFocusArea() == "right"}}
+        {{focusClass = "focus-right"}}
+      {{else if .GetCarouselImageFocusArea() == "center"}}
+        {{focusClass = "focus-center"}}
+      {{end}}
+    {{end}}
+    <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{focusClass}}"></s72-image>
   {{end}}
 {{end}}

--- a/site/templates/collection/carousel/item/image.jet
+++ b/site/templates/collection/carousel/item/image.jet
@@ -1,14 +1,6 @@
 {{block carouselItemImage()}}
   {{if isset(.Images["Carousel"])}}
     {* If carousel focus is set for film (film infos metadata) or tv season (tv seasons metadata) or custom fields for Pages / Bundles then it will set a class accordingly to position the carousel image *}
-      {{carouselFocus = ""}}
-      {{if isset(.InnerItem["CarouselFocus"]) && .InnerItem["CarouselFocus"] != "" }}
-        {{carouselFocus = .InnerItem["CarouselFocus"]}}
-      {{end}}
-      {{ if .InnerItem.CustomFields.GetString("carousel_focus", "") != ""}}
-        {{carouselFocus = .InnerItem.CustomFields.GetString("carousel_focus", "")}}
-      {{end}}
-    {{carouselFocusClass := (carouselFocus != "" ) ? "carousel-focus-" + carouselFocus : ""}}
-    <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{carouselFocusClass}}"></s72-image>
+    <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{.GetCarouselImageFocusArea()}}"></s72-image>
   {{end}}
 {{end}}

--- a/site/templates/collection/carousel/item/image.jet
+++ b/site/templates/collection/carousel/item/image.jet
@@ -1,5 +1,6 @@
 {{block carouselItemImage()}}
   {{if isset(.Images["Carousel"])}}
+    {* If carousel focus is set for film (film infos metadata) or tv season (tv seasons metadata) then it will set a class accordingly to position the carousel image *}
     {{carouselFocusClass := (isset(.InnerItem["CarouselFocus"]) && .InnerItem["CarouselFocus"] != "" ) ? "carousel-focus-" + .InnerItem["CarouselFocus"] : ""}}
     <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{carouselFocusClass}}"></s72-image>
   {{end}}

--- a/site/templates/collection/carousel/item/image.jet
+++ b/site/templates/collection/carousel/item/image.jet
@@ -1,6 +1,6 @@
 {{block carouselItemImage()}}
   {{if isset(.Images["Carousel"])}}
-    {{carouselFocusClass := (isset(.InnerItem["CarouselFocus"]) && .InnerItem["CarouselFocus"] != "" ) ? .InnerItem["CarouselFocus"] : ""}}
+    {{carouselFocusClass := (isset(.InnerItem["CarouselFocus"]) && .InnerItem["CarouselFocus"] != "" ) ? "carousel-focus-" + .InnerItem["CarouselFocus"] : ""}}
     <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{carouselFocusClass}}"></s72-image>
   {{end}}
 {{end}}

--- a/site/templates/collection/carousel/item/image.jet
+++ b/site/templates/collection/carousel/item/image.jet
@@ -1,5 +1,6 @@
 {{block carouselItemImage()}}
   {{if isset(.Images["Carousel"])}}
-    <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image"></s72-image>
+    {{carouselFocusClass := (isset(.InnerItem["CarouselFocus"]) && .InnerItem["CarouselFocus"] != "" ) ? .InnerItem["CarouselFocus"] : ""}}
+    <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{carouselFocusClass}}"></s72-image>
   {{end}}
 {{end}}


### PR DESCRIPTION
ADO card: ☑️ [AB#12169](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/12169)

## Description of work
Checks if carousel image focus area has been set for a carousel item and applies a class to fix the image to the left / right center. 

## Related PRs 

### Any PRs which this PR depends on
- Kibble: https://github.com/shift72/kibble/pull/138
- Admin: https://github.com/indiereign/shift72-admin/pull/890 (to allow admins to set the carousel image focus area on film / seasons / pages / bundles).


### Affected Clients
 - All clients who use Kibble


## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
