### PR TITLE
add noindex toggle check

### DIFF
--- a/site/templates/application/head/seo.jet
+++ b/site/templates/application/head/seo.jet
@@ -14,6 +14,9 @@
     {{seoImage = .Seo.Image}}
   {{end}}
 
+  {* override default setting to index the page if no_index toggle is set *}
+  {{index := site.Toggles["no_index"] ? false : index}}
+
   <title>{{seoTitle}}</title>
   <meta property="og:title" content="{{seoTitle|trimSpace}}">
   <meta property="twitter:title" content="{{seoTitle|trimSpace}}">


### PR DESCRIPTION
The seo jet is called in on all generated pages with a hardcoded index value - true / false. Added a check to make this false if a no_index feature toggle is set.  This can be an extra measure for sites that wish to remain off search engines. 