### PR TITLE
remove extra space before , in cast list; tweak link underline css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/shift72/core-template/compare/1.9.27...HEAD)
 
+### Changed
+
+ - Cast list: remove erroneous space before comma. CSS tweaks for the link underlines
+
 ## [1.9.27](https://github.com/shift72/core-template/compare/1.9.26...1.9.27)
 
 ### Changed

--- a/site/styles/_meta-detail.scss
+++ b/site/styles/_meta-detail.scss
@@ -277,6 +277,9 @@ s72-element-switcher,
     a {
       animation: fadein 2s;
 
+      text-decoration-color: rgba(var(--body-color-rgb), 0.5);
+      text-underline-offset: 0.1em;
+
       &:hover {
         text-decoration: none;
       }

--- a/site/templates/film/item.jet
+++ b/site/templates/film/item.jet
@@ -90,8 +90,7 @@
                         {{range index, member := film.Cast}}
                           {{ path := "/search.html?q=" + member.Name }}
                           {{ showCharacter := !isEnabled("site_hide_cast_character_name")}}
-                          <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if len(member.Character) > 0 && showCharacter}}<span class="meta-detail-character"> ({{member.Character}})</span>{{end}}
-                          {{if index < len(film.Cast) - 1}}, {{end}}
+                          <a href="{{ routeToPath(path) }}">{{member.Name}}</a>{{if len(member.Character) > 0 && showCharacter}}<span class="meta-detail-character"> ({{member.Character}})</span>{{end}}{{if index < len(film.Cast) - 1}}, {{end}}
                         {{end}}
                       </p>
                     </div>


### PR DESCRIPTION
**Old**
<img width="375" height="107" alt="image" src="https://github.com/user-attachments/assets/e4c38dbc-187b-41e3-be95-a2c4c417087a" />

**New**
<img width="367" height="107" alt="image" src="https://github.com/user-attachments/assets/5a491a80-cd50-4df7-b357-0e78e1d4f1d4" />
