### PR TITLE
add basic comments embed in film detail page

### DIFF
--- a/kibble.json
+++ b/kibble.json
@@ -118,7 +118,8 @@
     ]
   },
   "proxy": [
-    "^/checkout/"
+    "^/checkout/",
+    "^/play/"
   ],
   "routes": [
     {

--- a/site/static/js/comments.js
+++ b/site/static/js/comments.js
@@ -1,0 +1,7 @@
+import s72 from 's72';
+import {bindEachComponent, attrs} from 's72.ui';
+
+bindEachComponent('comment-section', (e) => {
+  const props = attrs(e);
+  s72.comments.mountCommentsForSlug({slug: props.slug, container: e});
+});

--- a/site/static/js/main.js
+++ b/site/static/js/main.js
@@ -3,6 +3,7 @@ import './can-be-watched-button.component.js';
 import './external-purchase-button.component.js';
 import './carousel-video-mute-button.component.js';
 import './detail-player/detail-player.component.js';
+import './comments.js';
 
 /*global Swiper, Modernizr, s72*/
 

--- a/site/styles/_legacy.scss
+++ b/site/styles/_legacy.scss
@@ -7,6 +7,12 @@ body {
   flex-direction: column;
   font-family: $font-family-base;
   height: 100%;
+
+  // really only affects macOS. This makes the fonts look a lot less jaggy
+  // especially on non-retina displays. It's pretty much the default in every
+  // modern css reset/library because it makes font rendering more consistent
+  // with other platforms
+  -webkit-font-smoothing: antialiased;
 }
 
 .animate-this {

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -483,3 +483,18 @@ s72-element-switcher {
     @include caption-1-style;
   }
 }
+
+
+comment-section {
+  display: block;
+  margin-bottom: 3rem;
+
+  padding-left: var(--page-detail-padding-hz);
+  padding-right: var(--page-detail-padding-hz);
+
+  @include media-breakpoint-up(lg) {
+    padding-left: var(--page-detail-padding-hz-lg);
+    padding-right: var(--page-detail-padding-hz-lg);
+  }
+
+}

--- a/site/templates/application/application.jet
+++ b/site/templates/application/application.jet
@@ -58,6 +58,11 @@
 
     <script src="{{CDN}}/s72.transactional.js" defer></script>
 
+    {{if isEnabled("commenting")}}
+      <script src="//cdn.shift72.com/comments/dev/s72.comments.js" defer></script>
+      <link rel="stylesheet" href="//cdn.shift72.com/comments/dev/s72.comments.css">
+    {{end}}
+
     <script src="https://js.stripe.com/v3/" defer></script>
 
     {* get default language from site record or kibble.json depening on if db translations is enabled *}

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -21,7 +21,6 @@
 {{end}}
 
 {{block body()}}
-
   {{useDetailPlayer := config("use_detail_page_player", "false") == "true"}}
 
   <main id="main" class="page page-film meta-detail meta-detail-film{{if useDetailPlayer}} meta-detail-creator{{end}}">
@@ -38,7 +37,7 @@
       {{end}}
 
       <div class="meta-detail-main">
-      
+
         <s72-live-label data-slug="{{film.Slug}}"></s72-live-label>
 
         <div class="poster-wrapper">
@@ -178,6 +177,8 @@
         </div>
       </div>
     </div>
+
+    <comment-section slug="{{film.Slug}}"></comment-section>
 
     {{if len(film.Recommendations) > 0 }}
     <section class="page-collection recommendations-collection" aria-label="{{i18n("meta_detail_recommendations_title")}}">


### PR DESCRIPTION
Integrating the comment section component into the detail.

You can do local dev by changing the paths in application.jet, but I haven't figured out the best way to get Vite to run a dev server for a library build so I end up doing `npm run build && npm start` which puts the output files into `http://localhost:5173/dist/s72.comments.{js,css}` 