### PR TITLE
Fix visual centering of the magnifying glass icon

### DIFF
--- a/site/styles/_nav.scss
+++ b/site/styles/_nav.scss
@@ -362,7 +362,7 @@
     left: 5px;
     pointer-events: none;
     position: absolute;
-    top: 50%;
+    top: calc(50% + 2px);
     transform: translateY(-50%);
     transition: none;
   }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9afa5d96-06b2-4d7a-94d4-97828308143f)

It looked even worse when there is no language selector

Old:
![image](https://github.com/user-attachments/assets/9f0f323a-47c4-474c-839e-46e008312636)

New:
![image](https://github.com/user-attachments/assets/e87c7912-a436-4cfd-b7b3-1db8e0c3a878)
