### PR TITLE
Alignment fix ups for sliders/collections/library pages

### DIFF
--- a/site/styles/_collections.scss
+++ b/site/styles/_collections.scss
@@ -261,7 +261,7 @@
   }
 
   .caption {
-    padding: 4px 0;
+    padding: 0px 0 8px;
 
     .crumb {
       @extend .d-flex;

--- a/site/styles/_collections.scss
+++ b/site/styles/_collections.scss
@@ -42,9 +42,6 @@
   @extend .meta-item;
   float: left;
   padding: 5px;
-  &:first-child {
-    margin-left: -5px;
-  }
 
   h2 {
     @include subtitle-1-style;
@@ -341,4 +338,12 @@
 
 .collection-items {
   margin: 0 auto;
+}
+
+// To cancel out the 5px padding on items, add some negative margin to the containers
+.swiper-wrapper,
+.page-collection-items,
+.s72-userlibrary-items,
+.s72-userwishlist-items {
+  margin-left: -5px;
 }

--- a/site/styles/_library.scss
+++ b/site/styles/_library.scss
@@ -1,3 +1,9 @@
+.library-page s72-userlibrary {
+  // It looks a bit silly if the user library stretches too wide -- the gap
+  // between items gets big rather than adding more items!
+  max-width: 1920px;
+}
+
 .s72-userlibrary-items {
   @extend .d-flex;
 

--- a/site/styles/_wishlist.scss
+++ b/site/styles/_wishlist.scss
@@ -53,3 +53,7 @@
   margin: 0;
   padding: 0;
 }
+
+.wishlist-page s72-userwishlist {
+  max-width: 1920px;
+}


### PR DESCRIPTION
Collection views had a negative margin hack that was causing grid rows to not line up -- it was adding -5px margin to the first child of the collection to counteract the 5px padding to align the poster with the titles, but this caused subsequent rows to be misaligned.

I've also tweaked the caption padding to move the text closer to the poster.  This makes the visual grouping clearer when there are multiple rows -- the text used to sit awkwardly close to the middle.

![image](https://github.com/user-attachments/assets/bdb34a2c-8a14-443d-b579-86555e6b6834)

Another fix was adding a max-width to the library and wishlist pages to avoid the items spreading out if you have a really wide window.