### PR TITLE
Disable picture in picture for carousel video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.9.25...HEAD)
 
+### Fixed
+
+ - Disable picture-in-picture for carousel videos
+
 ## [1.9.25](https://github.com/shift72/core-template/compare/1.9.24...1.9.25)
 
 ### Added

--- a/site/templates/collection/carousel/item/video.jet
+++ b/site/templates/collection/carousel/item/video.jet
@@ -1,5 +1,5 @@
-{{block carouselItemVideo()}} 
-  <video autoplay muted loop playsInline class="carousel-item-video" data-src="{{trailerURL}}" poster="{{.Images.Carousel}}">
+{{block carouselItemVideo()}}
+  <video autoplay muted loop playsInline disablePictureInPicture class="carousel-item-video" data-src="{{trailerURL}}" poster="{{.Images.Carousel}}">
     <s72-image src="{{.Images.Carousel}}" alt="{{.Title}}" class="carousel-item-image {{focusClass}}"></s72-image>
     <source src="" type="video/mp4">
   </video>


### PR DESCRIPTION
Noticed when testing in Firefox that it shows some pretty obnoxious picture in picture UI if you don't disable it.