### PR TITLE
Add detail player to film detail page

### DIFF
--- a/site/static/js/main.js
+++ b/site/static/js/main.js
@@ -567,3 +567,12 @@ document.addEventListener('s72loaded', event => {
   let app = event.detail.app;
   documentReady(app);
 });
+
+window.addEventListener('message', event => {
+  if (event.data == 'toggle-theatre-mode') {
+    document.getElementById('detail-player').scrollIntoView({ behavior: 'smooth', block: 'start' });
+    document.querySelector('.meta-detail-player').classList.toggle('theatre-mode');
+    document.querySelector('.meta-detail-bg.creator-page').classList.toggle('lights-out');
+    document.querySelector('.poster-wrapper').classList.toggle('d-none');
+  }
+});

--- a/site/styles/_detail-player.scss
+++ b/site/styles/_detail-player.scss
@@ -1,0 +1,64 @@
+s72-detail-player {
+  iframe {
+    border: none;
+  }
+}
+
+.meta-detail-bg.creator-page {
+  filter: blur(20px);
+  max-height: unset;
+  transition: 0.5s;
+
+  @include media-breakpoint-down(md) {
+    opacity: 0;
+  }
+
+  &.lights-out {
+    opacity: 0;
+  }
+
+}
+
+.meta-detail-main.creator-page {
+  padding-top: 0;
+  .poster-wrapper {
+    @include media-breakpoint-down(md) {
+      display: none;
+    }
+  }
+}
+
+.meta-detail-player {
+
+  width: 100%;
+  max-width: 1700px;
+  margin: 140px 20px 30px 20px;
+  aspect-ratio: 16 / 9;
+  border: solid 1px #ffffff20;
+  border-radius: 10px;
+  overflow: hidden;
+  transition: 0.5s;
+
+  @include media-breakpoint-up(lg) {
+    width: 65%;
+    margin: 200px 50px 30px 50px;
+  }
+
+  @include media-breakpoint-down(md) {
+    height: 100%;
+    max-width: unset;
+    margin: 140px 0 15px 0;
+    border-radius: 0;
+  }
+
+  &.theatre-mode {
+    width: 100%;
+    max-width: unset;
+    margin: 200px 0 15px 0;
+    border-radius: 0;
+    @include media-breakpoint-up(lg) {
+      height: calc(100vh -  105px);
+    }
+  }
+
+}

--- a/site/styles/main.scss
+++ b/site/styles/main.scss
@@ -30,6 +30,7 @@
 @import '_poster';
 
 @import '_meta-detail';
+@import '_detail-player';
 @import '_footer';
 
 @import '_shopping';

--- a/site/templates/common/cta_buttons.jet
+++ b/site/templates/common/cta_buttons.jet
@@ -12,7 +12,7 @@
 
   {{showPricingButtons := isFilm || isSeason || isBundle}}
 
-  {{showPlayButton := isFilm || isSeason || isEpisode}}
+  {{showPlayButton := isFilm || isSeason || isEpisode && config("is_creator", "false") == "false" }}
   {{showTrailerButton := trailerURL != ""}}
   {{showWishlistButton := isFilm || isSeason || isEpisode}}
   {{showShareButton := isFilm || isSeason || isEpisode || isBundle}}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -22,19 +22,28 @@
 
 {{block body()}}
 
+  {{isCreator := config("is_creator", "false") == "true"}}
+
   <main id="main" class="page page-film meta-detail meta-detail-film">
-    <div class="meta-detail-bg">
+    <div class="meta-detail-bg{{ if isCreator }} creator-page{{end}}">
       <div class="right-gradient"></div>
       <s72-image src="{{film.ImageMap["Background"]}}" alt="" class="meta-detail-bg-img"></s72-image>
     </div>
     <div class="container">
-      <div class="meta-detail-main">
+
+      {{if isCreator}}
+        <div class="meta-detail-player">
+          <s72-detail-player data-slug="{{film.Slug}}" data-bg-image="{{film.ImageMap["Background"]}}"></s72-detail-player> 
+        </div>
+      {{end}}
+
+      <div class="meta-detail-main{{ if isCreator }} creator-page{{end}}">
+      
         <s72-live-label data-slug="{{film.Slug}}"></s72-live-label>
 
         <div class="poster-wrapper">
           {{if config("default_image_type") == "portrait"}}
             {{yield sponsor() film}}
-
               <div class="poster poster-portrait">
                 {{if film.ImageMap["Portrait"] != ""}}
                   <s72-availability-status data-slug="{{film.Slug}}"></s72-availability-status>


### PR DESCRIPTION
ADO card: ☑️ AB#XXXX

Elab notes/AC: 📃 [Detail Page Video Player - Google Docs](https://docs.google.com/document/d/1I5nf4ewQTGUmLR3or-ThzvPDjvtsM5zdF9egmVcSoag/edit?tab=t.0#heading=h.ochadmr1vhv4)
- [ ] Has this been discussed with Delivery Team?

## Description of work
Implementation of detail player on film detail page

## Config settings/Toggles required for the feature to work
- ```is_creator = true``` turns film detail page into creator page

## Related PRs 
- https://github.com/indiereign/shift72-web/pull/469

### Affected Clients
 - All clients who use Kibble

## Checklist
- [ ] CI tests are passing Github actions (inc. linting)
- [ ] Key areas of the feature outlined for context and testing
- [ ] If there are designs for this work are they noted here and in the ADO card 
- [ ] Design review
- [ ] Have checked this at multiple screen resolutions and range of browsers
- [ ] Moved ADO card to Dev/done, checked link to Github, tagged "Review"
- [ ] Updated changelog (if applicable)
- [ ] I promise to document any new feature toggles/configurations in the appropriate documentation
