### PR TITLE
Update the theme to support new version of Checkout theme

### DIFF
--- a/site/theme.json.jet
+++ b/site/theme.json.jet
@@ -1,4 +1,4 @@
 {
-  "primaryColor": {{isset(site.Config["theme_primary_color"]) ? json(site.Config["theme_primary_color"]) : "null" | raw }},
-  "mode": {{site.Config["theme_mode"] == "dark" ? "\"dark\"" : "\"light\"" | raw}}
+  "colorScheme": {{site.Config["theme_mode"] == "light" ? "\"light\"" : "\"dark\"" | raw}},
+  "colorPrimary": {{isset(site.Config["theme_primary_color"]) ? json(site.Config["theme_primary_color"]) : "null" | raw }}
 }


### PR DESCRIPTION
I have updated Checkout to support many new theming options. Part of this changes the names of the primary color and color mode. 

`primaryColor` -> `colorPrimary`

The theme variables were based off Stripes theme variables. I liked prefixing the colors with `color` and the suffix was the thing the color related to. It also made it easy to map from the theme to Stripe's theme.

`mode` -> `colorScheme`

This change was to match what Mantine called the light/dark toggle.  I felt it was more specific.

I've also updated the default color scheme to be `dark`. This is because most of our sites are dark.

This release needs to go out before we can roll Checkout out to production.