### PR TITLE
Film title images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.9.22...HEAD)
 
-- Add support for film title images
+### Added
+
+- Film title images
+
+### Fixed
+
+- Carousel video mute button to support light / custom theme
 
 ## [1.9.22](https://github.com/shift72/core-template/compare/1.9.21...1.9.22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.9.22...HEAD)
 
+- Add support for film title images
+
 ## [1.9.22](https://github.com/shift72/core-template/compare/1.9.21...1.9.22)
 
 ### Fixed

--- a/kibble.json
+++ b/kibble.json
@@ -1,7 +1,7 @@
 {
   "name": "core-template",
-  "version": "0.38.6",
-  "siteUrl": "https://store-kibble.shift72.com",
+  "version": "0.0.1",
+  "siteUrl": "https://tvoddemo-addons.shift72.com",
   "builderVersion": "0.17.5",
   "defaultLanguage": "en",
   "languages": {
@@ -112,14 +112,9 @@
   },
   "siteRootPath": "site",
   "liveReload": {
-    "ignoredPaths": [
-      "styles",
-      "js"
-    ]
+    "ignoredPaths": ["styles", "js"]
   },
-  "proxy": [
-    "^/checkout/"
-  ],
+  "proxy": ["^/checkout/"],
   "routes": [
     {
       "name": "filmItem",

--- a/kibble.json
+++ b/kibble.json
@@ -1,7 +1,7 @@
 {
   "name": "core-template",
-  "version": "0.0.1",
-  "siteUrl": "https://tvoddemo-addons.shift72.com",
+  "version": "0.38.6",
+  "siteUrl": "https://store-kibble.shift72.com",
   "builderVersion": "0.17.5",
   "defaultLanguage": "en",
   "languages": {

--- a/site/styles/_meta-item-title.scss
+++ b/site/styles/_meta-item-title.scss
@@ -1,5 +1,6 @@
 .item-title-image {
   max-height: var(--title-image-max-height);
+  margin-left: var(--title-image-left-margin);
   object-fit: contain;
   object-position: left;
   width: var(--title-image-width);

--- a/site/styles/_meta-item-title.scss
+++ b/site/styles/_meta-item-title.scss
@@ -1,0 +1,18 @@
+.item-title-image {
+  max-height: 250px;
+  object-fit: contain;
+  object-position: left;
+  width: 250px;
+  @include media-breakpoint-up(sm) {
+    width: 350px;
+  }
+  @include media-breakpoint-up(lg) {
+    width: 400px;
+  }
+  &.carousel {
+    margin-bottom: 16px;
+  }
+  &.film {
+    margin-bottom: 8px;
+  }
+}

--- a/site/styles/_meta-item-title.scss
+++ b/site/styles/_meta-item-title.scss
@@ -1,13 +1,13 @@
 .item-title-image {
-  max-height: 250px;
+  max-height: var(--title-image-max-height);
   object-fit: contain;
   object-position: left;
-  width: 250px;
+  width: var(--title-image-width);
   @include media-breakpoint-up(sm) {
-    width: 350px;
+    width: var(--title-image-width-sm);
   }
   @include media-breakpoint-up(lg) {
-    width: 400px;
+    width: var(--title-image-width-lg);
   }
   &.carousel {
     margin-bottom: 16px;

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -121,6 +121,12 @@
   --carousel-image-object-position-sm: center;
   --carousel-image-object-position-lg: center;
 
+  // Title Image sizing - carousel and detail page:
+  --title-image-width: 250px;
+  --title-image-width-sm: 350px;
+  --title-image-width-lg: 400px;
+  --title-image-max-height: 180px;
+
   // Pages
   --collection-padding-bottom: 40px;
 

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -126,6 +126,7 @@
   --title-image-width-sm: 350px;
   --title-image-width-lg: 400px;
   --title-image-max-height: 180px;
+  --title-image-left-margin: 0px;
 
   // Pages
   --collection-padding-bottom: 40px;

--- a/site/styles/main.scss
+++ b/site/styles/main.scss
@@ -21,6 +21,7 @@
 @import '_meta-item';
 @import '_meta-sub-item';
 @import '_meta-item-tagline';
+@import '_meta-item-title';
 @import '_availability-tags';
 
 @import '_collections';

--- a/site/templates/collection/carousel/item.jet
+++ b/site/templates/collection/carousel/item.jet
@@ -37,7 +37,7 @@
           {{end}}
 
           <div class="meta-item-content">
-            {{yield itemTitle(title=item.GetTitle(i18n),class="carousel") item.InnerItem}}
+            {{yield itemTitle(title=item.GetTitle(i18n),class="carousel",element="h3") item.InnerItem}}
 
             {{yield carouselItemTagline() item.InnerItem}}
 

--- a/site/templates/collection/carousel/item.jet
+++ b/site/templates/collection/carousel/item.jet
@@ -1,10 +1,10 @@
 {{import "../../common/awards/carousel.jet"}}
-{{import "./item/title.jet"}}
 {{import "./item/tagline.jet"}}
 {{import "./item/image.jet"}}
 {{import "./item/synopsis.jet"}}
 {{import "../../common/sponsor-image.jet"}}
 {{import "../../common/cta_buttons.jet"}}
+{{import "../../items/title.jet"}}
 
 
 
@@ -37,7 +37,7 @@
           {{end}}
 
           <div class="meta-item-content">
-            {{yield carouselItemTitle(title=item.GetTitle(i18n))}}
+            {{yield itemTitle(title=item.GetTitle(i18n),class="carousel") item.InnerItem}}
 
             {{yield carouselItemTagline() item.InnerItem}}
 

--- a/site/templates/collection/carousel/item/title.jet
+++ b/site/templates/collection/carousel/item/title.jet
@@ -1,3 +1,0 @@
-{{block carouselItemTitle(title)}}
-  <h3>{{title}}</h3>
-{{end}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -46,7 +46,7 @@
         </div>
 
         <div class="meta-detail-content">
-          {{yield itemTitle(title=film.Title,class="carousel") film}}
+          {{yield itemTitle(title=film.Title,class="carousel",element="h1") film}}
           <div class="meta-detail-tagline-and-classification">
             <div class="meta-detail-tagline">
               {{yield metaItemTagline() film}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -1,6 +1,7 @@
 {{extends "../application/application.jet"}}
 {{import "../common/slider.jet"}}
 {{import "../items/tagline.jet"}}
+{{import "../items/title.jet"}}
 {{import "../items/sub_item.jet"}}
 {{import "../collection/page_collection_item.jet"}}
 {{import "../collection/slider.jet"}}
@@ -45,7 +46,7 @@
         </div>
 
         <div class="meta-detail-content">
-          <h1>{{ film.Title }}</h1>
+          {{yield itemTitle(title=film.Title,class="carousel") film}}
           <div class="meta-detail-tagline-and-classification">
             <div class="meta-detail-tagline">
               {{yield metaItemTagline() film}}

--- a/site/templates/items/title.jet
+++ b/site/templates/items/title.jet
@@ -1,10 +1,10 @@
-{{block itemTitle(title,class)}}
+{{block itemTitle(title,class,element="h1")}}
 
  {{titleImage := .ImageMap["Title"]}}
 
   {{if isset(titleImage)}}
-    <img src="{{titleImage}}" alt="{{title}}" class="item-title-image {{class}}"></s72-image>
+    <img src="{{titleImage}}" alt="{{title}}" class="item-title-image {{class}}" />
   {{else}}
-    <h3>{{title}}</h3>
+    <{{element}}>{{title}}</{{element}}>
   {{end}}
 {{end}}

--- a/site/templates/items/title.jet
+++ b/site/templates/items/title.jet
@@ -1,0 +1,10 @@
+{{block itemTitle(title,class)}}
+
+ {{titleImage := .ImageMap["Title"]}}
+
+  {{if isset(titleImage)}}
+    <img src="{{titleImage}}" alt="{{title}}" class="item-title-image {{class}}"></s72-image>
+  {{else}}
+    <h3>{{title}}</h3>
+  {{end}}
+{{end}}


### PR DESCRIPTION
Uses existing custom image type for films so that a title image can be added into admin for upload with the other images. 

Create a generic title jet so i can be used both on the carousel and detail page. this will load in the image if it exists, else just use the existing heading.

Sets image as fixed width with a max height in an attempt to keep it within a desirable location. The custom image types are defined per site in uber, so have set these as variables to allow for simplifying some flexibility if for some reason a client had a custom size to display. 

Looking at custom image type support for film, there would be some substantial work to extend this to pages / tv etc, so scope is just for films at the moment.

Initial PR for feedback / thoughts on where from here. 