### PR TITLE
Typography Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.9.25...HEAD)
 
+### Changed
+
+ - Added `-webkit-font-smoothing: antialiased` and `font-synthesis: none` to
+   body to avoid ugly font rendering. The antialiased setting can make fonts
+   render slightly lighter on macOS but should make it more consistent with
+   other platforms. Disabling font-synthesis prevents Safari from creating
+   hideous faux bold/italic faces when the exact weights aren't loaded.
+ - Make the default meta tagline styling on posters a bit more subtle.
+   Introduces CSS variables for this to make customizing these styles easier.
+
 ### Fixed
 
  - Disable picture-in-picture for carousel videos

--- a/site/styles/_globals.scss
+++ b/site/styles/_globals.scss
@@ -1,3 +1,14 @@
+body {
+  // Makes the fonts look a lot sharper on macOS. This is a pretty standard part
+  // of most CSS resets.
+  -webkit-font-smoothing: antialiased;
+
+  // prevents Safari (especially) from synthesizing bold or italic version of
+  // font faces (e.g. if you specify a font weight that isn't loaded). These
+  // look really bad.
+  font-synthesis: none;
+}
+
 small {
   font-size: 85%;
 }

--- a/site/styles/_legacy.scss
+++ b/site/styles/_legacy.scss
@@ -7,7 +7,6 @@ body {
   flex-direction: column;
   font-family: $font-family-base;
   height: 100%;
-  -webkit-font-smoothing: antialiased;
 }
 
 .animate-this {

--- a/site/styles/_legacy.scss
+++ b/site/styles/_legacy.scss
@@ -7,6 +7,7 @@ body {
   flex-direction: column;
   font-family: $font-family-base;
   height: 100%;
+  -webkit-font-smoothing: antialiased;
 }
 
 .animate-this {

--- a/site/styles/_meta-item-tagline.scss
+++ b/site/styles/_meta-item-tagline.scss
@@ -56,8 +56,8 @@
 }
 
 .caption .meta-item-tagline {
-  --overline-style-opacity: var(--collection-item-tagline-opacity);
-  --overline-style-font-size: var(--collection-item-tagline-font-size);
-  --overline-style-line-height: var(--collection-item-tagline-line-height);
-  --overline-style-letter-spacing: var(--collection-item-tagline-letter-spacing);
+  opacity: var(--collection-item-tagline-opacity);
+  font-size: var(--collection-item-tagline-font-size);
+  line-height: var(--collection-item-tagline-line-height);
+  letter-spacing: var(--collection-item-tagline-letter-spacing);
 }

--- a/site/styles/_meta-item-tagline.scss
+++ b/site/styles/_meta-item-tagline.scss
@@ -54,3 +54,10 @@
   display: flex !important;
   padding: 5px 0 16px;
 }
+
+.caption .meta-item-tagline {
+  --overline-style-opacity: var(--collection-item-tagline-opacity);
+  --overline-style-font-size: var(--collection-item-tagline-font-size);
+  --overline-style-line-height: var(--collection-item-tagline-line-height);
+  --overline-style-letter-spacing: var(--collection-item-tagline-letter-spacing);
+}

--- a/site/styles/_nav.scss
+++ b/site/styles/_nav.scss
@@ -881,6 +881,7 @@ s72-dropdown,
   z-index: 10;
   .header-banner-message {
     font-size: 12px;
+    font-weight: 400;
     margin-bottom: 0;
     @include media-breakpoint-up(sm) {
       font-size: 14px;

--- a/site/styles/_typography.scss
+++ b/site/styles/_typography.scss
@@ -4,7 +4,8 @@
   $font-weight: null,
   $margin-bottom: null,
   $font-color: null,
-  $line-height: null
+  $line-height: null,
+  $opacity: null
 ) {
   color: $font-color;
   font-size: $font-size;
@@ -12,6 +13,7 @@
   letter-spacing: $letter-spacing;
   line-height: $line-height;
   margin-bottom: $margin-bottom;
+  opacity: $opacity;
 }
 
 @mixin heading-1-style() {
@@ -119,8 +121,9 @@
   @include typography-style(
     $font-size: var(--overline-style-font-size),
     $letter-spacing: var(--overline-style-letter-spacing),
-    $font-weight: $font-weight-normal,
-    $line-height: 18px
+    $font-weight: var(--overline-style-font-weight),
+    $opacity: var(--overline-style-opacity),
+    $line-height: var(--overline-style-line-height),
   );
 }
 

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -148,7 +148,6 @@
   --subtitle-1-style-letter-spacing: normal;
   --subtitle-2-style-letter-spacing: normal;
   --caption-1-style-letter-spacing: normal;
-  --overline-style-letter-spacing: normal;
 
   --heading-1-style-font-size: 32px;
   --heading-1-style-font-size-xs: 46px;
@@ -163,7 +162,17 @@
   --subtitle-1-style-font-size: 16px;
   --subtitle-2-style-font-size: 14px;
   --caption-1-style-font-size: 16px;
+
   --overline-style-font-size: 14px;
+  --overline-style-font-weight: 400;
+  --overline-style-line-height: 18px;
+  --overline-style-letter-spacing: 0px;
+  --overline-style-opacity: 0.8;
+
+  --collection-item-tagline-opacity: 0.6;
+  --collection-item-tagline-font-size: 13px;
+  --collection-item-tagline-line-height: 1.2;
+  --collection-item-tagline-letter-spacing: -0.2px;
 
   /* Alert component dark theme colours */
 
@@ -313,6 +322,8 @@ $meta-item-border-radius: 4px !default;
 $featured-meta-item-body-padding: 10px !default;
 $meta-item-body-color: var(--body-color) !default;
 $meta-item-tagline-classification-border-radius: $meta-item-border-radius !default;
+
+
 
 // Posters
 // ------------------------------------


### PR DESCRIPTION
New

![image](https://github.com/user-attachments/assets/33307ed5-e5b0-421b-84a7-bc39180e3ec8)


Old

![image](https://github.com/user-attachments/assets/aa76d083-6c79-458b-84f3-17cc35461986)


Add global `-webkit-font-smoothing: antialiased` and disabled font synthesis (prevents Safari from generating hideous looking fake bold fonts if styles use a weight that isn't available.

Tweaked the poster styling so that the meta tagline is more subtle.