### PR TITLE
Continue watching slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Continue watching slider
+
 ### Changed
 
 ### Fixed

--- a/site/ar_LB.all.json
+++ b/site/ar_LB.all.json
@@ -1779,5 +1779,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "أفهم أن هذا الإجراء دائم"
+  },
+  "continue_watching_slider_header": {
+    "other": "مواصلة المشاهدة"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "مواصلة المشاهدة"
   }
 }

--- a/site/ca_ES.all.json
+++ b/site/ca_ES.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Entenc que aquesta acció és permanent"
+  },
+  "continue_watching_slider_header": {
+    "other": "Continuar mirant"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Continuar mirant"
   }
 }

--- a/site/da_DK.all.json
+++ b/site/da_DK.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Jeg forstår, at denne handling er permanent"
+  },
+  "continue_watching_slider_header": {
+    "other": "Fortsæt med at se"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Fortsæt med at se"
   }
 }

--- a/site/de_DE.all.json
+++ b/site/de_DE.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Ich verstehe, dass diese Aktion dauerhaft ist"
+  },
+  "continue_watching_slider_header": {
+    "other": "Weiter schauen"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Weiter schauen"
   }
 }

--- a/site/el_EL.all.json
+++ b/site/el_EL.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Κατανοώ ότι αυτή η ενέργεια είναι μόνιμη"
+  },
+  "continue_watching_slider_header": {
+    "other": "Συνεχίστε την παρακολούθηση"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Συνεχίστε την παρακολούθηση"
   }
 }

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -831,6 +831,9 @@
   "userwishlist_button_remove_compact": {
     "other": "My List"
   },
+  "continue_watching_slider_header": {
+    "other": "Continue Watching"
+  },
   "activatedevice_page_header": {
     "other": "Activate Device"
   },
@@ -1246,6 +1249,9 @@
   },
   "wcag_aria_label_wishlist": {
     "other": "Wishlist"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Continue watching"
   },
   "wcag_aria_label_facebook": {
     "other": "Share on Facebook"

--- a/site/en_AU.all.json
+++ b/site/en_AU.all.json
@@ -1251,7 +1251,7 @@
     "other": "Wishlist"
   },
   "wcag_aria_label_continue_watching": {
-    "other": "Continue watching"
+    "other": "Continue Watching"
   },
   "wcag_aria_label_facebook": {
     "other": "Share on Facebook"

--- a/site/es_ES.all.json
+++ b/site/es_ES.all.json
@@ -1719,5 +1719,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Entiendo que esta acción es permanente"
+  },
+  "continue_watching_slider_header": {
+    "other": "Continuar viendo"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Continuar viendo"
   }
 }

--- a/site/es_MX.all.json
+++ b/site/es_MX.all.json
@@ -1719,5 +1719,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Entiendo que esta acción es permanente"
+  },
+  "continue_watching_slider_header": {
+    "other": "Continuar viendo"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Continuar viendo"
   }
 }

--- a/site/et_ET.all.json
+++ b/site/et_ET.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Saan aru, et see toiming on püsiv"
+  },
+  "continue_watching_slider_header": {
+    "other": "Jätkake vaatamist"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Jätkake vaatamist"
   }
 }

--- a/site/fi_FI.all.json
+++ b/site/fi_FI.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Ymmärrän, että tämä toimenpide on pysyvä"
+  },
+  "continue_watching_slider_header": {
+    "other": "Jatka katselua"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Jatka katselua"
   }
 }

--- a/site/fr_FR.all.json
+++ b/site/fr_FR.all.json
@@ -1719,5 +1719,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Je comprends que cette action est permanente"
+  },
+  "continue_watching_slider_header": {
+    "other": "Continuer à regarder"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Continuer à regarder"
   }
 }

--- a/site/hr_HR.all.json
+++ b/site/hr_HR.all.json
@@ -1717,5 +1717,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Razumijem da je ova akcija trajna"
+  },
+  "continue_watching_slider_header": {
+    "other": "Nastavite s gledanjem"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Nastavite s gledanjem"
   }
 }

--- a/site/hu_HU.all.json
+++ b/site/hu_HU.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Megértem, hogy ez a művelet végleges"
+  },
+  "continue_watching_slider_header": {
+    "other": "Folytassa a nézést"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Folytassa a nézést"
   }
 }

--- a/site/it_IT.all.json
+++ b/site/it_IT.all.json
@@ -1719,5 +1719,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Capisco che questa azione è permanente"
+  },
+  "continue_watching_slider_header": {
+    "other": "Continua a guardare"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Continua a guardare"
   }
 }

--- a/site/ja_JP.all.json
+++ b/site/ja_JP.all.json
@@ -1702,5 +1702,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "このアクションは永続的なものであることを理解しています"
+  },
+  "continue_watching_slider_header": {
+    "other": "視聴を続ける"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "視聴を続ける"
   }
 }

--- a/site/lt_LT.all.json
+++ b/site/lt_LT.all.json
@@ -1747,5 +1747,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Suprantu, kad šis veiksmas yra nuolatinis"
+  },
+  "continue_watching_slider_header": {
+    "other": "Žiūrėti toliau"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Žiūrėti toliau"
   }
 }

--- a/site/nl_BE.all.json
+++ b/site/nl_BE.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Ik begrijp dat deze actie permanent is"
+  },
+  "continue_watching_slider_header": {
+    "other": "Ga door met kijken"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Ga door met kijken"
   }
 }

--- a/site/no_NO.all.json
+++ b/site/no_NO.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Jeg forstår at denne handlingen er permanent"
+  },
+  "continue_watching_slider_header": {
+    "other": "Fortsett å se"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Fortsett å se"
   }
 }

--- a/site/pl_PL.all.json
+++ b/site/pl_PL.all.json
@@ -1792,5 +1792,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Rozumiem, że to działanie ma charakter trwały"
+  },
+  "continue_watching_slider_header": {
+    "other": "Kontynuuj oglądanie"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Kontynuuj oglądanie"
   }
 }

--- a/site/pt_BR.all.json
+++ b/site/pt_BR.all.json
@@ -1719,5 +1719,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Entendo que esta ação é permanente"
+  },
+  "continue_watching_slider_header": {
+    "other": "Continuar assistindo"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Continuar assistindo"
   }
 }

--- a/site/pt_PT.all.json
+++ b/site/pt_PT.all.json
@@ -1719,5 +1719,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Entendo que esta ação é permanente"
+  },
+  "continue_watching_slider_header": {
+    "other": "Continuar assistindo"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Continuar assistindo"
   }
 }

--- a/site/ru_RU.all.json
+++ b/site/ru_RU.all.json
@@ -1769,5 +1769,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Я понимаю, что это действие является постоянным"
+  },
+  "continue_watching_slider_header": {
+    "other": "Продолжить просмотр"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Продолжить просмотр"
   }
 }

--- a/site/sr_SR.all.json
+++ b/site/sr_SR.all.json
@@ -1731,5 +1731,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Разумем да је ова акција трајна"
+  },
+  "continue_watching_slider_header": {
+    "other": "Наставите са гледањем"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Наставите са гледањем"
   }
 }

--- a/site/static/js/main.js
+++ b/site/static/js/main.js
@@ -6,34 +6,34 @@ import './external-purchase-button.component.js';
 
 let slideObservers = [];
 
-function initializeWishlist() {
-  let wishlist = document.querySelector('s72-userwishlist');
-  if (!wishlist) return;
-  let originalFunction = wishlist.classList.remove;
-  wishlist.classList.remove = function (className) {
-    if (className == 's72-hide') {
-      // Hide this from view
-      wishlist.style.opacity = '0';
+function initializeCustomSliders() {
+  ['s72-userwishlist', 's72-continue-watching'].forEach(selector => {
+    let wishlist = document.querySelector(selector);
+    if (!wishlist) return;
 
+    // Gross.
+    let originalFunction = wishlist.classList.remove;
+    wishlist.classList.remove = function (className) {
       // Remove class
       originalFunction.apply(this, [className]);
+      if (className === 's72-hide') {
+        // Hide this from view
+        wishlist.style.opacity = '0';
 
-      /* Convert this to a swiper */
-      let containers = wishlist.getElementsByClassName('swiper-container');
-      if (containers.length > 0) {
-        let container = containers[0];
-        let swiper = initializeSwiper(container, true);
+        /* Convert this to a swiper */
+        let containers = wishlist.getElementsByClassName('swiper-container');
+        if (containers.length > 0) {
+          let container = containers[0];
+          let swiper = initializeSwiper(container, true);
+          init(swiper);
+          toggleButtons(container);
+        }
 
-        init(swiper);
-        toggleButtons(container);
+        // Now show it
+        wishlist.style.opacity = '1';
       }
-
-      // Now show it
-      wishlist.style.opacity = '1';
-    } else {
-      originalFunction.apply(this, [className]);
-    }
-  };
+    };
+  });
 }
 
 function initializeSwiper(element, force) {
@@ -463,7 +463,7 @@ function toggleScroll() {
 }
 
 function documentReady(app) {
-  initializeWishlist();
+  initializeCustomSliders();
 
   app.classificationsService.load('/classifications.all.json');
   app.urlMapService.load('/urlmap.json');

--- a/site/templates/collection/continue_watching.jet
+++ b/site/templates/collection/continue_watching.jet
@@ -1,0 +1,33 @@
+{{import "./page_collection_item.jet"}}
+{{import "../common/slider.jet"}}
+{{import "./slider-buttons.jet"}}
+
+{{block continueWatchingCollection()}}
+  {{layout := config("default_image_type")}}
+  {{itemsPerRow := layout == "portrait" ? 6 : 4}}
+  <s72-continue-watching
+      hide-if-empty="true"
+      partials-base-path="/partials"
+      partials-classes="swiper-slide"
+      partials-insert-point-selector=".swiper-wrapper"
+      force-login="false"
+      data-item-layout="{{layout}}"
+      data-items-per-page="{{itemsPerRow}}"
+      class="user-continue-watching s72-slider s72-hide">
+    <section class="page-collection" aria-label="{{i18n("wcag_aria_label_continue_watching")}}">
+      <div class="collection-wrapper-container swiper-wrapper-container">
+        <div class="collection-container swiper-container" data-items-per-row="{{itemsPerRow}}" data-layout="{{layout}}">
+          {{if i18n("continue_watching_slider_header") != ""}}
+          <div class="swiper-title">
+              <h3>{{i18n("continue_watching_slider_header")}}</h3>
+          </div>
+          {{end}}
+          <div class="swiper-wrapper">
+            {{yield content}}
+          </div>
+        </div>
+        {{ yield sliderButtons() }}
+      </div>
+    </section>
+  </s72-continue-watching>
+{{end}}

--- a/site/templates/page/homepage.jet
+++ b/site/templates/page/homepage.jet
@@ -2,6 +2,7 @@
 {{import "templates/collection/page_collection.jet"}}
 {{import "../collection/carousel/carousel.jet"}}
 {{import "templates/collection/wishlist.jet"}}
+{{import "templates/collection/continue_watching.jet"}}
 
 {{block head()}}
   {{yield seo() page}}
@@ -23,6 +24,11 @@
     <div class="other-sliders">
       <h2 class="sr-only">{{i18n("wcag_collections_h2")}}</h2>
       <div class="other-sliders-container">
+
+        {{if config("continue_watching") == "true"}}
+          {{yield continueWatchingCollection()}}
+        {{end}}
+
         {{yield wishlistCollection()}}
         {{range index, pf := page.PageCollections}}
           {{if index == 1}}{{yield pageCollection() pf}}{{end}}

--- a/site/tr_TR.all.json
+++ b/site/tr_TR.all.json
@@ -1715,5 +1715,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Bu eylemin kalıcı olduğunu anlıyorum"
+  },
+  "continue_watching_slider_header": {
+    "other": "İzlemeye Devam Et"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "İzlemeye Devam Et"
   }
 }

--- a/site/uk_UA.all.json
+++ b/site/uk_UA.all.json
@@ -1775,5 +1775,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "Я розумію, що ця дія є постійною"
+  },
+  "continue_watching_slider_header": {
+    "other": "Продовжити перегляд"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "Продовжити перегляд"
   }
 }

--- a/site/zh_TW.all.json
+++ b/site/zh_TW.all.json
@@ -1702,5 +1702,11 @@
   },
   "confirm_delete_check_box_message": {
     "other": "我了解此操作是永久性的"
+  },
+  "continue_watching_slider_header": {
+    "other": "繼續觀看"
+  },
+  "wcag_aria_label_continue_watching": {
+    "other": "繼續觀看"
   }
 }


### PR DESCRIPTION
ADO card: ☑️ [AB#XXXX](https://dev.azure.com/S72/SHIFT72/_workitems/edit/12307)

Elab notes/AC: 📃 [Google Docs](https://docs.google.com)

## Description of work

- Think this is going to be an easy couple of hours tops, it's basically just the wishlist with a different data source right
- See the extent of the hacks but get to work refactoring
- ???
- ...Profit?

<img width=600 src="https://github.com/shift72/core-template/assets/98778140/1640f11f-75b6-45f7-b2f5-dacd41143ea6">


## Config settings/Toggles required for the feature to work
- Config `continue_watching = true`. Figured this is the kind of thing we might want to just make admin-configurable.
- Related configs in Relish can control max items and max age of items that get shown.

## Related PRs 
- https://github.com/indiereign/shift72-web/pull/453

### Affected Clients

This feature will be most valuable to SVOD and AVOD clients, but it could be turned on for TVOD clients too.

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
