### PR TITLE
Use cloudflare CDN for polyfill.js to avoid supply chain risk

### DIFF
--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -50,7 +50,7 @@
       {{yield seo()}}
     {{end}}
 
-    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.js?features=Intl%2Cdefault%2Cfetch" defer></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=Intl%2Cdefault%2Cfetch" defer></script>
     <script src="{{CDN}}/s72.core.js" defer></script>
     <script src="{{CDN}}/s72.ui.js" defer></script>
 

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -50,7 +50,7 @@
       {{yield seo()}}
     {{end}}
 
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=Intl%2Cdefault%2Cfetch" defer></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.js?features=Intl%2Cdefault%2Cfetch" defer></script>
     <script src="{{CDN}}/s72.core.js" defer></script>
     <script src="{{CDN}}/s72.ui.js" defer></script>
 


### PR DESCRIPTION
Refs https://sansec.io/research/polyfill-supply-chain-attack

polyfill.io CDN has released polyfilljs version with malware. This change is to use the Cloudflare CDN as they are more reputable. This is a short term fix, long term we need to move away from using a 3rd party CDN for this issue (along with GDPR compliance).