### PR TITLE
De-janking poster / collection loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
  - Video player on film detail page for content creators
  - Add fade in transition on poster images
+ - Add skeleton background color for posters before they load.
+ - Add fade transition on carousel images
 
 ### Changed
 
@@ -15,6 +17,8 @@
    hideous faux bold/italic faces when the exact weights aren't loaded.
  - Make the default meta tagline styling on posters a bit more subtle.
    Introduces CSS variables for this to make customizing these styles easier.
+ - Poster images have an aspect-ratio applied before they load. `.meta-item`
+   uses flex-column sizing to give the posters some size before the images load
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
       "max-nesting-depth": 3,
       "prettier/prettier": true,
       "scss/at-extend-no-missing-placeholder": null,
-      "scss/at-import-no-partial-leading-underscore": null
+      "scss/at-import-no-partial-leading-underscore": null,
+      "order/properties-alphabetical-order": null
     }
   },
   "browserslist": [

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -50,16 +50,17 @@ s72-carousel {
 
     z-index: -1;
 
-    &.s72-image--loaded {
-      opacity: 1;
-    }
-
     @include media-breakpoint-up(sm) {
       object-position: var(--carousel-image-object-position-sm);
     }
     @include media-breakpoint-up(lg) {
       object-position: var(--carousel-image-object-position-lg);
     }
+
+    &.s72-image--loaded {
+      opacity: 1;
+    }
+
     &.focus-left {
       object-position: left;
     }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -48,11 +48,12 @@ s72-carousel {
     opacity: 0;
     transition: opacity 0.25s ease;
 
+    z-index: -1;
+
     &.s72-image--loaded {
       opacity: 1;
     }
 
-    z-index: -1;
     @include media-breakpoint-up(sm) {
       object-position: var(--carousel-image-object-position-sm);
     }

--- a/site/styles/_carousel.scss
+++ b/site/styles/_carousel.scss
@@ -44,6 +44,14 @@ s72-carousel {
     object-fit: cover;
     object-position: var(--carousel-image-object-position);
     width: 100%;
+
+    opacity: 0;
+    transition: opacity 0.25s ease;
+
+    &.s72-image--loaded {
+      opacity: 1;
+    }
+
     z-index: -1;
     @include media-breakpoint-up(sm) {
       object-position: var(--carousel-image-object-position-sm);

--- a/site/styles/_collections.scss
+++ b/site/styles/_collections.scss
@@ -266,7 +266,7 @@
   }
 
   .caption {
-    padding: 0px 0 8px;
+    padding: 0 0 8px;
     margin-top: 4px;
 
     .crumb {

--- a/site/styles/_collections.scss
+++ b/site/styles/_collections.scss
@@ -35,6 +35,11 @@
   display: block;
 }
 
+.page-collection-item {
+  display: flex;
+  flex-direction: column;
+}
+
 /* stylelint-disable selector-max-compound-selectors, max-nesting-depth */
 .page-collection-item,
 .slider-item,
@@ -261,7 +266,8 @@
   }
 
   .caption {
-    padding: 0 0 8px;
+    padding: 0px 0 8px;
+    margin-top: 4px;
 
     .crumb {
       @extend .d-flex;

--- a/site/styles/_detail-player.scss
+++ b/site/styles/_detail-player.scss
@@ -22,7 +22,7 @@
     transition: 1s;
     width: 100%;
     z-index: 1;
-    
+
     &--visible {
       opacity: 1;
     }
@@ -82,7 +82,7 @@
     &--unlocked {
       background-color: rgba(var(--detail-player-messsage-bg-color), 0);
       box-shadow: 3px 3px 3px #0000;
-      backdrop-filter: blur(0px);
+      backdrop-filter: blur(0);
     }
 
     &-text {
@@ -114,12 +114,28 @@
     }
 
     @keyframes wiggle {
-      0% { transform: rotate(0deg) }
-      20%, 40%, 60% { transform: rotate(8deg) }
-      30%, 50%, 70% { transform: rotate(-8deg) }
-      80% { transform: rotate(4deg) }
-      90% { transform: rotate(-4deg) }
-      100% { transform: rotate(0deg) }
+      0% {
+        transform: rotate(0deg);
+      }
+      20%,
+      40%,
+      60% {
+        transform: rotate(8deg);
+      }
+      30%,
+      50%,
+      70% {
+        transform: rotate(-8deg);
+      }
+      80% {
+        transform: rotate(4deg);
+      }
+      90% {
+        transform: rotate(-4deg);
+      }
+      100% {
+        transform: rotate(0deg);
+      }
     }
     &--large {
       filter: drop-shadow(5px 5px 3px #0008);

--- a/site/styles/_meta-item.scss
+++ b/site/styles/_meta-item.scss
@@ -1,4 +1,7 @@
 .meta-item {
+  display: flex;
+  flex-direction: column;
+
   a {
     display: inline-block;
   }

--- a/site/styles/_poster.scss
+++ b/site/styles/_poster.scss
@@ -41,6 +41,24 @@
   max-width: 100%;
   position: relative;
   width: 100%;
+
+  // setting aspect ratios for posters helps prevent layout shift as images load
+  // in and improves the effectiveness of image lazy-loading because the images
+  // don't all collapse down to zero height.
+  &.poster-image-portrait {
+    aspect-ratio: var(--poster-portrait-aspect-ratio);
+  }
+
+  &.poster-image-landscape {
+    aspect-ratio: var(--poster-landscape-aspect-ratio);
+  }
+
+  &.s72-image--loaded {
+    // once poster images load in, let them be their intrinsic dimensions. This
+    // handles cases where the actual image size doesn't match the configured
+    // size in the css a bit better, while still keeping layouts stable in nor
+    aspect-ratio: unset;
+  }
 }
 
 s72-image .poster-image {

--- a/site/styles/_poster.scss
+++ b/site/styles/_poster.scss
@@ -6,6 +6,8 @@
   width: 100%;
   z-index: 1;
 
+  background-color: var(--poster-skeleton-background-color);
+
   s72-availability-status,
   s72-plan-label {
     color: $button-text-color;

--- a/site/styles/_search.scss
+++ b/site/styles/_search.scss
@@ -29,6 +29,8 @@
 
     .partial {
       @extend .slider-item;
+      display: flex;
+      flex-direction: column;
     }
   }
 }

--- a/site/styles/_swiper.scss
+++ b/site/styles/_swiper.scss
@@ -68,3 +68,20 @@
     padding-left: 25px;
   }
 }
+
+// this helps to cover up wonky layouts before the Swiper components are
+// mounted. Items get sized dynamically and this can mean poster images
+// momentarily become huge
+.swiper-container {
+  opacity: 1;
+  transition: opacity 0.1s ease;
+
+  &:not(.swiper-container-initialized) {
+    opacity: 0;
+    pointer-events: none;
+
+    // bit of a hack to keep the length of the page from getting mad during init
+    // this isn't accurate
+    max-height: 500px;
+  }
+}

--- a/site/styles/_typography.scss
+++ b/site/styles/_typography.scss
@@ -123,7 +123,7 @@
     $letter-spacing: var(--overline-style-letter-spacing),
     $font-weight: var(--overline-style-font-weight),
     $opacity: var(--overline-style-opacity),
-    $line-height: var(--overline-style-line-height),
+    $line-height: var(--overline-style-line-height)
   );
 }
 

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -180,6 +180,8 @@
   --poster-portrait-aspect-ratio: 282 / 422;
   --poster-landscape-aspect-ratio: 585 / 330;
 
+  --poster-skeleton-background-color: #3335;
+
   // Detail player
   --page-detail-player-padding-top: 140px;
   --page-detail-player-padding-top-lg: 200px;

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -176,6 +176,10 @@
   --collection-item-tagline-line-height: 1.2;
   --collection-item-tagline-letter-spacing: -0.2px;
 
+  // Posters
+  --poster-portrait-aspect-ratio: 282 / 422;
+  --poster-landscape-aspect-ratio: 585 / 330;
+
   // Detail player
   --page-detail-player-padding-top: 140px;
   --page-detail-player-padding-top-lg: 200px;

--- a/site/styles/_variables.scss
+++ b/site/styles/_variables.scss
@@ -126,7 +126,7 @@
   --title-image-width-sm: 350px;
   --title-image-width-lg: 400px;
   --title-image-max-height: 180px;
-  --title-image-left-margin: 0px;
+  --title-image-left-margin: 0;
 
   // Pages
   --collection-padding-bottom: 40px;
@@ -138,7 +138,7 @@
   --page-detail-padding-top-md: 248px;
   --page-detail-padding-top-lg: 400px;
   --page-detail-padding-hz: 20px;
-  --page-detail-padding-hz-lg: 50px;  
+  --page-detail-padding-hz-lg: 50px;
 
   --heading-1-style-letter-spacing: normal;
   --heading-2-style-letter-spacing: normal;
@@ -168,7 +168,7 @@
   --overline-style-font-size: 14px;
   --overline-style-font-weight: 400;
   --overline-style-line-height: 18px;
-  --overline-style-letter-spacing: 0px;
+  --overline-style-letter-spacing: 0;
   --overline-style-opacity: 0.8;
 
   --collection-item-tagline-opacity: 0.6;
@@ -344,8 +344,6 @@ $meta-item-border-radius: 4px !default;
 $featured-meta-item-body-padding: 10px !default;
 $meta-item-body-color: var(--body-color) !default;
 $meta-item-tagline-classification-border-radius: $meta-item-border-radius !default;
-
-
 
 // Posters
 // ------------------------------------


### PR DESCRIPTION
Adds a skeleton and proper sizing for posters before the images load in.

This prevents collection pages from collapsing down to only show a bunch of titles, and also just looks less broken as the pages load.

![image](https://github.com/user-attachments/assets/5ae18ddd-ad65-455b-afa7-f06643515cf0)


### Poster placeholders

The skeleton colour can be controlled with the `--poster-skeleton-background-color` variable

The expected poster aspect ratio is set with CSS variables but only affects the placeholders -- once the image loads, the aspect-ratio rule is removed.

In order to get the responsive sizing right, I've changed meta items to use flex-column layout. 

### Slider loading

Adding skeletons revealed some jank with swipers -- the slides would momentarily be huge (100% width basically) because it relies on the Swiper library calculating the widths in JS.

To fix this, I've hidden the sliders  and set a max-height until the Swiper lib initializes them and adds the .swiper-initialized class.  The max-height is wrong, but less wrong than each slider having 2000px tall posters.

